### PR TITLE
adds the createdCount variable to the Vue data element

### DIFF
--- a/bin/templates/entrypoints/App.vue
+++ b/bin/templates/entrypoints/App.vue
@@ -21,6 +21,7 @@ export default {
   data() {
     return {
       date: dayjs(),
+      createdCount: 0,
     };
   },
   computed: {


### PR DESCRIPTION
**Pull Request Description**

Earlier changes to the template for the Vue.app that is added when a new entry point is created removed the `createdCount` variable from the Vue `data` element by mistake. This replaces it.

---

**Licensing Certification**

FarmData2 is a [Free Cultural Work](https://freedomdefined.org/Definition) and all accepted contributions are licensed as described in the LICENSE.md file. This requires that the contributor holds the rights to do so. By submitting this pull request **I certify that I satisfy the terms of the [Developer Certificate of Origin](https://developercertificate.org/)** for its contents.
