### PR TITLE
chore: updates `addEntrypoint.bash` to use development branch

### DIFF
--- a/bin/addEntrypoint.bash
+++ b/bin/addEntrypoint.bash
@@ -10,11 +10,11 @@ SCRIPT_PATH=$(readlink -f "$0")                     # Path to this script.
 SCRIPT_DIR=$(dirname "$SCRIPT_PATH")                # Path to directory containing this script.
 REPO_ROOT_DIR=$(builtin cd "$SCRIPT_DIR/.." && pwd) # REPO root directory.
 
-# Check that the main branch is checked out
+# Check that the development branch is checked out
 CUR_GIT_BRANCH=$(git branch)
-if [[ ! "$CUR_GIT_BRANCH" == *"* main"* ]]; then
-  echo -e "${ON_RED}ERROR:${NO_COLOR} You must have the main branch checked out to add an entry point."
-  echo "Switch to the main branch."
+if [[ ! "$CUR_GIT_BRANCH" == *"* development"* ]]; then
+  echo -e "${ON_RED}ERROR:${NO_COLOR} You must have the development branch checked out to add an entry point."
+  echo "Switch to the development branch."
   echo "Then run this script again."
   exit 255
 fi
@@ -269,7 +269,7 @@ if [ ! "$TESTS_PASSED" == "0" ]; then
   echo "  Correct any errors and rerun tests using test.bash."
   echo "  Or try again by:"
   echo "    Commit changes to the current git branch: $FEATURE_BRANCH_NAME."
-  echo "    Switch to the main branch"
+  echo "    Switch to the development branch"
   echo "    Delete the $FEATURE_BRANCH_NAME branch."
   echo "    Run this script again."
 else

--- a/modules/README.md
+++ b/modules/README.md
@@ -36,9 +36,18 @@ Inside each of the above module directories there are the following directories 
   - stores - used by Vue pinia store
   - composer.json - Drupal configuration information (only for farm_fd2)
 
-## Adding Entry Points
+## Adding an new Entry Point
 
-- use bin/addEntrypoint.bash
+- ensure you have no uncommitted changes
+- switch to `development` branch
+- run `addEntrypoint.bash`
+  - Will create a new feature branch
+  - Switch to that branch
+  - Add boilerplate and starter code to it
+  - Run some basic tests against the added code
+    - Note: running test script also builds the module containing the new entry point.
+- Edit `App.vue` to implement the entry point.
+- Add `\*.cy.js` files to test the new entry point.
 
 ## Testing
 


### PR DESCRIPTION
**Pull Request Description**

The `addEntrypoint.bash` script was written to use the `main` branch as the base for the new feature branch in which to implement the entry point.  This had to be updated to match the use of `development` as the default branch.

---

**Licensing Certification**

FarmData2 is a [Free Cultural Work](https://freedomdefined.org/Definition) and all accepted contributions are licensed as described in the LICENSE.md file. This requires that the contributor holds the rights to do so. By submitting this pull request **I certify that I satisfy the terms of the [Developer Certificate of Origin](https://developercertificate.org/)** for its contents.
