### PR TITLE
build: updates entrypoints to include entry_point_name.html files

### DIFF
--- a/.fd2-cspell.txt
+++ b/.fd2-cspell.txt
@@ -24,9 +24,12 @@ linkcheck
 lintstagedrc
 localstorage
 mfinelli
+Michal
 mryhryki
 novnc
 pgid
+pietmichal
+Pietraszko
 pinia
 preprocess
 readlink

--- a/bin/addEntrypoint.bash
+++ b/bin/addEntrypoint.bash
@@ -164,6 +164,7 @@ echo ""
 
 # Make the directory for the entrypoint and populate it with the template files.
 mkdir "$ENTRY_POINT_SRC_DIR"
+error_check "Failed to create directory $ENTRY_POINT_SRC_DIR."
 echo "Created entry point directory '$ENTRY_POINT_SRC_DIR"
 
 cp "$ENTRY_POINT_TEMPLATE_DIR/App.vue" "$ENTRY_POINT_SRC_DIR"
@@ -180,6 +181,9 @@ cp "$ENTRY_POINT_TEMPLATE_DIR/index.html" "$ENTRY_POINT_SRC_DIR/index.html"
 sed -i "s/%ENTRY_POINT_TITLE%/$ENTRY_POINT_TITLE/g" "$ENTRY_POINT_SRC_DIR/index.html"
 sed -i "s/%ENTRY_POINT%/$ENTRY_POINT/g" "$ENTRY_POINT_SRC_DIR/index.html"
 echo "  Added $ENTRY_POINT_SRC_DIR/index.html from templates."
+
+cp "$ENTRY_POINT_SRC_DIR/index.html" "$ENTRY_POINT_SRC_DIR/$ENTRY_POINT.html"
+echo "  Copied $ENTRY_POINT_SRC_DIR/index.html as $ENTRY_POINT_SRC_DIR/$ENTRY_POINT.html."
 
 cp "$ENTRY_POINT_TEMPLATE_DIR/entry_point.js" "$ENTRY_POINT_SRC_DIR/$ENTRY_POINT.js"
 echo "  Added $ENTRY_POINT_SRC_DIR/$ENTRY_POINT.js from templates."

--- a/bin/test.bash
+++ b/bin/test.bash
@@ -156,12 +156,14 @@ if [ -n "$E2E_TESTS" ]; then
     URL_PREFIX="fd2_school"
   fi
 else
-  CYPRESS_TEST_TYPE="component"
-  CYPRESS_PROJECT="modules/farm_fd2"
   if [ -n "$COMPONENT_TESTS" ]; then
     echo "Component testing requested."
+    CYPRESS_PROJECT="modules/farm_fd2"
+    CYPRESS_TEST_TYPE="component"
   else
     echo "Unit testing requested."
+    CYPRESS_PROJECT="library"
+    CYPRESS_TEST_TYPE="e2e"
   fi
 fi
 

--- a/modules/README.md
+++ b/modules/README.md
@@ -52,3 +52,260 @@ Inside each of the above module directories there are the following directories 
 ## Testing
 
 - use bin/test.bash
+
+- use watch:fd2 by default and just run in live farmOS.
+  - point to another document that discusses the use of the dev and preview servers.
+
+## Entry point structure
+
+- Main container is a Bootstrap-Vue-Next [_BCard_](https://bootstrap-vue-next.github.io/bootstrap-vue-next/docs/components/card)
+
+- BOIL THIS DOWN TO A MINIMAL EXAMPLE...
+
+```JavaScript
+<script setup>
+import dayjs from 'dayjs';
+import CropSelector from '@comps/CropSelector/CropSelector.vue';
+import * as uiUtil from '@libs/uiUtil/uiUtil.js';
+</script>
+
+<template>
+  <BToaster />
+  <BCard
+    bg-variant="light"
+    header-tag="header"
+  >
+    <template #header>
+      <h2 class="text-center">Tray Seeding</h2>
+    </template>
+
+    <BForm
+      @submit="submit"
+      @reset="reset"
+    >
+      <!-- Seeding Date -->
+      <BFormGroup
+        id="ts-date-group"
+        label-for="ts-date"
+        label-cols="auto"
+        label-align="end"
+        content-cols="auto"
+      >
+        <template v-slot:label>Date:<sup class="text-danger">*</sup> </template>
+        <BFormInput
+          id="ts-date"
+          data-cy="ts-date"
+          type="date"
+          v-model="form.seedingDate"
+          aria-describedby="date-help"
+          required
+        />
+        <BFormText id="date-help">Date seeding occurred.</BFormText>
+      </BFormGroup>
+
+      <!-- Crop Selection -->
+      <CropSelector
+        required
+        helpText="Select seeded crop."
+        v-model:selected="form.crop"
+        v-on:ready="createdCount++"
+        v-on:error="
+          (msg) =>
+            uiUtil.showToast('Network Error', msg, 'top-center', 'danger', 5)
+        "
+      />
+
+      <!-- Submit and Reset Buttons -->
+
+      <!-- TODO: MAKE SO CAN'T SUBMIT AGAIN UNTIL A CHANGE HAS BEEN MADE -->
+      <!-- POSSIBLY JUST CLEAR THE LOCATION OR THE CROP? -->
+      <BRow>
+        <BCol cols="8">
+          <BButton
+            type="Create"
+            class="form-control"
+            variant="primary"
+            >Submit</BButton
+          >
+        </BCol>
+        <BCol cols="4">
+          <BButton
+            type="Reset"
+            class="form-control"
+            variant="danger"
+            >Reset</BButton
+          >
+        </BCol>
+      </BRow>
+    </BForm>
+  </BCard>
+
+  <div
+    data-cy="page-loaded"
+    v-show="false"
+  >
+    {{ pageDoneLoading }}
+  </div>
+</template>
+
+<script>
+export default {
+  data() {
+    return {
+      form: {
+        seedingDate: dayjs().format('YYYY-MM-DD'),
+        crop: null,
+      },
+      createdCount: 0,
+    };
+  },
+  methods: {
+    submit() {
+      console.log(this.form);
+    },
+    reset() {
+      this.seedingDate = dayjs().format('YYYY-MM-DD');
+      this.form.crop = null;
+    },
+  },
+  computed: {
+    pageDoneLoading() {
+      return this.createdCount == 2;
+    },
+  },
+  created() {
+    this.createdCount++;
+  },
+};
+</script>
+```
+
+Every entry point has a `<BToaster />` element as its first element.
+
+- The `BToaster` allows alert/info/success/error messages to be displayed.
+
+  - Every FarmData2 component emits an `error` event with a message when an error occurs.
+  - The entrypoint then must have an `on-error` handler that displays the Toast.
+
+```JavaScript
+v-on:error="(msg) => showToast('Network Error', msg, 'top-center', 'danger')"
+```
+
+- Values for placement and variant should be documented by pointing to the Bootstrap-Vue-Next documentation
+
+- Every entry point will import the `showToast` function from the `uiUtil` module
+
+- All components are contained in a Bootstrap-Vue-Next [_Form_](https://bootstrap-vue-next.github.io/bootstrap-vue-next/docs/components/form) element.
+
+  - Ideally all components will be FarmData2 components that wrap the Bootstrap-Vue-Next components to simplify their use in FD2.
+
+- Every entry point contains some essential code that facilitates testing.
+
+Every entry point has a data element with at least a `form`, a `validity` and a `createdCount` element:
+
+- form contains values for each form element and are v-modeled to props.
+- `validity` contains the validity of each form element and are set by `valid` event handlers.
+  - all should be `null` to start.
+  - used to determine if the form can be submitted.
+  - also contains a `show` attribute bound to the `show-validity` prop
+    - set to true to have component styled to show validity.
+- createdCount is used to track when the entry point is ready to be used in tests.
+
+```JavaScript
+data() {
+  return {
+    form: {
+      ...,
+    },
+    validity: {
+      show: false,
+      ...
+    }
+    createdCount: 0,
+  };
+},
+```
+
+The form will have an `isValid()` computed property that uses the `validity` values to set the `show-validity` prop of all of the components and to enable/disable the submit button.
+
+Every API call made in created must increment `createdCount` when finished.
+
+```JavaScript
+created() {
+
+  // once promise from API call resolves...
+  this.createdCount++;
+},
+```
+
+Every FarmData2 component emits a `ready` event when it is ready to be used in tests.
+
+- Every component used must have a `v-on` handler for this event.
+
+  - This handler increments the `createdCount`.
+
+- Props that the entry point uses to affect the component state should be `v-model`ed to the data in `data.form`
+
+```JavaScript
+<CropSelector
+  required
+  helpText="Select seeded crop."
+  v-model:selected="form.crop"
+  v-on:ready="createdCount++"
+  v-on:error="
+    (msg) =>
+      uiUtil.showToast('Network Error', msg, 'top-center', 'danger', 5)
+  "
+/>
+```
+
+Every entry point has a computed property that indicates when all API calls and components are ready.
+
+```JavaScript
+pageDoneLoading() {
+  return this.createdCount == 2;
+},
+```
+
+Every entry point template ends with the following `<div>` that uses the `pageDoneLoading()` property to indicate that the page is ready for testing.
+
+```JavaScript
+  <div
+    data-cy="page-loaded"
+    v-show="false"
+  >
+    { pageDoneLoading }}
+  </div>
+```
+
+Cypress tests use `cy.waitForPage()` to wait for the entry point to fully load before running tests.
+
+```JavaScript
+describe('Sample test.', () => {
+  it('Sample test.', () => {
+    // Login if running in live farmOS.
+    cy.login('admin', 'admin');
+    // Go to the desired entry point.
+    cy.visit('fd2/tray_seeding/');
+    // Wait for everything to be ready before testing.
+    cy.waitForPage();
+
+    // Entry point is now fully loaded...
+  });
+});
+```
+
+- Include the following CSS in an entrypoint to optimize the entry point for mobile. This hides and reduces the space required for some of the farmOS UI elements. It reduces margins and borders to increase screen real estate.
+
+```CSS
+<style>
+@import url('@css/fd2-mobile.css');
+</style>
+```
+
+## Technical Build Details
+
+- both an entry_point.html and an index.html
+  - identical.
+  - entry_point.html allows vite to put css for SPC in its on dir.
+  - index.html allows us to access page using the same url on the dev/prev server as in farmOS.

--- a/modules/cypress.config.js
+++ b/modules/cypress.config.js
@@ -12,6 +12,7 @@ module.exports = defineConfig({
   screenshotOnRunFailure: false,
   video: false,
   trashAssetsBeforeRuns: true,
+  chromeWebSecurity: false,
   e2e: {
     specPattern: 'src/entrypoints/**/*.cy.js',
   },

--- a/modules/cypress/support/commands.js
+++ b/modules/cypress/support/commands.js
@@ -85,3 +85,40 @@ Cypress.Commands.add('login', (user, password) => {
 Cypress.Commands.add('waitForPage', () => {
   cy.get('[data-cy=page-loaded]').should('have.text', 'true');
 });
+
+/**
+ * Cypress clears the local and session storage between tests.  This work around
+ * can be used to copy the local or session storage at the end of each test
+ * (i.e. in an afterEach) and then restore it at the start of the
+ * the next test (i.e. in a beforeEach).
+ *
+ * This work around was created by Michal Pietraszko (pietmichal on GitHub):
+ * https://github.com/cypress-io/cypress/issues/461#issuecomment-392070888
+ */
+let LOCAL_STORAGE_MEMORY = {};
+
+Cypress.Commands.add('saveLocalStorage', () => {
+  Object.keys(localStorage).forEach((key) => {
+    LOCAL_STORAGE_MEMORY[key] = localStorage[key];
+  });
+});
+
+Cypress.Commands.add('restoreLocalStorage', () => {
+  Object.keys(LOCAL_STORAGE_MEMORY).forEach((key) => {
+    localStorage.setItem(key, LOCAL_STORAGE_MEMORY[key]);
+  });
+});
+
+let SESSION_STORAGE_MEMORY = {};
+
+Cypress.Commands.add('saveSessionStorage', () => {
+  Object.keys(sessionStorage).forEach((key) => {
+    SESSION_STORAGE_MEMORY[key] = sessionStorage[key];
+  });
+});
+
+Cypress.Commands.add('restoreSessionStorage', () => {
+  Object.keys(SESSION_STORAGE_MEMORY).forEach((key) => {
+    sessionStorage.setItem(key, SESSION_STORAGE_MEMORY[key]);
+  });
+});

--- a/modules/cypress/support/component.js
+++ b/modules/cypress/support/component.js
@@ -26,3 +26,7 @@ Cypress.Commands.add('mount', mount);
 
 // Example use:
 // cy.mount(MyComponent)
+
+// Import the bootstrap Vue CSS files
+import 'bootstrap/dist/css/bootstrap.css';
+import 'bootstrap-vue-next/dist/bootstrap-vue-next.css';

--- a/modules/farm_fd2/src/entrypoints/main/main.html
+++ b/modules/farm_fd2/src/entrypoints/main/main.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <link
+      rel="icon"
+      href="/favicon.ico"
+    />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1.0"
+    />
+    <title>FD2 Main Module</title>
+  </head>
+  <body>
+    <div id="app"></div>
+    <script
+      type="module"
+      src="/main/main.js"
+    ></script>
+  </body>
+</html>

--- a/modules/farm_fd2/vite.config.js
+++ b/modules/farm_fd2/vite.config.js
@@ -1,5 +1,4 @@
 import { fileURLToPath, URL } from 'node:url';
-import path from 'node:path';
 import glob from 'glob';
 import { defineConfig } from 'vite';
 import { viteStaticCopy } from 'vite-plugin-static-copy';
@@ -39,20 +38,17 @@ let viteConfig = {
       // the live farmos server shows the most recent content.
       name: 'afterBuild',
       closeBundle: async () => {
-        await exec(
-          'docker exec fd2_farmos drush cr',
-          (error, stderr, stdout) => {
-            if (error) {
-              console.error(`error:  ${error.message}`);
-              return;
-            }
-            if (stderr) {
-              console.error(`stderr: ${stderr}`);
-              return;
-            }
-            console.log(`Rebuilding drupal cache...\n  ${stdout}`);
+        exec('docker exec fd2_farmos drush cr', (error, stderr, stdout) => {
+          if (error) {
+            console.error(`error:  ${error.message}`);
+            return;
           }
-        );
+          if (stderr) {
+            console.error(`stderr: ${stderr}`);
+            return;
+          }
+          console.log(`Rebuilding drupal cache...\n  ${stdout}`);
+        });
       },
     },
   ],
@@ -62,17 +58,23 @@ let viteConfig = {
     exclude: ['**/*.cy.js', '**/*.cy.comp.js', '**/*.cy.unit.js'],
     rollupOptions: {
       input: Object.fromEntries(
-        glob
-          .sync('modules/farm_fd2/src/entrypoints/*')
-          .map((dir) => [path.basename(dir), dir + '/index.html'])
+        glob.sync('modules/farm_fd2/src/entrypoints/*/*.html').map((dir) => {
+          let key = dir.split('/').at(-2) + '/' + dir.split('/').at(-1);
+          return [key, dir];
+        })
       ),
       output: {
         // Ensures that the entry point and css names are not hashed.
         entryFileNames: '[name]/[name].js',
         assetFileNames: (assetInfo) => {
+          let name = assetInfo.name.split('/').at(0);
           let ext = assetInfo.name.split('.').at(1);
           if (ext === 'css') {
-            return 'shared/[name].css';
+            if (name.startsWith('_plugin-vue_')) {
+              return 'shared/index.css';
+            } else {
+              return '[name]/[name].css';
+            }
           } else {
             return 'shared/[name].[ext]';
           }
@@ -85,7 +87,8 @@ let viteConfig = {
     alias: {
       '@': fileURLToPath(new URL('./src/', import.meta.url)),
       '@comps': fileURLToPath(new URL('../../components/', import.meta.url)),
-      '@libs': fileURLToPath(new URL('../../libraries/', import.meta.url)),
+      '@libs': fileURLToPath(new URL('../../library/', import.meta.url)),
+      '@css': fileURLToPath(new URL('../css/', import.meta.url)),
     },
   },
 };

--- a/modules/farm_fd2_examples/src/entrypoints/main/main.html
+++ b/modules/farm_fd2_examples/src/entrypoints/main/main.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <link
+      rel="icon"
+      href="/favicon.ico"
+    />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1.0"
+    />
+    <title>FarmData2 Examples Module</title>
+  </head>
+  <body>
+    <div id="app"></div>
+    <script
+      type="module"
+      src="/main/main.js"
+    ></script>
+  </body>
+</html>

--- a/modules/farm_fd2_examples/vite.config.js
+++ b/modules/farm_fd2_examples/vite.config.js
@@ -1,5 +1,4 @@
 import { fileURLToPath, URL } from 'node:url';
-import path from 'node:path';
 import glob from 'glob';
 import { defineConfig } from 'vite';
 import { viteStaticCopy } from 'vite-plugin-static-copy';
@@ -59,16 +58,24 @@ let viteConfig = {
     rollupOptions: {
       input: Object.fromEntries(
         glob
-          .sync('modules/farm_fd2_examples/src/entrypoints/*')
-          .map((dir) => [path.basename(dir), dir + '/index.html'])
+          .sync('modules/farm_fd2_examples/src/entrypoints/*/*.html')
+          .map((dir) => {
+            let key = dir.split('/').at(-2) + '/' + dir.split('/').at(-1);
+            return [key, dir];
+          })
       ),
       output: {
         // Ensures that the entry point and css names are not hashed.
         entryFileNames: '[name]/[name].js',
         assetFileNames: (assetInfo) => {
+          let name = assetInfo.name.split('/').at(0);
           let ext = assetInfo.name.split('.').at(1);
           if (ext === 'css') {
-            return 'shared/[name].css';
+            if (name.startsWith('_plugin-vue_')) {
+              return 'shared/index.css';
+            } else {
+              return '[name]/[name].css';
+            }
           } else {
             return 'shared/[name].[ext]';
           }
@@ -81,7 +88,8 @@ let viteConfig = {
     alias: {
       '@': fileURLToPath(new URL('./src/', import.meta.url)),
       '@comps': fileURLToPath(new URL('../../components/', import.meta.url)),
-      '@libs': fileURLToPath(new URL('../../libraries/', import.meta.url)),
+      '@libs': fileURLToPath(new URL('../../library/', import.meta.url)),
+      '@css': fileURLToPath(new URL('../css/', import.meta.url)),
     },
   },
 };

--- a/modules/farm_fd2_school/src/entrypoints/main/main.html
+++ b/modules/farm_fd2_school/src/entrypoints/main/main.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <link
+      rel="icon"
+      href="/favicon.ico"
+    />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1.0"
+    />
+    <title>FarmData2 School Module</title>
+  </head>
+  <body>
+    <div id="app"></div>
+    <script
+      type="module"
+      src="/main/main.js"
+    ></script>
+  </body>
+</html>

--- a/modules/farm_fd2_school/vite.config.js
+++ b/modules/farm_fd2_school/vite.config.js
@@ -1,5 +1,4 @@
 import { fileURLToPath, URL } from 'node:url';
-import path from 'node:path';
 import glob from 'glob';
 import { defineConfig } from 'vite';
 import { viteStaticCopy } from 'vite-plugin-static-copy';
@@ -59,16 +58,24 @@ let viteConfig = {
     rollupOptions: {
       input: Object.fromEntries(
         glob
-          .sync('modules/farm_fd2_school/src/entrypoints/*')
-          .map((dir) => [path.basename(dir), dir + '/index.html'])
+          .sync('modules/farm_fd2_school/src/entrypoints/*/*.html')
+          .map((dir) => {
+            let key = dir.split('/').at(-2) + '/' + dir.split('/').at(-1);
+            return [key, dir];
+          })
       ),
       output: {
         // Ensures that the entry point and css names are not hashed.
         entryFileNames: '[name]/[name].js',
         assetFileNames: (assetInfo) => {
+          let name = assetInfo.name.split('/').at(0);
           let ext = assetInfo.name.split('.').at(1);
           if (ext === 'css') {
-            return 'shared/[name].css';
+            if (name.startsWith('_plugin-vue_')) {
+              return 'shared/index.css';
+            } else {
+              return '[name]/[name].css';
+            }
           } else {
             return 'shared/[name].[ext]';
           }
@@ -81,7 +88,8 @@ let viteConfig = {
     alias: {
       '@': fileURLToPath(new URL('./src/', import.meta.url)),
       '@comps': fileURLToPath(new URL('../../components/', import.meta.url)),
-      '@libs': fileURLToPath(new URL('../../libraries/', import.meta.url)),
+      '@libs': fileURLToPath(new URL('../../library/', import.meta.url)),
+      '@css': fileURLToPath(new URL('../css/', import.meta.url)),
     },
   },
 };


### PR DESCRIPTION
**Pull Request Description**

Each entry point only `index.html` as the file being served. This PR adds `entry_point_name.html` as a copy of `index.html` to the built module and reconfigures the vite configuration so that each built entry point contains both an `index.html` and an `entry_point_name.html` (which are identical).  This was done because vite uses the `entry_point_name.html` file to figure out what is to be included in the built entry point, but the dev environment serves the `index.html` file.  Having both was a convenient way to make this all work.

---

**Licensing Certification**

FarmData2 is a [Free Cultural Work](https://freedomdefined.org/Definition) and all accepted contributions are licensed as described in the LICENSE.md file. This requires that the contributor holds the rights to do so. By submitting this pull request **I certify that I satisfy the terms of the [Developer Certificate of Origin](https://developercertificate.org/)** for its contents.
