### PR TITLE
fix: improves idioms for styling valid and invliad data elements

### DIFF
--- a/bin/templates/component/NewComponent.vue
+++ b/bin/templates/component/NewComponent.vue
@@ -26,6 +26,7 @@
  */
 export default {
   name: '%COMPONENT_NAME%',
+  components: {},
   emits: ['ready', 'valid'],
   props: {
     /**
@@ -36,70 +37,47 @@ export default {
       default: false,
     },
     /**
-     * Text that appears below the input element when value is valid.
-     */
-    validText: {
-      type: String,
-      default: 'Default valid message.',
-    },
-    /**
-     * Text that appears below the input element when value is invalid.
-     */
-    invalidText: {
-      type: String,
-      default: 'Default invalid message.',
-    },
-    /**
-     * Whether to show the validity styling of the input elements.
+     * Whether validity styling should appear on input elements with invalid values.
      * This prop is watched by the component.
      */
-    showValidity: {
+    showInvalidStyling: {
       type: Boolean,
       default: false,
     },
   },
   data() {
-    return {
-      validate: this.showValidity,
-    };
+    return {};
   },
   computed: {
     isValid() {
-      // Indicates if the current value of the component is valid.
-      if (this.required) {
-        return false;  // TODO: Add validation here.
-      } else {
-        return true;
-      }
+      /*
+       * Edit this computed property to indicate when the values are valid.
+       * This should account for the `required` prop but should be independent of the `showInvalid` prop.
+       */
+      return true;
     },
-    useValidityStyling() {
-      // Indicates if the component UI validity should be shown.
-      // 'null' if the entrypoint says not to showValidity
-      // `true` if the entrypoint says to showValidity and component value is valid.
-      // `false` otherwise.
-      if (!this.validate) {
-        return null;
-      } else {
-        return this.isValid;
-      }
+    // Controls component styling (i.e. when green check or red X and invalid feedback) should be displayed.
+    validationStyling() {
+      return uiUtil.validationStyling(this.isValid, this.showInvalidStyling);
     },
   },
   methods: {},
   watch: {
-    showValidity() {
-      this.validate = this.showValidity;
-    },
     isValid() {
       /**
-       * The validity of the component has changed.
-       * @property {boolean} valid whether the component's value is valid or not.
+       * The validity of the component has changed.  Also emitted when the component is created.
+       * @property {*} valid `true` if the component's value is valid; `false` if it is invalid.
        */
       this.$emit('valid', this.isValid);
     },
   },
   created() {
+    
+    //Emit the initial valid state of the component's value.
+    this.$emit('valid', this.isValid);
+
     /**
-     * This component is ready for use.
+     * The component is ready for use.
      */
     this.$emit('ready');
   },

--- a/components/CropSelector/CropSelector.behavior.comp.cy.js
+++ b/components/CropSelector/CropSelector.behavior.comp.cy.js
@@ -11,7 +11,7 @@ describe('Test the CropSelector behaviors', () => {
     cy.saveSessionStorage();
   });
 
-  it('Clicking add crop button goes to add crop form', () => {
+  it('Clicking add crop button goes to the add crop form', () => {
     const readySpy = cy.spy().as('readySpy');
 
     cy.intercept('GET', '**/taxonomy/manage/plant_type/add', {

--- a/components/CropSelector/CropSelector.content.comp.cy.js
+++ b/components/CropSelector/CropSelector.content.comp.cy.js
@@ -47,7 +47,7 @@ describe('Test the CropSelector content', () => {
   it('Test showInvalid true when not required', () => {
     cy.mount(CropSelector, {
       props: {
-        showinvalid: true,
+        showinvalidStyling: true,
       },
     });
 
@@ -61,7 +61,7 @@ describe('Test the CropSelector content', () => {
     cy.mount(CropSelector, {
       props: {
         required: true,
-        showInvalid: true,
+        showInvalidStyling: true,
       },
     });
 

--- a/components/CropSelector/CropSelector.content.comp.cy.js
+++ b/components/CropSelector/CropSelector.content.comp.cy.js
@@ -18,19 +18,18 @@ describe('Test the CropSelector content', () => {
     cy.get('[data-cy="crop-label"]').should('have.text', 'Crop:');
     cy.get('[data-cy="required-star"]').should('not.exist');
     cy.get('[data-cy="crop-select"]').should('exist');
-    cy.get('[data-cy="option-0"]').should('have.value', 'Choose crop...');
-    cy.get('[data-cy="option-1"]').should('exist');
-    cy.get('[data-cy="option-111"]').should('exist');
+    cy.get('[data-cy="crop-select"]').should('not.have.class', 'is-valid');
+    cy.get('[data-cy="crop-select"]').should('not.have.class', 'is-invalid');
+    cy.get('[data-cy="option-0"]').should('have.value', '');
     cy.get('[data-cy="add-crop-button"]').should('exist');
-    cy.get('[data-cy="crop-valid-text"]').should('have.text', 'Select crop.');
-    cy.get('[data-cy="crop-invalid-text"]').should('not.be.visible');
-    cy.get('[data-cy="crop-invalid-text"]').should(
-      'have.text',
-      'Crop selection is required.'
+    cy.get('[data-cy="crop-invalid-feedback"]').should('not.be.visible');
+    cy.get('[data-cy="crop-invalid-feedback"]').should(
+      'contain.text',
+      'A crop selection is required.'
     );
   });
 
-  it('Test the defaults when CropSelector is required', () => {
+  it('Test required prop', () => {
     cy.mount(CropSelector, {
       props: {
         required: true,
@@ -38,49 +37,37 @@ describe('Test the CropSelector content', () => {
     });
     cy.get('[data-cy="required-star"]').should('exist');
     cy.get('[data-cy="required-star"]').should('have.text', '*');
-    cy.get('[data-cy="crop-valid-text"]').should('not.be.visible');
+
+    // No styling should appear because show invalid is false and initially empty is okay.
+    cy.get('[data-cy="crop-select"]').should('not.have.class', 'is-valid');
+    cy.get('[data-cy="crop-select"]').should('not.have.class', 'is-invalid');
+    cy.get('[data-cy="crop-invalid-feedback"]').should('not.be.visible');
   });
 
-  it('Test that custom validText and invalidText work', () => {
+  it('Test showInvalid true when not required', () => {
     cy.mount(CropSelector, {
       props: {
-        validText: 'Testing valid text.',
-        invalidText: 'Testing invalid text.',
+        showinvalid: true,
       },
     });
 
-    cy.get('[data-cy="crop-valid-text"]').should(
-      'have.text',
-      'Testing valid text.'
-    );
-    cy.get('[data-cy="crop-invalid-text"]').should(
-      'have.text',
-      'Testing invalid text.'
-    );
+    // No styling should appear because empty is okay when not required.
+    cy.get('[data-cy="crop-select"]').should('not.have.class', 'is-valid');
+    cy.get('[data-cy="crop-select"]').should('not.have.class', 'is-invalid');
+    cy.get('[data-cy="crop-invalid-feedback"]').should('not.be.visible');
   });
 
-  it('Test showValidity with valid state', () => {
-    cy.mount(CropSelector, {
-      props: {
-        showValidity: true,
-      },
-    });
-
-    cy.get('[data-cy="crop-select"]').should('have.class', 'is-valid');
-    cy.get('[data-cy="crop-valid-text"]').should('be.visible');
-    cy.get('[data-cy="crop-invalid-text"]').should('not.be.visible');
-  });
-
-  it('Test showValidity with invalid state', () => {
+  it('Test showInvalid true when required', () => {
     cy.mount(CropSelector, {
       props: {
         required: true,
-        showValidity: true,
+        showInvalid: true,
       },
     });
 
+    // Styling should appear because empty is not okay when not required.
+    cy.get('[data-cy="crop-select"]').should('not.have.class', 'is-valid');
     cy.get('[data-cy="crop-select"]').should('have.class', 'is-invalid');
-    cy.get('[data-cy="crop-valid-text"]').should('not.be.visible');
-    cy.get('[data-cy="crop-invalid-text"]').should('be.visible');
+    cy.get('[data-cy="crop-invalid-feedback"]').should('be.visible');
   });
 });

--- a/components/CropSelector/CropSelector.content.comp.cy.js
+++ b/components/CropSelector/CropSelector.content.comp.cy.js
@@ -44,7 +44,7 @@ describe('Test the CropSelector content', () => {
     cy.get('[data-cy="crop-invalid-feedback"]').should('not.be.visible');
   });
 
-  it('Test showInvalid true when not required', () => {
+  it('Test showInvalidStyling true when not required', () => {
     cy.mount(CropSelector, {
       props: {
         showinvalidStyling: true,
@@ -57,7 +57,7 @@ describe('Test the CropSelector content', () => {
     cy.get('[data-cy="crop-invalid-feedback"]').should('not.be.visible');
   });
 
-  it('Test showInvalid true when required', () => {
+  it('Test showInvalidStyling true when required', () => {
     cy.mount(CropSelector, {
       props: {
         required: true,

--- a/components/CropSelector/CropSelector.events.comp.cy.js
+++ b/components/CropSelector/CropSelector.events.comp.cy.js
@@ -157,7 +157,7 @@ describe('Test the CropSelector events', () => {
             'is-invalid'
           );
 
-          wrapper.setProps({ showInvalid: true });
+          wrapper.setProps({ showInvalidStyling: true });
 
           cy.get('[data-cy="crop-select"]').should('have.class', 'is-invalid');
         });

--- a/components/CropSelector/CropSelector.events.comp.cy.js
+++ b/components/CropSelector/CropSelector.events.comp.cy.js
@@ -29,6 +29,25 @@ describe('Test the CropSelector events', () => {
       });
   });
 
+  it('Emits "valid" on creation', () => {
+    const readySpy = cy.spy().as('readySpy');
+    const validSpy = cy.spy().as('validSpy');
+
+    cy.mount(CropSelector, {
+      props: {
+        onReady: readySpy,
+        onValid: validSpy,
+      },
+    });
+
+    cy.get('@readySpy')
+      .should('have.been.calledOnce')
+      .then(() => {
+        cy.get('@validSpy').should('have.been.calledOnce');
+        cy.get('@validSpy').should('have.been.calledWith', false);
+      });
+  });
+
   it('Verify that `selected` prop is watched', () => {
     const readySpy = cy.spy().as('readySpy');
     const updateSpy = cy.spy().as('updateSpy');
@@ -85,9 +104,10 @@ describe('Test the CropSelector events', () => {
     cy.get('@readySpy')
       .should('have.been.calledOnce')
       .then(() => {
+        cy.get('@validSpy').should('have.been.calledWith', false); // during creation.
         cy.get('[data-cy="crop-select"]').select('ARUGULA');
-        cy.get('@validSpy').should('have.been.calledOnce');
-        cy.get('@validSpy').should('have.been.calledWith', true);
+        cy.get('@validSpy').should('have.been.calledTwice'); // on creation and on selection.
+        cy.get('@validSpy').should('have.been.calledWith', true); // during selection.
       });
   });
 
@@ -106,10 +126,13 @@ describe('Test the CropSelector events', () => {
     cy.get('@readySpy')
       .should('have.been.calledOnce')
       .then(() => {
+        cy.get('@validSpy').should('have.been.calledOnce'); // on creation.
         cy.get('[data-cy="crop-select"]').select('ARUGULA');
+        cy.get('@validSpy').should('have.been.calledTwice'); // on selection.
         cy.get('[data-cy="crop-select"]').select('BROCCOLI');
-        cy.get('@validSpy').should('have.been.calledOnce');
-        cy.get('@validSpy').should('have.been.calledWith', true);
+        cy.get('@validSpy').should('have.been.calledTwice'); // but not again - no change in validity.
+        cy.get('[data-cy="crop-select"]').select('ZUCCHINI');
+        cy.get('@validSpy').should('have.been.calledTwice');
       });
   });
 
@@ -134,7 +157,7 @@ describe('Test the CropSelector events', () => {
             'is-invalid'
           );
 
-          wrapper.setProps({ showValidity: true });
+          wrapper.setProps({ showInvalid: true });
 
           cy.get('[data-cy="crop-select"]').should('have.class', 'is-invalid');
         });
@@ -159,7 +182,7 @@ describe('Test the CropSelector events', () => {
     cy.get('@errorSpy').should('have.been.calledOnce');
     cy.get('@errorSpy').should(
       'have.been.calledWith',
-      'Unable to connect to farm.'
+      'Unable to connect to farmOS server.'
     );
   });
 

--- a/components/CropSelector/CropSelector.vue
+++ b/components/CropSelector/CropSelector.vue
@@ -22,7 +22,7 @@
         id="crop-select"
         data-cy="crop-select"
         v-model="crop"
-        v-bind:state="showInvalidStyling"
+        v-bind:state="validationStyling"
         v-bind:required="required"
       >
         <template v-slot:first>
@@ -52,7 +52,7 @@
       <BFormInvalidFeedback
         id="crop-invalid-feedback"
         data-cy="crop-invalid-feedback"
-        v-bind:state="showInvalidStyling"
+        v-bind:state="validationStyling"
       >
         A crop selection is required.
       </BFormInvalidFeedback>
@@ -104,7 +104,7 @@ export default {
      * Whether validity styling should appear on input elements with invalid values.
      * This prop is watched by the component.
      */
-    showInvalid: {
+    showInvalidStyling: {
       type: Boolean,
       default: false,
     },
@@ -130,8 +130,8 @@ export default {
       return this.required && this.crop != null;
     },
     // Controls when the invalid styling (i.e. red X) should be displayed.
-    showInvalidStyling() {
-      return uiUtil.showInvalidStyling(this.isValid, this.showInvalid);
+    validationStyling() {
+      return uiUtil.validationStyling(this.isValid, this.showInvalidStyling);
     },
   },
   methods: {},

--- a/components/CropSelector/CropSelector.vue
+++ b/components/CropSelector/CropSelector.vue
@@ -22,7 +22,7 @@
         id="crop-select"
         data-cy="crop-select"
         v-model="crop"
-        v-bind:state="useValidityStyling"
+        v-bind:state="showInvalidStyling"
         v-bind:required="required"
       >
         <template v-slot:first>
@@ -30,8 +30,7 @@
             v-bind:value="null"
             data-cy="option-0"
             disabled
-            >Choose crop...</BFormSelectOption
-          >
+          />
         </template>
         <BFormSelectOption
           v-for="(crop, i) in cropList"
@@ -50,17 +49,12 @@
           >+</BButton
         >
       </BInputGroupAppend>
-      <BFormValidFeedback
-        id="crop-valid-text"
-        data-cy="crop-valid-text"
-        v-bind:state="isValid"
-        >{{ validText }}</BFormValidFeedback
-      >
       <BFormInvalidFeedback
-        id="crop-invalid-text"
-        data-cy="crop-invalid-text"
-        v-bind:state="isValid"
-        >{{ invalidText }}
+        id="crop-invalid-feedback"
+        data-cy="crop-invalid-feedback"
+        v-bind:state="showInvalidStyling"
+      >
+        A crop selection is required.
       </BFormInvalidFeedback>
     </BInputGroup>
   </BFormGroup>
@@ -68,6 +62,7 @@
 
 <script>
 import * as farmosUtil from '@libs/farmosUtil/farmosUtil.js';
+import * as uiUtil from '@libs/uiUtil/uiUtil.js';
 
 /**
  * A component that allows the user to select a crop.
@@ -75,43 +70,27 @@ import * as farmosUtil from '@libs/farmosUtil/farmosUtil.js';
  * ## Usage Example
  *
  * ```html
- * <CropSelector
- *   required
- *   validText="Select seeded crop."
- *   invalidText="Seeded crop is required."
- *   v-model:selected="form.crop"
- *   v-bind:showValidity="form.validity.show" 
- *   v-on:valid="(valid) => form.validity.crop = valid"
- *   v-on:ready="createdCount++"
- *   v-on:error="
- *     (msg) =>
- *        uiUtil.showToast('Network Error', msg, 'top-center', 'danger', 5)
- *   "
+ * TODO: Update this example.
  * />
 
  * ```
- * - Notes:
- *   - The entrypoint using this component as shown above would need to:
- *      - import `uiUtil`.
- *      - define `form.crop` and `createdCount` in its `data` property.
- *   - See the `modules/README.md` for more information about using components.
  *
  * ## `data-cy` Attributes
  *
- * Attribute Name        | Description
- * ----------------------| -----------
- * `crop-group`          | The `BFormGroup` component containing this component.
- * `crop-label`          | The `span` component containing the "Crop" label.
- * `required-star`       | The `*` that appears in the label if the input is required.
- * `crop-select`         | The `BFormSelect` component used to select a crop.
- * `option-0`            | The disabled "Choose crop..." option in the `BFormSelect` component.
- * `option-n`            | The nth option in the `BFormSelect` component [1...n].
- * `add-crop-button`     | The `BButton` component that redirects to the page for adding a new crop.
- * `crop-valid-text`     | The `BFormValidFeedback` component that displays help when input is valid.
- * `crop-invalid-text`   | The `BFormInvalidFeedback` component that displays help when input is invalid.
+ * Attribute Name          | Description
+ * ------------------------| -----------
+ * `crop-group`            | The `BFormGroup` component containing this component.
+ * `crop-label`            | The `span` component containing the "Crop" label.
+ * `required-star`         | The `*` that appears in the label if the input is required.
+ * `crop-select`           | The `BFormSelect` component used to select a crop.
+ * `option-0`              | The disabled "Choose crop..." option in the `BFormSelect` component.
+ * `option-n`              | The nth option in the `BFormSelect` component [1...n].
+ * `add-crop-button`       | The `BButton` component that redirects to the page for adding a new crop.
+ * `crop-invalid-feedback` | The `BFormInvalidFeedback` component that displays help when input is invalid.
  */
 export default {
   name: 'CropSelector',
+  components: {},
   emits: ['error', 'ready', 'update:selected', 'valid'],
   props: {
     /**
@@ -122,24 +101,10 @@ export default {
       default: false,
     },
     /**
-     * Text that appears below the select element when value is valid.
-     */
-    validText: {
-      type: String,
-      default: 'Select crop.',
-    },
-    /**
-     * Text that appears below the select element when value is invalid.
-     */
-    invalidText: {
-      type: String,
-      default: 'Crop selection is required.',
-    },
-    /**
-     * Whether to show the validity styling of the component elements.
+     * Whether validity styling should appear on input elements with invalid values.
      * This prop is watched by the component.
      */
-    showValidity: {
+    showInvalid: {
       type: Boolean,
       default: false,
     },
@@ -156,28 +121,17 @@ export default {
     return {
       cropList: [],
       crop: this.selected,
-      validate: this.showValidity,
     };
   },
   computed: {
     isValid() {
-      // Indicates if the current value of the component is valid.
-      if (this.required) {
-        return this.crop != null;
-      } else {
-        return true;
-      }
+      // Returns true if the component's values are valid and false otherwise.
+      // This is to be determined independent of the `showInvalid` prop.
+      return this.required && this.crop != null;
     },
-    useValidityStyling() {
-      // Indicates if the component UI validity should be shown.
-      // 'null' if the entrypoint says not to showValidity
-      // `true` if the entrypoint says to showValidity and this component is valid.
-      // `false` otherwise.
-      if (!this.validate) {
-        return null;
-      } else {
-        return this.isValid;
-      }
+    // Controls when the invalid styling (i.e. red X) should be displayed.
+    showInvalidStyling() {
+      return uiUtil.showInvalidStyling(this.isValid, this.showInvalid);
     },
   },
   methods: {},
@@ -192,13 +146,10 @@ export default {
     selected() {
       this.crop = this.selected;
     },
-    showValidity() {
-      this.validate = this.showValidity;
-    },
     isValid() {
       /**
-       * The validity of the component has changed.
-       * @property {boolean} valid whether the component's value is valid or not.
+       * The validity of the component has changed.  Also emitted when the component is created.
+       * @property {*} valid `true` if the component's value is valid; `false` if it is invalid.
        */
       this.$emit('valid', this.isValid);
     },
@@ -211,8 +162,11 @@ export default {
           .getCropNameToTermMap(farm)
           .then((cropMap) => {
             this.cropList = Array.from(cropMap.keys());
+            // Emit the initial valid state of the component's value.
+            this.$emit('valid', this.isValid);
+
             /**
-             * The select has been populated with the list of crops.
+             * The select has been populated with the list of crops and the component is ready to be used.
              */
             this.$emit('ready');
           })
@@ -229,7 +183,7 @@ export default {
       .catch((error) => {
         console.error('CropSelector: Error connecting to farm.');
         console.error(error);
-        this.$emit('error', 'Unable to connect to farm.');
+        this.$emit('error', 'Unable to connect to farmOS server.');
       });
   },
 };

--- a/components/DateSelector/DateSelector.content.comp.cy.js
+++ b/components/DateSelector/DateSelector.content.comp.cy.js
@@ -22,12 +22,12 @@ describe('Test the default DateSelector content', () => {
       'have.value',
       dayjs().format('YYYY-MM-DD')
     );
-    cy.get('[data-cy="date-valid-text"]').should('be.visible');
-    cy.get('[data-cy="date-valid-text"]').should('have.text', 'Select date.');
-    cy.get('[data-cy="date-invalid-text"]').should('not.be.visible');
-    cy.get('[data-cy="date-invalid-text"]').should(
-      'have.text',
-      'Date selection is required.'
+    cy.get('[data-cy="date-input"]').should('have.class', 'is-valid');
+    cy.get('[data-cy="date-input"]').should('not.have.class', 'is-invalid');
+    cy.get('[data-cy="date-invalid-feedback"]').should('not.be.visible');
+    cy.get('[data-cy="date-invalid-feedback"]').should(
+      'contain.text',
+      'A valid date is required.'
     );
   });
 
@@ -40,26 +40,9 @@ describe('Test the default DateSelector content', () => {
 
     cy.get('[data-cy="required-star"]').should('exist');
     cy.get('[data-cy="required-star"]').should('have.text', '*');
-    cy.get('[data-cy="date-valid-text"]').should('be.visible');
-    cy.get('[data-cy="date-invalid-text"]').should('not.be.visible');
-  });
-
-  it('Test props for validText and invalidText', () => {
-    cy.mount(DateSelector, {
-      props: {
-        validText: 'The valid text.',
-        invalidText: 'The invalid text.',
-      },
-    });
-
-    cy.get('[data-cy="date-valid-text"]').should(
-      'have.text',
-      'The valid text.'
-    );
-    cy.get('[data-cy="date-invalid-text"]').should(
-      'have.text',
-      'The invalid text.'
-    );
+    cy.get('[data-cy="date-input"]').should('have.class', 'is-valid');
+    cy.get('[data-cy="date-input"]').should('not.have.class', 'is-invalid');
+    cy.get('[data-cy="date-invalid-feedback"]').should('not.be.visible');
   });
 
   it('Test the date prop', () => {
@@ -72,39 +55,101 @@ describe('Test the default DateSelector content', () => {
     cy.get('[data-cy="date-input"]').should('have.value', '1999-01-02');
   });
 
-  it('Test valid with date set to null', () => {
+  /*
+   *There are 8 possibilities here...
+   *
+   * required    validDate    showValidStyling  Test
+   * false       false        false             Not required with valid date not showing invalid styling
+   * false       false        true              Not required with invalid date showing invalid styling
+   * false       true         false             Check all of the data-cy elements. (above)
+   * false       true         true              Not required with valid date not showing invalid styling
+   * true        false        false             Required with invalid valid date not showing invalid styling
+   * true        false        true              Required with invalid valid date not showing invalid styling
+   * true        true         false             Test defaults when DateSelector is required. (above)
+   * true        true         true              Required with valid date showing invalid styling
+   */
+
+  it('Not required with invalid date not showing invalid styling', () => {
     cy.mount(DateSelector, {
       props: {
-        required: true,
-        date: null,
+        requried: false,
+        date: '1999-01-02',
+        showInvalidStyling: false,
       },
     });
 
-    cy.get('[data-cy="date-valid-text"]').should('not.be.visible');
-    cy.get('[data-cy="date-invalid-text"]').should('be.visible');
+    cy.get('[data-cy="date-input"]').should('have.class', 'is-valid');
+    cy.get('[data-cy="date-input"]').should('not.have.class', 'is-invalid');
+    cy.get('[data-cy="date-invalid-feedback"]').should('not.be.visible');
   });
 
-  it('Test valid with date set to empty string', () => {
+  it('Not required with invalid date showing invalid styling', () => {
     cy.mount(DateSelector, {
       props: {
-        required: true,
-        date: '',
+        reqiured: false,
+        date: 'invalid-date',
+        showInvalidStyling: true,
       },
     });
 
-    cy.get('[data-cy="date-valid-text"]').should('not.be.visible');
-    cy.get('[data-cy="date-invalid-text"]').should('be.visible');
+    cy.get('[data-cy="date-input"]').should('have.class', 'is-valid');
+    cy.get('[data-cy="date-input"]').should('not.have.class', 'is-invalid');
+    cy.get('[data-cy="date-invalid-feedback"]').should('not.be.visible');
   });
 
-  it('Test valid with date set to an invalid date', () => {
+  it('Not required with valid date not showing invalid styling', () => {
+    cy.mount(DateSelector, {
+      props: {
+        requried: false,
+        date: '1999-01-02',
+        showInvalidStyling: true,
+      },
+    });
+
+    cy.get('[data-cy="date-input"]').should('have.class', 'is-valid');
+    cy.get('[data-cy="date-input"]').should('not.have.class', 'is-invalid');
+    cy.get('[data-cy="date-invalid-feedback"]').should('not.be.visible');
+  });
+
+  it('Required with invalid valid date not showing invalid styling', () => {
     cy.mount(DateSelector, {
       props: {
         required: true,
         date: 'invalid-date',
+        showInvalidStyling: false,
       },
     });
 
-    cy.get('[data-cy="date-valid-text"]').should('not.be.visible');
-    cy.get('[data-cy="date-invalid-text"]').should('be.visible');
+    cy.get('[data-cy="date-input"]').should('not.have.class', 'is-valid');
+    cy.get('[data-cy="date-input"]').should('not.have.class', 'is-invalid');
+    cy.get('[data-cy="date-invalid-feedback"]').should('not.be.visible');
+  });
+
+  it('Required with invalid valid date not showing invalid styling', () => {
+    cy.mount(DateSelector, {
+      props: {
+        required: true,
+        date: 'invalid-date',
+        showInvalidStyling: false,
+      },
+    });
+
+    cy.get('[data-cy="date-input"]').should('not.have.class', 'is-valid');
+    cy.get('[data-cy="date-input"]').should('not.have.class', 'is-invalid');
+    cy.get('[data-cy="date-invalid-feedback"]').should('not.be.visible');
+  });
+
+  it('Required with valid date showing invalid styling', () => {
+    cy.mount(DateSelector, {
+      props: {
+        required: true,
+        date: '1999-01-02',
+        showInvalidStyling: true,
+      },
+    });
+
+    cy.get('[data-cy="date-input"]').should('have.class', 'is-valid');
+    cy.get('[data-cy="date-input"]').should('not.have.class', 'is-invalid');
+    cy.get('[data-cy="date-invalid-feedback"]').should('not.be.visible');
   });
 });

--- a/components/DateSelector/DateSelector.events.comp.cy.js
+++ b/components/DateSelector/DateSelector.events.comp.cy.js
@@ -27,6 +27,25 @@ describe('Test the  DateSelector component events', () => {
       });
   });
 
+  it('Emits "valid" on creation', () => {
+    const readySpy = cy.spy().as('readySpy');
+    const validSpy = cy.spy().as('validSpy');
+
+    cy.mount(DateSelector, {
+      props: {
+        onReady: readySpy,
+        onValid: validSpy,
+      },
+    });
+
+    cy.get('@readySpy')
+      .should('have.been.calledOnce')
+      .then(() => {
+        cy.get('@validSpy').should('have.been.calledOnce');
+        cy.get('@validSpy').should('have.been.calledWith', true);
+      });
+  });
+
   it('Verify that `date` prop is watched', () => {
     const readySpy = cy.spy().as('readySpy');
     const updateSpy = cy.spy().as('updateSpy');
@@ -67,12 +86,13 @@ describe('Test the  DateSelector component events', () => {
       });
   });
 
-  it('Watches showValidity prop', () => {
+  it('Component reacts to changed showInvalidStyling prop', () => {
     const readySpy = cy.spy().as('readySpy');
 
     cy.mount(DateSelector, {
       props: {
         required: true,
+        date: 'invalid-date',
         onReady: readySpy,
       },
     }).then(({ wrapper }) => {
@@ -85,9 +105,10 @@ describe('Test the  DateSelector component events', () => {
             'is-invalid'
           );
 
-          wrapper.setProps({ showValidity: true });
+          wrapper.setProps({ showInvalidStyling: true });
 
-          cy.get('[data-cy="date-input"]').should('have.class', 'is-valid');
+          cy.get('[data-cy="date-input"]').should('not.have.class', 'is-valid');
+          cy.get('[data-cy="date-input"]').should('have.class', 'is-invalid');
         });
     });
   });
@@ -107,8 +128,12 @@ describe('Test the  DateSelector component events', () => {
     cy.get('@readySpy')
       .should('have.been.calledOnce')
       .then(() => {
-        cy.get('[data-cy="date-input"]').clear();
         cy.get('@validSpy').should('have.been.calledOnce');
+        cy.get('@validSpy').should('have.been.calledWith', true);
+
+        cy.get('[data-cy="date-input"]').clear();
+
+        cy.get('@validSpy').should('have.been.calledTwice');
         cy.get('@validSpy').should('have.been.calledWith', false);
       });
   });
@@ -122,16 +147,20 @@ describe('Test the  DateSelector component events', () => {
         required: true,
         onReady: readySpy,
         onValid: validSpy,
-        date: '',
+        date: 'invalid-date',
       },
     });
 
     cy.get('@readySpy')
       .should('have.been.calledOnce')
       .then(() => {
-        cy.get('[data-cy="date-input"]').type('1999-01-02');
         cy.get('@validSpy').should('have.been.calledOnce');
-        cy.get('@validSpy').should('have.been.calledWith', true);
+        cy.get('@validSpy').should('have.been.calledWith', false);
+
+        cy.get('[data-cy="date-input"]').type('1999-01-02');
+
+        cy.get('@validSpy').should('have.been.calledTwice');
+        cy.get('@validSpy').should('have.been.calledWith', false);
       });
   });
 
@@ -150,8 +179,13 @@ describe('Test the  DateSelector component events', () => {
     cy.get('@readySpy')
       .should('have.been.calledOnce')
       .then(() => {
+        cy.get('@validSpy').should('have.been.calledOnce');
+
         cy.get('[data-cy="date-input"]').type('1999-01-02');
-        cy.get('@validSpy').should('not.have.been.called');
+        cy.get('[data-cy="date-input"]').type('1999-01-03');
+        cy.get('[data-cy="date-input"]').type('1999-01-04');
+
+        cy.get('@validSpy').should('have.been.calledOnce');
       });
   });
 });

--- a/components/DateSelector/DateSelector.vue
+++ b/components/DateSelector/DateSelector.vue
@@ -22,26 +22,22 @@
       data-cy="date-input"
       type="date"
       v-model="chosenDate"
-      v-bind:state="useValidityStyling"
+      v-bind:state="validationStyling"
       v-bind:required="required"
     />
-    <BFormValidFeedback
-      id="date-valid-text"
-      data-cy="date-valid-text"
-      v-bind:state="isValid"
-      >{{ validText }}</BFormValidFeedback
-    >
     <BFormInvalidFeedback
-      id="date-invalid-text"
-      data-cy="date-invalid-text"
-      v-bind:state="isValid"
-      >{{ invalidText }}</BFormInvalidFeedback
+      id="date-invalid-feedback"
+      data-cy="date-invalid-feedback"
+      v-bind:state="validationStyling"
     >
+      A valid date is required.
+    </BFormInvalidFeedback>
   </BFormGroup>
 </template>
 
 <script>
 import dayjs from 'dayjs';
+import * as uiUtil from '@libs/uiUtil/uiUtil.js';
 
 /**
  * A component for selecting a date.
@@ -55,14 +51,13 @@ import dayjs from 'dayjs';
  *
  * ## `data-cy` Attributes
  *
- * Attribute Name        | Description
- * ----------------------| -----------
- * `date-group`          | The `BFormGroup` component containing this component.
- * `date-label`          | The `span` component containing the "Date:" label.
- * `required-star`       | The `*` that appears in the label if the input is required.
- * `date-input`          | The `BFormInput` component used to select a date.
- * `date-valid-text`     | The `BFormValidFeedback` component that displays help when the date is valid.
- * `date-invalid-text`   | The `BFormInvalidFeedback` component that displays help when the date is invalid.
+ * Attribute Name            | Description
+ * --------------------------| -----------
+ * `date-group`              | The `BFormGroup` component containing this component.
+ * `date-label`              | The `span` component containing the "Date:" label.
+ * `required-star`           | The `*` that appears in the label if the input is required.
+ * `date-input`              | The `BFormInput` component used to select a date.
+ * `date-invalid-feedback`   | The `BFormInvalidFeedback` component that displays help when the date is invalid.
  */
 export default {
   name: 'DateSelector',
@@ -76,24 +71,10 @@ export default {
       default: false,
     },
     /**
-     * Text that appears below the date input when the date is valid.
-     */
-    validText: {
-      type: String,
-      default: 'Select date.',
-    },
-    /**
-     * Text that appears below the date input when the date is invalid.
-     */
-    invalidText: {
-      type: String,
-      default: 'Date selection is required.',
-    },
-    /**
-     * Whether to show the validity styling of the component elements.
+     * Whether validity styling should appear on input elements with invalid values.
      * This prop is watched by the component.
      */
-    showValidity: {
+    showInvalidStyling: {
       type: Boolean,
       default: false,
     },
@@ -108,7 +89,6 @@ export default {
   data() {
     return {
       chosenDate: this.date,
-      validate: this.showValidity,
     };
   },
   computed: {
@@ -120,16 +100,9 @@ export default {
         return true;
       }
     },
-    useValidityStyling() {
-      // Indicates if the component UI validity should be shown.
-      // 'null' if the entrypoint says not to showValidity
-      // `true` if the entrypoint says to showValidity and this component is valid.
-      // `false` otherwise.
-      if (!this.validate) {
-        return null;
-      } else {
-        return this.isValid;
-      }
+    // Controls component styling (i.e. when green check or red X and invalid feedback) should be displayed.
+    validationStyling() {
+      return uiUtil.validationStyling(this.isValid, this.showInvalidStyling);
     },
   },
   methods: {},
@@ -144,9 +117,6 @@ export default {
     date() {
       this.chosenDate = this.date;
     },
-    showValidity() {
-      this.validate = this.showValidity;
-    },
     isValid() {
       /**
        * The validity of the component has changed.
@@ -156,6 +126,9 @@ export default {
     },
   },
   created() {
+    // Emit the initial valid state of the component's value.
+    this.$emit('valid', this.isValid);
+
     /**
      * The component is ready for use.
      */

--- a/components/README.md
+++ b/components/README.md
@@ -140,31 +140,16 @@ Custom FarmData2 Vue Components.
 
       - i.e. check that changing each watched prop has the desired effect in the component.
 
-      ```JavaScript
-      it.only('Verify that `selected` prop is watched', () => {
-        const readySpy = cy.spy().as('readySpy');
-        const updateSpy = cy.spy().as('updateSpy');
-
-        cy.mount(CropSelector, {
-          props: {
-            onReady: readySpy,
-            'onUpdate:selected': updateSpy,
-            selected: null,
-          },
-        }).then(({ wrapper }) => {
-          cy.get('@readySpy').should('have.been.calledOnce').then(() => {
-            wrapper.setProps({ selected: 'ARUGULA' });
-            cy.get('@updateSpy').should('have.been.calledOnce');
-            cy.get('[data-cy="crop-select"]').should('have.value', 'ARUGULA');
-          });
-        });
-      });
-      ```
-
     - check that all other events are emitted properly
+
       - i.e. do something to cause the event and check that it is emitted properly and has the correct payload.
       - include all error events (including network errors) are emitted properly
         - i.e. Use `cy.intercept` to generate network errors on the appropriate route.
+
+    - Give or point to examples that illustrate structure for:
+
+      - waiting for `ready` before doing more.
+      - changing props.
 
   - check other behaviors (`*.behavior.comp.cy.js`)
 

--- a/components/README.md
+++ b/components/README.md
@@ -26,18 +26,18 @@ Custom FarmData2 Vue Components.
 
 - Each input element must have:
 
-  - `<BFormValidFeedback>`
   - `<BFormInvalidFeedback>`
-  - `v-bound to a prop`
+    - with its `state` prop `v-bound` to the `invalidStyling` prop
 
 - Elements must also have:
 - `id` must be set for each input element.
 - All testable elements in the component must have a `data-cy` attribute.
   - e.g. every input element must have a `data-cy` attribute.
+- their `state` prop `v-bound` to the `invalidStyling` prop
 - `BRow` and `BCol` can be used to create more complex layouts.
 - `BFormSelect` elements should begin with `{ value: null, text: '' }`.
   - to allow them to be blank when form is reset.
-- attributes on element should appear in the order:
+- attributes on component/element tags should appear in the order:
   - id
   - data-cy
   - classes, properties
@@ -53,7 +53,7 @@ Custom FarmData2 Vue Components.
 - elements of the script should be in the order:
 
   - name
-  - components
+  - components - may be empty as Bootstrap-Vue-Next components are automatically imported.
   - emits
   - props
   - data
@@ -66,30 +66,32 @@ Custom FarmData2 Vue Components.
   - Indicates that inputs are required field if present.
   - required fields are indicated by a red asterisk
 
-- All components must have a `validText` and `invalidText` props to indicate ARIA text below the field when teh value in the component is valid or invalid.
+- All components must have a `showInvalid` prop
 
-- All components must have a `showValidity` prop that indicates if the validity of components should be shown using the bootstrap styling.
+  - This prop is set by the entry point to indicates that bootstrap styling should be shown for invalid inputs.
+  - The component indicates the validity of inputs using its `isValid` computed property as described below.
+  - The validity styling is shown:
 
-  - The component computes validity as described below but only shows it when `show-validity` is set to true.
-  - This prop is watched and is set to true by the entry point when "Submit" is clicked.
+    - When `isValid` is true (regardless of the value of the `showInvalid` prop).
+    - When `isValid` is false and `showInvalid` is true.
+
+  - This prop should be is set by the entry point to
+    - `true` when "Submit" is clicked
+    - `false` when "Reset" is clicked
 
 - Components manage props, state and events to allow page to change state via the prop.
 
   - The component provides a `prop` for every value that is collected by the component
   - The component watches the `props` and the state variables that are `v-modeled` to input elements
-  - When a value that a component collects changes, the component emits an `updated:prop_name` event with a payload giving the new value of the prop.
-  - The entry point should `v-model` the prop to an element in `data.form`
+  - when a watched prop changes the component updates its state.
+  - When the state for a value that a component collects changes, the component emits an `updated:prop_name` event with a payload giving the new value of the prop.
+  - The entry point should `v-model` the prop to an element in its `data.form`
 
 - All events emitted must be kabob-case.
+
 - All components must emit a `ready` event when they are ready to be used in tests.
 
   - e.g. any API calls that were made in `created` have completed.
-
-- All components must emit a `valid` event any time their validity changes.
-
-  - This event will have a `boolean` payload indicating if the component's value is valid or not.
-  - Entry points will use this value to enable/disable submission.
-  - The component `watch`es the `isValid` computed property for changes and emits this event.
 
 - If an error occurs, the component must emit an `error` event with a `String` message as the payload.
 
@@ -102,8 +104,14 @@ Custom FarmData2 Vue Components.
   - is bound to `state` on `<BFormValidFeedback>` and `<BFormInvalidFeedback>`
   - watched and a `valid` event is emitted when validity changes.
 
-- Components will have a `useValidityStyling()` computed property
-  - uses `isValid` and `showValidity` to determine if the component should show its validity styling.
+- All components must emit a `valid` event any time their validity changes.
+
+  - This event will have a `boolean` payload indicating if the component's value is valid or not.
+  - The component `watch`es the `isValid` computed property for changes and emits this event.
+
+- Components have a `invalidStyling()` computed property
+  - uses `isValid` computed property and `showInvalid` prop to determine if the component should show its validity styling.
+  - provided by `uiUtil.invalidStyling` so that it is consistent across components.
 
 ## Component Testing
 

--- a/library/uiUtil/uiUtil.js
+++ b/library/uiUtil/uiUtil.js
@@ -46,20 +46,14 @@ export function showToast(title, message, placement, variant, duration) {
  *   - the red X when submit is clicked and the value is invalid.
  *
  * @param {boolean} isValid - the value of the `isValid` computed property in the component.
- * @param {boolean} showValidity - the value of the `showValidity`
+ * @param {boolean} showInvalidStyling - the value of the `showInvalidStyling` prop in the component.
  * @returns {*} `true`, `false`, or `null`. `true` indicates that valid styling should be applied. `false` indicates that invalid styling should be applied. `null` indicates that no styling should be applied.
  */
-export function validationStyling(isValid, showValidity) {
-  /*
-
-   *
-   * This computed property should not be edited.
-   * Use the `isValid` computed property to indicate when the values are valid.
-   */
+export function validationStyling(isValid, showInvalidStyling) {
   if (isValid) {
     return true;
   } else {
-    if (showValidity) {
+    if (showInvalidStyling) {
       return isValid;
     } else {
       return null;

--- a/library/uiUtil/uiUtil.js
+++ b/library/uiUtil/uiUtil.js
@@ -32,3 +32,37 @@ export function showToast(title, message, placement, variant, duration) {
     },
   });
 }
+
+/**
+ * Indicates if a component's styling should reflect the value of isValid.
+ *
+ * This function is called by the `showInvalidStyling` computed property
+ * in a components to control the styling.  It is defined here to ensure
+ * that it is consistent across all components.
+ *
+ * If the conventions defined in `components/README.md` and `modules/README.md`
+ * are followed this function ensures that:
+ *   - the green check anytime the value is valid.
+ *   - the red X when submit is clicked and the value is invalid.
+ *
+ * @param {boolean} isValid - the value of the `isValid` computed property in the component.
+ * @param {boolean} showValidity - the value of the `showValidity`
+ * @returns
+ */
+export function showInvalidStyling(isValid, showValidity) {
+  /*
+
+   *
+   * This computed property should not be edited.
+   * Use the `isValid` computed property to indicate when the values are valid.
+   */
+  if (isValid) {
+    return true;
+  } else {
+    if (showValidity) {
+      return isValid;
+    } else {
+      return null;
+    }
+  }
+}

--- a/library/uiUtil/uiUtil.js
+++ b/library/uiUtil/uiUtil.js
@@ -34,7 +34,7 @@ export function showToast(title, message, placement, variant, duration) {
 }
 
 /**
- * Indicates if a component's styling should reflect the value of isValid.
+ * Indicates when a component's styling should reflect the value of isValid.
  *
  * This function is called by the `showInvalidStyling` computed property
  * in a components to control the styling.  It is defined here to ensure
@@ -47,9 +47,9 @@ export function showToast(title, message, placement, variant, duration) {
  *
  * @param {boolean} isValid - the value of the `isValid` computed property in the component.
  * @param {boolean} showValidity - the value of the `showValidity`
- * @returns
+ * @returns {*} `true`, `false`, or `null`. `true` indicates that valid styling should be applied. `false` indicates that invalid styling should be applied. `null` indicates that no styling should be applied.
  */
-export function showInvalidStyling(isValid, showValidity) {
+export function validationStyling(isValid, showValidity) {
   /*
 
    *

--- a/library/uiUtil/uiUtil.showInvalidStyling.unit.cy.js
+++ b/library/uiUtil/uiUtil.showInvalidStyling.unit.cy.js
@@ -1,0 +1,14 @@
+import * as uiUtil from './uiUtil.js';
+
+describe('Test the showInvalidStyling function', () => {
+  it('Test ', () => {
+    // valid value, show invalid styling.
+    expect(uiUtil.showInvalidStyling(true, true)).to.be.true;
+    // valid value, don't show invalid styling.
+    expect(uiUtil.showInvalidStyling(true, false)).to.be.true;
+    // invalid value, show invalid styling.
+    expect(uiUtil.showInvalidStyling(false, true)).to.be.false;
+    // invalid value, don't show invalid styling.
+    expect(uiUtil.showInvalidStyling(false, false)).to.be.null;
+  });
+});

--- a/library/uiUtil/uiUtil.showInvalidStyling.unit.cy.js
+++ b/library/uiUtil/uiUtil.showInvalidStyling.unit.cy.js
@@ -3,12 +3,12 @@ import * as uiUtil from './uiUtil.js';
 describe('Test the showInvalidStyling function', () => {
   it('Test ', () => {
     // valid value, show invalid styling.
-    expect(uiUtil.showInvalidStyling(true, true)).to.be.true;
+    expect(uiUtil.validationStyling(true, true)).to.be.true;
     // valid value, don't show invalid styling.
-    expect(uiUtil.showInvalidStyling(true, false)).to.be.true;
+    expect(uiUtil.validationStyling(true, false)).to.be.true;
     // invalid value, show invalid styling.
-    expect(uiUtil.showInvalidStyling(false, true)).to.be.false;
+    expect(uiUtil.validationStyling(false, true)).to.be.false;
     // invalid value, don't show invalid styling.
-    expect(uiUtil.showInvalidStyling(false, false)).to.be.null;
+    expect(uiUtil.validationStyling(false, false)).to.be.null;
   });
 });


### PR DESCRIPTION
**Pull Request Description**

Updates the behavior of components so that:
  - Valid inputs are always marked with a green check
  - Invalid inputs are only marked with a red x when the entry point sets the `showInvalidStyling` prop.
  - The `showInvalidStyling` prop also controls the display of the `<BFormInvalidFeedback> element.

Factors this behavior out into a library function in `uiUtil.js` so that it is common to all modules.

Updates the templates for new components.

---

**Licensing Certification**

FarmData2 is a [Free Cultural Work](https://freedomdefined.org/Definition) and all accepted contributions are licensed as described in the LICENSE.md file. This requires that the contributor holds the rights to do so. By submitting this pull request **I certify that I satisfy the terms of the [Developer Certificate of Origin](https://developercertificate.org/)** for its contents.
