### PR TITLE
chore: updates entrypoint template to not use CounterExample component.

### DIFF
--- a/bin/templates/entrypoints/App.vue
+++ b/bin/templates/entrypoints/App.vue
@@ -1,21 +1,11 @@
 <script setup>
 import dayjs from 'dayjs';
-import Counter from '@comps/CounterExample/CounterExample.vue';
 </script>
 
 <template>
-  <h1
-    class="sample"
-    data-cy="title"
-  >
-    Template for %ENTRY_POINT% Entry Point
-  </h1>
+  <h1 data-cy="title">Template for %ENTRY_POINT% Entry Point</h1>
   <p>
     This uses the dayjs import: <span>{{ formatDate }}</span>
-  </p>
-  <p>
-    This uses the CounterExample component.
-    <Counter />
   </p>
 
   <div
@@ -31,7 +21,6 @@ export default {
   data() {
     return {
       date: dayjs(),
-      createdCount: 0,
     };
   },
   computed: {
@@ -47,9 +36,3 @@ export default {
   },
 };
 </script>
-
-<style scoped>
-.sample {
-  color: blue;
-}
-</style>


### PR DESCRIPTION
**Pull Request Description**

The entrypoint template `bin/templates/entrypoints/App.vue` used the `CounterExample` component, which was removed from the repo. This PR removes the use of it from the template.

---

**Licensing Certification**

FarmData2 is a [Free Cultural Work](https://freedomdefined.org/Definition) and all accepted contributions are licensed as described in the LICENSE.md file. This requires that the contributor holds the rights to do so. By submitting this pull request **I certify that I satisfy the terms of the [Developer Certificate of Origin](https://developercertificate.org/)** for its contents.
