### PR TITLE
feat(docs): adds script for generating the library and component docs

### DIFF
--- a/.fd2-cspell.txt
+++ b/.fd2-cspell.txt
@@ -19,6 +19,7 @@ farmos
 getopt
 gids
 isready
+jsdoc
 jsdocrc
 linkcheck
 lintstagedrc

--- a/bin/makeDocs.bash
+++ b/bin/makeDocs.bash
@@ -1,0 +1,120 @@
+#!/bin/bash
+
+source colors.bash
+source lib.bash
+
+PWD="$(pwd)"
+
+# Get the path to the main repo directory.
+SCRIPT_PATH=$(readlink -f "$0")                     # Path to this script.
+SCRIPT_DIR=$(dirname "$SCRIPT_PATH")                # Path to directory containing this script.
+REPO_ROOT_DIR=$(builtin cd "$SCRIPT_DIR/.." && pwd) # REPO root directory.
+
+echo -e "${GREEN}Generating FarmData2 documentation.${NO_COLOR}."
+
+echo "  Deleting old docs..."
+rm -rf docs/components 2 &> /dev/null
+mkdir docs/components
+rm -rf docs/library 2 &> /dev/null
+mkdir docs/library
+echo "  Deleted."
+
+echo "  Creating index file: $INDEX_FILE..."
+INDEX_FILE="FarmData2.md"
+INDEX_PATH="$REPO_ROOT_DIR/docs/$INDEX_FILE" # Absolute path.
+echo "# FarmData2 Documentation" > "$INDEX_PATH"
+echo "" >> "$INDEX_PATH"
+echo "  Created."
+
+echo "  Generating docs for all Components..."
+echo "    Adding Components section to $INDEX_FILE..."
+echo "## Components" >> "$INDEX_PATH"
+echo "" >> "$INDEX_PATH"
+echo "    Added."
+
+safe_cd "$REPO_ROOT_DIR/components"
+DIRS=$(ls -d ./*/)
+safe_cd "$REPO_ROOT_DIR"
+
+for DIR in $DIRS; do                     # Names of the components with a trailing /
+  COMP_NAME=$(echo "$DIR" | cut -d/ -f1) # Only the name of the component
+  COMP_VUE_PATH="components/$COMP_NAME/$COMP_NAME.vue"
+  COMP_MD_FILE="$COMP_NAME.md"
+  DOCS_DIR="docs"
+
+  echo "    Generating docs for $COMP_NAME..."
+  echo "      Creating docs for $COMP_NAME..."
+  # vue-docgen expects paths relative to components directory.
+  npx vue-docgen "$COMP_VUE_PATH" "$DOCS_DIR"
+  # Get rid of the extra directory layer that we don't need.
+  mv "$DOCS_DIR/components/$COMP_NAME/$COMP_MD_FILE" "$DOCS_DIR/components/$COMP_MD_FILE"
+  rmdir "$DOCS_DIR/components/$COMP_NAME"
+  echo "      Created."
+
+  echo "      Adding link for $COMP_MD_FILE to $INDEX_FILE..."
+  DESC_TEXT=$(grep -m 1 -A 1 "/\*\*" "$COMP_VUE_PATH" | tail -1 | cut -d' ' -f3-)
+  COMP_MD_LINK="components/$COMP_MD_FILE" # Link is relative to docs.
+  echo "- [$COMP_NAME]($COMP_MD_LINK) - $DESC_TEXT" >> "$INDEX_PATH"
+  echo "      Added."
+
+  echo "      Adding back links from $COMP_MD_FILE to $INDEX_FILE..."
+  TMP_PATH="docs/components/$COMP_NAME.tmp"
+  echo "[[FarmData2 Documentation]](../$INDEX_FILE)" > "$TMP_PATH"
+  # shellcheck disable=SC2129
+  echo "" >> "$TMP_PATH"
+  cat "docs/components/$COMP_MD_FILE" >> "$TMP_PATH"
+  echo "" >> "$TMP_PATH"
+  echo "[[FarmData2 Documentation]](../$INDEX_FILE)" >> "$TMP_PATH"
+  mv -f "$TMP_PATH" "docs/components/$COMP_MD_FILE"
+  echo "      Added."
+  echo "    Generated."
+done
+echo "  Generated."
+
+echo "  Generating docs for all libraries..."
+
+echo "    Adding Library section to $INDEX_FILE..."
+echo "## Library" >> "$INDEX_PATH"
+echo "" >> "$INDEX_PATH"
+echo "    Added."
+
+safe_cd "$REPO_ROOT_DIR/library"
+LIBS=$(ls -d ./*/)
+safe_cd "$REPO_ROOT_DIR"
+
+for LIB in $LIBS; do                      # Names of the libraries with a trailing /
+  if [ "$LIB" != "cypress/" ]; then       # skip the cypress directory
+    LIB_NAME=$(echo "$LIB" | cut -d/ -f1) # Only the name of the library
+    LIB_JS_PATH="library/$LIB_NAME/$LIB_NAME.js"
+    LIB_MD_FILE="$LIB_NAME.md"
+    LIB_MD_PATH="docs/library/$LIB_MD_FILE"
+    DOCS_DIR="docs"
+
+    echo "      Generating docs for $LIB_NAME..."
+    echo "        Creating docs for $LIB_NAME..."
+    npx jsdoc2md "$LIB_JS_PATH" > "$LIB_MD_PATH"
+    echo "        Created."
+
+    echo "      Adding link for $LIB_MD_FILE to $INDEX_FILE..."
+    DESC_TEXT=$(grep "@description" "$LIB_JS_PATH" | cut -d' ' -f4-)
+    LIB_MD_LINK="library/$LIB_MD_FILE" # Link is relative to docs.
+    echo "- [$LIB_NAME]($LIB_MD_LINK) - $DESC_TEXT" >> "$INDEX_PATH"
+    echo "      Added."
+
+    echo "      Adding back links from $LIB_MD_FILE to $INDEX_FILE..."
+    TMP_PATH="docs/library/$LIB_NAME.tmp"
+    echo "[[FarmData2 Documentation]](../$INDEX_FILE)" > "$TMP_PATH"
+    # shellcheck disable=SC2129
+    echo "" >> "$TMP_PATH"
+    cat "docs/library/$LIB_MD_FILE" >> "$TMP_PATH"
+    echo "" >> "$TMP_PATH"
+    echo "[[FarmData2 Documentation]](../$INDEX_FILE)" >> "$TMP_PATH"
+    mv -f "$TMP_PATH" "docs/library/$LIB_MD_FILE"
+    echo "      Added."
+
+    echo "    Generated."
+  fi
+done
+echo "  Generated."
+
+echo -e "${GREEN}Done.${NO_COLOR}"

--- a/bin/makeDocs.bash
+++ b/bin/makeDocs.bash
@@ -33,7 +33,7 @@ echo "" >> "$INDEX_PATH"
 echo "    Added."
 
 safe_cd "$REPO_ROOT_DIR/components"
-DIRS=$(ls -d ./*/)
+DIRS=$(ls -d -- */)
 safe_cd "$REPO_ROOT_DIR"
 
 for DIR in $DIRS; do                     # Names of the components with a trailing /
@@ -79,7 +79,7 @@ echo "" >> "$INDEX_PATH"
 echo "    Added."
 
 safe_cd "$REPO_ROOT_DIR/library"
-LIBS=$(ls -d ./*/)
+LIBS=$(ls -d -- */)
 safe_cd "$REPO_ROOT_DIR"
 
 for LIB in $LIBS; do                      # Names of the libraries with a trailing /


### PR DESCRIPTION
**Pull Request Description**

Adds the `bin/makeDocs.bash` script that uses `jsdoc2md` and `vue-docgen` and some custom scripting to generate documentation for the `components` and `libraries`.  The docs are generated with the `npm run docs:gen` command. The docs are placed into the `docs` folder when generated. The docs are viewed with the `npm run docs:view` command, which opens a browser window and renders the markdown.

---

**Licensing Certification**

FarmData2 is a [Free Cultural Work](https://freedomdefined.org/Definition) and all accepted contributions are licensed as described in the LICENSE.md file. This requires that the contributor holds the rights to do so. By submitting this pull request **I certify that I satisfy the terms of the [Developer Certificate of Origin](https://developercertificate.org/)** for its contents.
