### PR TITLE
adds bootstrap-Vue-next to the entrypoint templates

### DIFF
--- a/bin/templates/entrypoints/entry_point.js
+++ b/bin/templates/entrypoints/entry_point.js
@@ -1,3 +1,7 @@
+// Imports for Bootstrap-Vue components.
+import 'bootstrap/dist/css/bootstrap.css';
+import 'bootstrap-vue-next/dist/bootstrap-vue-next.css';
+
 import { createApp } from 'vue';
 import { createPinia } from 'pinia';
 import App from './App.vue';

--- a/bin/templates/entrypoints/libraries.yml
+++ b/bin/templates/entrypoints/libraries.yml
@@ -8,3 +8,6 @@
   css:
     theme:
       %ENTRY_POINT%/%ENTRY_POINT%.css: {}
+    component:
+      shared/index.css: {}
+    

--- a/modules/farm_fd2/src/entrypoints/main/main.js
+++ b/modules/farm_fd2/src/entrypoints/main/main.js
@@ -1,4 +1,6 @@
-//import '@/shared/site.css'
+// Imports for Bootstrap-Vue components.
+import 'bootstrap/dist/css/bootstrap.css';
+import 'bootstrap-vue-next/dist/bootstrap-vue-next.css';
 
 import { createApp } from 'vue';
 import { createPinia } from 'pinia';

--- a/modules/farm_fd2/src/module/farm_fd2.libraries.yml
+++ b/modules/farm_fd2/src/module/farm_fd2.libraries.yml
@@ -7,3 +7,5 @@ main:
   css:
     theme:
       main/main.css: {}
+    component:
+      shared/index.css: {}

--- a/modules/farm_fd2/vite.config.js
+++ b/modules/farm_fd2/vite.config.js
@@ -5,6 +5,8 @@ import { defineConfig } from 'vite';
 import { viteStaticCopy } from 'vite-plugin-static-copy';
 import vue from '@vitejs/plugin-vue';
 import { exec } from 'child_process';
+import Components from 'unplugin-vue-components/vite';
+import { BootstrapVueNextResolver } from 'unplugin-vue-components/resolvers';
 
 let viteConfig = {
   root: 'modules/farm_fd2/src/entrypoints',
@@ -12,6 +14,9 @@ let viteConfig = {
   base: '/fd2/',
   plugins: [
     vue(),
+    Components({
+      resolvers: [BootstrapVueNextResolver()],
+    }),
     viteStaticCopy({
       // Copy the Drupal module stuff...
       targets: [
@@ -67,7 +72,7 @@ let viteConfig = {
         assetFileNames: (assetInfo) => {
           let ext = assetInfo.name.split('.').at(1);
           if (ext === 'css') {
-            return '[name]/[name].css';
+            return 'shared/[name].css';
           } else {
             return 'shared/[name].[ext]';
           }

--- a/modules/farm_fd2_examples/src/entrypoints/main/main.js
+++ b/modules/farm_fd2_examples/src/entrypoints/main/main.js
@@ -1,4 +1,6 @@
-//import '@/shared/site.css'
+// Imports for Bootstrap-Vue components.
+import 'bootstrap/dist/css/bootstrap.css';
+import 'bootstrap-vue-next/dist/bootstrap-vue-next.css';
 
 import { createApp } from 'vue';
 import { createPinia } from 'pinia';

--- a/modules/farm_fd2_examples/src/module/farm_fd2_examples.libraries.yml
+++ b/modules/farm_fd2_examples/src/module/farm_fd2_examples.libraries.yml
@@ -7,3 +7,5 @@ main:
   css:
     theme:
       main/main.css: {}
+    component:
+      shared/index.css: {}

--- a/modules/farm_fd2_examples/vite.config.js
+++ b/modules/farm_fd2_examples/vite.config.js
@@ -5,6 +5,8 @@ import { defineConfig } from 'vite';
 import { viteStaticCopy } from 'vite-plugin-static-copy';
 import vue from '@vitejs/plugin-vue';
 import { exec } from 'child_process';
+import Components from 'unplugin-vue-components/vite';
+import { BootstrapVueNextResolver } from 'unplugin-vue-components/resolvers';
 
 let viteConfig = {
   root: 'modules/farm_fd2_examples/src/entrypoints',
@@ -12,6 +14,9 @@ let viteConfig = {
   base: '/fd2_examples/',
   plugins: [
     vue(),
+    Components({
+      resolvers: [BootstrapVueNextResolver()],
+    }),
     viteStaticCopy({
       // Copy the Drupal module stuff...
       targets: [
@@ -63,7 +68,7 @@ let viteConfig = {
         assetFileNames: (assetInfo) => {
           let ext = assetInfo.name.split('.').at(1);
           if (ext === 'css') {
-            return '[name]/[name].css';
+            return 'shared/[name].css';
           } else {
             return 'shared/[name].[ext]';
           }

--- a/modules/farm_fd2_school/src/entrypoints/main/main.js
+++ b/modules/farm_fd2_school/src/entrypoints/main/main.js
@@ -1,4 +1,6 @@
-//import '@/shared/site.css'
+// Imports for Bootstrap-Vue components.
+import 'bootstrap/dist/css/bootstrap.css';
+import 'bootstrap-vue-next/dist/bootstrap-vue-next.css';
 
 import { createApp } from 'vue';
 import { createPinia } from 'pinia';

--- a/modules/farm_fd2_school/src/module/farm_fd2_school.libraries.yml
+++ b/modules/farm_fd2_school/src/module/farm_fd2_school.libraries.yml
@@ -7,3 +7,5 @@ main:
   css:
     theme:
       main/main.css: {}
+    component:
+      shared/index.css: {}

--- a/modules/farm_fd2_school/vite.config.js
+++ b/modules/farm_fd2_school/vite.config.js
@@ -5,6 +5,8 @@ import { defineConfig } from 'vite';
 import { viteStaticCopy } from 'vite-plugin-static-copy';
 import vue from '@vitejs/plugin-vue';
 import { exec } from 'child_process';
+import Components from 'unplugin-vue-components/vite';
+import { BootstrapVueNextResolver } from 'unplugin-vue-components/resolvers';
 
 let viteConfig = {
   root: 'modules/farm_fd2_school/src/entrypoints',
@@ -12,6 +14,9 @@ let viteConfig = {
   base: '/fd2_school/',
   plugins: [
     vue(),
+    Components({
+      resolvers: [BootstrapVueNextResolver()],
+    }),
     viteStaticCopy({
       // Copy the Drupal module stuff...
       targets: [
@@ -63,7 +68,7 @@ let viteConfig = {
         assetFileNames: (assetInfo) => {
           let ext = assetInfo.name.split('.').at(1);
           if (ext === 'css') {
-            return '[name]/[name].css';
+            return 'shared/[name].css';
           } else {
             return 'shared/[name].[ext]';
           }

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,8 @@
       "name": "fd2",
       "version": "0.0.0",
       "dependencies": {
+        "bootstrap": "^5.3.2",
+        "bootstrap-vue-next": "^0.14.10",
         "dayjs": "^1.11.8",
         "pinia": "^2.1.3",
         "vue": "^3.3.4"
@@ -37,6 +39,7 @@
         "shellcheck": "^2.2.0",
         "shfmt": "^0.0.1",
         "start-server-and-test": "^2.0.0",
+        "unplugin-vue-components": "^0.25.2",
         "vite": "^4.3.9",
         "vite-plugin-static-copy": "^0.16.0"
       }
@@ -48,6 +51,15 @@
       "dev": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/@antfu/utils": {
+      "version": "0.7.6",
+      "resolved": "https://registry.npmjs.org/@antfu/utils/-/utils-0.7.6.tgz",
+      "integrity": "sha512-pvFiLP2BeOKA/ZOS6jxx4XhKzdVLHDhGlFEaZ2flWWYf2xOqVniqpk38I04DFRyz+L0ASggl7SkItTc+ZLju4w==",
+      "dev": true,
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -1107,6 +1119,62 @@
         "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
       }
     },
+    "node_modules/@floating-ui/core": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.5.0.tgz",
+      "integrity": "sha512-kK1h4m36DQ0UHGj5Ah4db7R0rHemTqqO0QLvUqi1/mUUp3LuAWbWxdxSIf/XsnH9VS6rRVPLJCncjRzUvyCLXg==",
+      "dependencies": {
+        "@floating-ui/utils": "^0.1.3"
+      }
+    },
+    "node_modules/@floating-ui/dom": {
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.5.3.tgz",
+      "integrity": "sha512-ClAbQnEqJAKCJOEbbLo5IUlZHkNszqhuxS4fHAVxRPXPya6Ysf2G8KypnYcOTpx6I8xcgF9bbHb6g/2KpbV8qA==",
+      "dependencies": {
+        "@floating-ui/core": "^1.4.2",
+        "@floating-ui/utils": "^0.1.3"
+      }
+    },
+    "node_modules/@floating-ui/utils": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.1.6.tgz",
+      "integrity": "sha512-OfX7E2oUDYxtBvsuS4e/jSn4Q9Qb6DzgeYtsAdkPZ47znpoNsMgZw0+tVijiv3uGNR6dgNlty6r9rzIzHjtd/A=="
+    },
+    "node_modules/@floating-ui/vue": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@floating-ui/vue/-/vue-1.0.2.tgz",
+      "integrity": "sha512-sImlAl9mAoCKZLNlwWz2P2ZMJIDlOEDXrRD6aD2sIHAka1LPC+nWtB+D3lPe7IE7FGWSbwBPTnlSdlABa3Fr0A==",
+      "dependencies": {
+        "@floating-ui/dom": "^1.4.5",
+        "vue-demi": ">=0.13.0"
+      }
+    },
+    "node_modules/@floating-ui/vue/node_modules/vue-demi": {
+      "version": "0.14.6",
+      "resolved": "https://registry.npmjs.org/vue-demi/-/vue-demi-0.14.6.tgz",
+      "integrity": "sha512-8QA7wrYSHKaYgUxDA5ZC24w+eHm3sYCbp0EzcDwKqN3p6HqtTCGR/GVsPyZW92unff4UlcSh++lmqDWN3ZIq4w==",
+      "hasInstallScript": true,
+      "bin": {
+        "vue-demi-fix": "bin/vue-demi-fix.js",
+        "vue-demi-switch": "bin/vue-demi-switch.js"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      },
+      "peerDependencies": {
+        "@vue/composition-api": "^1.0.0-rc.1",
+        "vue": "^3.0.0-0 || ^2.6.0"
+      },
+      "peerDependenciesMeta": {
+        "@vue/composition-api": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@hapi/hoek": {
       "version": "9.3.0",
       "resolved": "https://registry.npmjs.org/@hapi/hoek/-/hoek-9.3.0.tgz",
@@ -1404,6 +1472,16 @@
         "node": ">=12"
       }
     },
+    "node_modules/@popperjs/core": {
+      "version": "2.11.8",
+      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.8.tgz",
+      "integrity": "sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==",
+      "peer": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/popperjs"
+      }
+    },
     "node_modules/@prettier/plugin-php": {
       "version": "0.19.7",
       "resolved": "https://registry.npmjs.org/@prettier/plugin-php/-/plugin-php-0.19.7.tgz",
@@ -1416,6 +1494,28 @@
       },
       "peerDependencies": {
         "prettier": "^1.15.0 || ^2.0.0"
+      }
+    },
+    "node_modules/@rollup/pluginutils": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-5.0.5.tgz",
+      "integrity": "sha512-6aEYR910NyP73oHiJglti74iRyOwgFU4x3meH/H8OJx6Ry0j6cOVZ5X/wTvub7G7Ao6qaHBEaNsV3GLJkSsF+Q==",
+      "dev": true,
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "estree-walker": "^2.0.2",
+        "picomatch": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "rollup": "^1.20.0||^2.0.0||^3.0.0||^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "rollup": {
+          "optional": true
+        }
       }
     },
     "node_modules/@rushstack/eslint-patch": {
@@ -6144,6 +6244,12 @@
         "url": "https://github.com/sindresorhus/is?sponsor=1"
       }
     },
+    "node_modules/@types/estree": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.3.tgz",
+      "integrity": "sha512-CS2rOaoQ/eAgAfcTfq6amKG7bsN+EMcgGY4FAFQdvSj2y1ixvOZTUA9mOtCai7E1SYu283XNw7urKK30nP3wkQ==",
+      "dev": true
+    },
     "node_modules/@types/minimatch": {
       "version": "3.0.5",
       "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.5.tgz",
@@ -6185,6 +6291,11 @@
       "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.9.tgz",
       "integrity": "sha512-zC0iXxAv1C1ERURduJueYzkzZ2zaGyc+P2c95hgkikHPr3z8EdUZOlgEQ5X0DRmwDZn+hekycQnoeiiRVrmilQ==",
       "dev": true
+    },
+    "node_modules/@types/web-bluetooth": {
+      "version": "0.0.18",
+      "resolved": "https://registry.npmjs.org/@types/web-bluetooth/-/web-bluetooth-0.0.18.tgz",
+      "integrity": "sha512-v/ZHEj9xh82usl8LMR3GarzFY1IrbXJw5L4QfQhokjRV91q+SelFqxQWSep1ucXEZ22+dSTwLFkXeur25sPIbw=="
     },
     "node_modules/@types/yauzl": {
       "version": "2.10.2",
@@ -6335,6 +6446,89 @@
       "version": "3.3.6",
       "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.3.6.tgz",
       "integrity": "sha512-Xno5pEqg8SVhomD0kTSmfh30ZEmV/+jZtyh39q6QflrjdJCXah5lrnOLi9KB6a5k5aAHXMXjoMnxlzUkCNfWLQ=="
+    },
+    "node_modules/@vueuse/core": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/@vueuse/core/-/core-10.5.0.tgz",
+      "integrity": "sha512-z/tI2eSvxwLRjOhDm0h/SXAjNm8N5ld6/SC/JQs6o6kpJ6Ya50LnEL8g5hoYu005i28L0zqB5L5yAl8Jl26K3A==",
+      "dependencies": {
+        "@types/web-bluetooth": "^0.0.18",
+        "@vueuse/metadata": "10.5.0",
+        "@vueuse/shared": "10.5.0",
+        "vue-demi": ">=0.14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/@vueuse/core/node_modules/vue-demi": {
+      "version": "0.14.6",
+      "resolved": "https://registry.npmjs.org/vue-demi/-/vue-demi-0.14.6.tgz",
+      "integrity": "sha512-8QA7wrYSHKaYgUxDA5ZC24w+eHm3sYCbp0EzcDwKqN3p6HqtTCGR/GVsPyZW92unff4UlcSh++lmqDWN3ZIq4w==",
+      "hasInstallScript": true,
+      "bin": {
+        "vue-demi-fix": "bin/vue-demi-fix.js",
+        "vue-demi-switch": "bin/vue-demi-switch.js"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      },
+      "peerDependencies": {
+        "@vue/composition-api": "^1.0.0-rc.1",
+        "vue": "^3.0.0-0 || ^2.6.0"
+      },
+      "peerDependenciesMeta": {
+        "@vue/composition-api": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vueuse/metadata": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/@vueuse/metadata/-/metadata-10.5.0.tgz",
+      "integrity": "sha512-fEbElR+MaIYyCkeM0SzWkdoMtOpIwO72x8WsZHRE7IggiOlILttqttM69AS13nrDxosnDBYdyy3C5mR1LCxHsw==",
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/@vueuse/shared": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/@vueuse/shared/-/shared-10.5.0.tgz",
+      "integrity": "sha512-18iyxbbHYLst9MqU1X1QNdMHIjks6wC7XTVf0KNOv5es/Ms6gjVFCAAWTVP2JStuGqydg3DT+ExpFORUEi9yhg==",
+      "dependencies": {
+        "vue-demi": ">=0.14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/@vueuse/shared/node_modules/vue-demi": {
+      "version": "0.14.6",
+      "resolved": "https://registry.npmjs.org/vue-demi/-/vue-demi-0.14.6.tgz",
+      "integrity": "sha512-8QA7wrYSHKaYgUxDA5ZC24w+eHm3sYCbp0EzcDwKqN3p6HqtTCGR/GVsPyZW92unff4UlcSh++lmqDWN3ZIq4w==",
+      "hasInstallScript": true,
+      "bin": {
+        "vue-demi-fix": "bin/vue-demi-fix.js",
+        "vue-demi-switch": "bin/vue-demi-switch.js"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      },
+      "peerDependencies": {
+        "@vue/composition-api": "^1.0.0-rc.1",
+        "vue": "^3.0.0-0 || ^2.6.0"
+      },
+      "peerDependenciesMeta": {
+        "@vue/composition-api": {
+          "optional": true
+        }
+      }
     },
     "node_modules/acorn": {
       "version": "8.10.0",
@@ -6743,6 +6937,40 @@
       "resolved": "https://registry.npmjs.org/boolean/-/boolean-3.2.0.tgz",
       "integrity": "sha512-d0II/GO9uf9lfUHH2BQsjxzRJZBdsjgsBiW4BvhWk/3qoKwQFjIDVN19PfX8F2D/r9PCMTtLWjYVCFrpeYUzsw==",
       "dev": true
+    },
+    "node_modules/bootstrap": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-5.3.2.tgz",
+      "integrity": "sha512-D32nmNWiQHo94BKHLmOrdjlL05q1c8oxbtBphQFb9Z5to6eGRDCm0QgeaZ4zFBHzfg2++rqa2JkqCcxDy0sH0g==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/twbs"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/bootstrap"
+        }
+      ],
+      "peerDependencies": {
+        "@popperjs/core": "^2.11.8"
+      }
+    },
+    "node_modules/bootstrap-vue-next": {
+      "version": "0.14.10",
+      "resolved": "https://registry.npmjs.org/bootstrap-vue-next/-/bootstrap-vue-next-0.14.10.tgz",
+      "integrity": "sha512-0czOUVVi8nSA3M9dm48jJnMUB6vP7sYrMxfbFjINE/MEwVbsi4b1Gq41k6gFJcwE54fj7pYQW9q8LP5fqcq0Lw==",
+      "dependencies": {
+        "@floating-ui/vue": "^1.0.2",
+        "@vueuse/core": "^10.4.1"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/bootstrap-vue-next"
+      },
+      "peerDependencies": {
+        "vue": "^3.3.4"
+      }
     },
     "node_modules/bottleneck": {
       "version": "2.19.5",
@@ -11107,6 +11335,18 @@
       "dev": true,
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/local-pkg": {
+      "version": "0.4.3",
+      "resolved": "https://registry.npmjs.org/local-pkg/-/local-pkg-0.4.3.tgz",
+      "integrity": "sha512-SFppqq5p42fe2qcZQqqEOiVRXl+WCP1MdT6k7BDEW1j++sp5fIY+/fdRQitvKgB5BrBcmrs5m/L0v2FrU5MY1g==",
+      "dev": true,
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
       }
     },
     "node_modules/locate-path": {
@@ -19709,6 +19949,79 @@
         "node": ">= 10.0.0"
       }
     },
+    "node_modules/unplugin": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/unplugin/-/unplugin-1.5.0.tgz",
+      "integrity": "sha512-9ZdRwbh/4gcm1JTOkp9lAkIDrtOyOxgHmY7cjuwI8L/2RTikMcVG25GsZwNAgRuap3iDw2jeq7eoqtAsz5rW3A==",
+      "dev": true,
+      "dependencies": {
+        "acorn": "^8.10.0",
+        "chokidar": "^3.5.3",
+        "webpack-sources": "^3.2.3",
+        "webpack-virtual-modules": "^0.5.0"
+      }
+    },
+    "node_modules/unplugin-vue-components": {
+      "version": "0.25.2",
+      "resolved": "https://registry.npmjs.org/unplugin-vue-components/-/unplugin-vue-components-0.25.2.tgz",
+      "integrity": "sha512-OVmLFqILH6w+eM8fyt/d/eoJT9A6WO51NZLf1vC5c1FZ4rmq2bbGxTy8WP2Jm7xwFdukaIdv819+UI7RClPyCA==",
+      "dev": true,
+      "dependencies": {
+        "@antfu/utils": "^0.7.5",
+        "@rollup/pluginutils": "^5.0.2",
+        "chokidar": "^3.5.3",
+        "debug": "^4.3.4",
+        "fast-glob": "^3.3.0",
+        "local-pkg": "^0.4.3",
+        "magic-string": "^0.30.1",
+        "minimatch": "^9.0.3",
+        "resolve": "^1.22.2",
+        "unplugin": "^1.4.0"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      },
+      "peerDependencies": {
+        "@babel/parser": "^7.15.8",
+        "@nuxt/kit": "^3.2.2",
+        "vue": "2 || 3"
+      },
+      "peerDependenciesMeta": {
+        "@babel/parser": {
+          "optional": true
+        },
+        "@nuxt/kit": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/unplugin-vue-components/node_modules/brace-expansion": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "dev": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/unplugin-vue-components/node_modules/minimatch": {
+      "version": "9.0.3",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.3.tgz",
+      "integrity": "sha512-RHiac9mvaRw0x3AYRgDC1CxAP7HTcNrrECeA8YYJeWnpo+2Q5CegtZjaotWTWxDG3UeGA1coE05iH1mPjT/2mg==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
     "node_modules/untildify": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/untildify/-/untildify-4.0.0.tgz",
@@ -20028,6 +20341,21 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
       "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "dev": true
+    },
+    "node_modules/webpack-sources": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-3.2.3.tgz",
+      "integrity": "sha512-/DyMEOrDgLKKIG0fmvtz+4dUX/3Ghozwgm6iPp8KRhvn+eQf9+Q7GWxVNMk3+uCPWfdXYC4ExGBckIXdFEfH1w==",
+      "dev": true,
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/webpack-virtual-modules": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/webpack-virtual-modules/-/webpack-virtual-modules-0.5.0.tgz",
+      "integrity": "sha512-kyDivFZ7ZM0BVOUteVbDFhlRt7Ah/CSPwJdi8hBpkK7QLumUqdLtVfm/PX/hkcnrvr0i77fO5+TjZ94Pe+C9iw==",
       "dev": true
     },
     "node_modules/whatwg-url": {

--- a/package.json
+++ b/package.json
@@ -28,6 +28,8 @@
     "zip:fd2": "cd modules/farm_fd2/dist/; zip -r farmdata2.zip farmdata2"
   },
   "dependencies": {
+    "bootstrap": "^5.3.2",
+    "bootstrap-vue-next": "^0.14.10",
     "dayjs": "^1.11.8",
     "pinia": "^2.1.3",
     "vue": "^3.3.4"
@@ -38,9 +40,9 @@
     "@saithodev/semantic-release-backmerge": "^3.2.0",
     "@semantic-release/changelog": "^6.0.3",
     "@semantic-release/git": "^10.0.1",
-    "conventional-changelog-conventionalcommits": "^7.0.1",
     "@vitejs/plugin-vue": "^4.2.3",
     "@vue/eslint-config-prettier": "^7.1.0",
+    "conventional-changelog-conventionalcommits": "^7.0.1",
     "cspell": "^6.31.2",
     "cypress": "^12.14.0",
     "eslint": "^8.39.0",
@@ -57,6 +59,7 @@
     "shellcheck": "^2.2.0",
     "shfmt": "^0.0.1",
     "start-server-and-test": "^2.0.0",
+    "unplugin-vue-components": "^0.25.2",
     "vite": "^4.3.9",
     "vite-plugin-static-copy": "^0.16.0"
   }


### PR DESCRIPTION
**Pull Request Description**

Adds the bootstrap-vue-next UI library to the templates in `bin` that are used to create new entrypoints.  All entrypoints created will be able to use BV next components.

---

**Licensing Certification**

FarmData2 is a [Free Cultural Work](https://freedomdefined.org/Definition) and all accepted contributions are licensed as described in the LICENSE.md file. This requires that the contributor holds the rights to do so. By submitting this pull request **I certify that I satisfy the terms of the [Developer Certificate of Origin](https://developercertificate.org/)** for its contents.
