### PR TITLE
feat(comps): adds the LocationSelector component

### DIFF
--- a/components/LocationSelector/LocationSelector.behavior.comp.cy.js
+++ b/components/LocationSelector/LocationSelector.behavior.comp.cy.js
@@ -1,0 +1,73 @@
+import LocationSelector from '@comps/LocationSelector/LocationSelector.vue';
+
+describe('Test the LocationSelector component behavior', () => {
+  beforeEach(() => {
+    cy.restoreLocalStorage();
+    cy.restoreSessionStorage();
+  });
+
+  afterEach(() => {
+    cy.saveLocalStorage();
+    cy.saveSessionStorage();
+  });
+
+  it('Test that selected prop is reactive', () => {
+    const readySpy = cy.spy().as('readySpy');
+
+    cy.mount(LocationSelector, {
+      props: {
+        includeGreenhouses: true,
+        onReady: readySpy,
+        selected: 'CHUAU',
+      },
+    }).then(({ wrapper }) => {
+      cy.get('@readySpy')
+        .should('have.been.calledOnce')
+        .then(() => {
+          cy.get('[data-cy="selector-input"]').should('have.value', 'CHUAU');
+          wrapper.setProps({ selected: 'JASMINE' });
+          cy.get('[data-cy="selector-input"]').should('have.value', 'JASMINE');
+        });
+    });
+  });
+
+  it('Test that showValidityStyling prop is reactive', () => {
+    const readySpy = cy.spy().as('readySpy');
+
+    cy.mount(LocationSelector, {
+      props: {
+        required: true,
+        includeGreenhouses: true,
+        onReady: readySpy,
+      },
+    }).then(({ wrapper }) => {
+      cy.get('@readySpy')
+        .should('have.been.calledOnce')
+        .then(() => {
+          cy.get('[data-cy="selector-input"]').should(
+            'not.have.class',
+            'is-valid'
+          );
+          cy.get('[data-cy="selector-input"]').should(
+            'not.have.class',
+            'is-invalid'
+          );
+          cy.get('[data-cy="selector-invalid-feedback"]').should(
+            'not.be.visible'
+          );
+
+          wrapper.setProps({ showValidityStyling: true });
+
+          cy.get('[data-cy="selector-input"]').should(
+            'not.have.class',
+            'is-valid'
+          );
+          cy.get('[data-cy="selector-input"]').should(
+            'have.class',
+            'is-invalid'
+          );
+          cy.get('[data-cy="selector-invalid-feedback"]').should('be.visible');
+        });
+    });
+  });
+});

--- a/components/LocationSelector/LocationSelector.content.comp.cy.js
+++ b/components/LocationSelector/LocationSelector.content.comp.cy.js
@@ -1,0 +1,195 @@
+import LocationSelector from '@comps/LocationSelector/LocationSelector.vue';
+
+describe('Test the default LocationSelector content', () => {
+  beforeEach(() => {
+    cy.restoreLocalStorage();
+    cy.restoreSessionStorage();
+  });
+
+  afterEach(() => {
+    cy.saveLocalStorage();
+    cy.saveSessionStorage();
+  });
+
+  it('Check for the SelectorBase element', () => {
+    const readySpy = cy.spy().as('readySpy');
+
+    cy.mount(LocationSelector, {
+      props: {
+        onReady: readySpy,
+      },
+    });
+
+    cy.get('@readySpy')
+      .should('have.been.calledOnce')
+      .then(() => {
+        cy.get('[data-cy="location-selector"]').should('exist');
+      });
+  });
+
+  it('Check that required prop is false by default', () => {
+    const readySpy = cy.spy().as('readySpy');
+
+    cy.mount(LocationSelector, {
+      props: {
+        onReady: readySpy,
+      },
+    });
+
+    cy.get('@readySpy')
+      .should('have.been.calledOnce')
+      .then(() => {
+        cy.get('[data-cy="selector-required"]').should('not.exist');
+      });
+  });
+
+  it('Check that props are passed through to the SelectorBase', () => {
+    const readySpy = cy.spy().as('readySpy');
+
+    cy.mount(LocationSelector, {
+      props: {
+        required: true,
+        onReady: readySpy,
+      },
+    });
+
+    cy.get('@readySpy')
+      .should('have.been.calledOnce')
+      .then(() => {
+        cy.get('[data-cy="selector-label"]').should('have.text', 'Location:');
+        cy.get('[data-cy="selector-required"]').should('have.text', '*');
+        cy.get('[data-cy="selector-invalid-feedback"]').should(
+          'contain.text',
+          'A location is required'
+        );
+      });
+  });
+
+  it('Test add url for greenhouses', () => {
+    const readySpy = cy.spy().as('readySpy');
+
+    cy.mount(LocationSelector, {
+      props: {
+        includeGreenhouses: true,
+        onReady: readySpy,
+      },
+    });
+
+    cy.get('@readySpy')
+      .should('have.been.calledOnce')
+      .then(() => {
+        cy.get('[data-cy="location-selector"]').should('exist');
+
+        cy.get('[data-cy="selector-add-button"]')
+          .should('have.attr', 'href')
+          .then((href) => href)
+          .should('eq', '/asset/add/structure');
+      });
+  });
+
+  it('Test add url for fields', () => {
+    const readySpy = cy.spy().as('readySpy');
+
+    cy.mount(LocationSelector, {
+      props: {
+        includeFields: true,
+        onReady: readySpy,
+      },
+    });
+
+    cy.get('@readySpy')
+      .should('have.been.calledOnce')
+      .then(() => {
+        cy.get('[data-cy="location-selector"]').should('exist');
+
+        cy.get('[data-cy="selector-add-button"]')
+          .should('have.attr', 'href')
+          .then((href) => href)
+          .should('eq', '/asset/add/land');
+      });
+  });
+
+  it('Test add url for both fields and greenhouses', () => {
+    const readySpy = cy.spy().as('readySpy');
+
+    cy.mount(LocationSelector, {
+      props: {
+        includeGreenhouses: true,
+        includeFields: true,
+        onReady: readySpy,
+      },
+    });
+
+    cy.get('@readySpy')
+      .should('have.been.calledOnce')
+      .then(() => {
+        cy.get('[data-cy="location-selector"]').should('exist');
+
+        cy.get('[data-cy="selector-add-button"]')
+          .should('have.attr', 'href')
+          .then((href) => href)
+          .should('eq', '/asset/add');
+      });
+  });
+
+  it('Test getting only greenhouses', () => {
+    const readySpy = cy.spy().as('readySpy');
+
+    cy.mount(LocationSelector, {
+      props: {
+        includeGreenhouses: true,
+        onReady: readySpy,
+      },
+    });
+
+    cy.get('@readySpy')
+      .should('have.been.calledOnce')
+      .then(() => {
+        cy.get('[data-cy="selector-input"] option').should('have.length', 6);
+        cy.get('[data-cy="selector-option-1"]').should('have.text', 'CHUAU');
+        cy.get('[data-cy="selector-option-5"]').should(
+          'have.text',
+          'SEEDING BENCH'
+        );
+      });
+  });
+
+  it('Test getting only fields', () => {
+    const readySpy = cy.spy().as('readySpy');
+
+    cy.mount(LocationSelector, {
+      props: {
+        includeFields: true,
+        onReady: readySpy,
+      },
+    });
+
+    cy.get('@readySpy')
+      .should('have.been.calledOnce')
+      .then(() => {
+        cy.get('[data-cy="selector-input"] option').should('have.length', 66);
+        cy.get('[data-cy="selector-option-1"]').should('have.text', 'A');
+        cy.get('[data-cy="selector-option-65"]').should('have.text', 'Z');
+      });
+  });
+
+  it('Test getting fields and greenhouses', () => {
+    const readySpy = cy.spy().as('readySpy');
+
+    cy.mount(LocationSelector, {
+      props: {
+        includeGreenhouses: true,
+        includeFields: true,
+        onReady: readySpy,
+      },
+    });
+
+    cy.get('@readySpy')
+      .should('have.been.calledOnce')
+      .then(() => {
+        cy.get('[data-cy="selector-input"] option').should('have.length', 71);
+        cy.get('[data-cy="selector-option-1"]').should('have.text', 'A');
+        cy.get('[data-cy="selector-option-70"]').should('have.text', 'Z');
+      });
+  });
+});

--- a/components/LocationSelector/LocationSelector.events.comp.cy.js
+++ b/components/LocationSelector/LocationSelector.events.comp.cy.js
@@ -1,0 +1,53 @@
+import LocationSelector from '@comps/LocationSelector/LocationSelector.vue';
+
+describe('Test the LocationSelector component events', () => {
+  beforeEach(() => {
+    cy.restoreLocalStorage();
+    cy.restoreSessionStorage();
+  });
+
+  afterEach(() => {
+    cy.saveLocalStorage();
+    cy.saveSessionStorage();
+  });
+
+  it('Test that "valid" event is propagated', () => {
+    const readySpy = cy.spy().as('readySpy');
+    const validSpy = cy.spy().as('validSpy');
+
+    cy.mount(LocationSelector, {
+      props: {
+        includeGreenhouses: true,
+        onReady: readySpy,
+        onValid: validSpy,
+      },
+    });
+
+    cy.get('@readySpy')
+      .should('have.been.calledOnce')
+      .then(() => {
+        cy.get('@validSpy').should('have.been.calledOnce');
+        cy.get('@validSpy').should('have.been.calledWith', false);
+      });
+  });
+
+  it('Test that "update:selection" event is propagated', () => {
+    const readySpy = cy.spy().as('readySpy');
+    const updateSpy = cy.spy().as('updateSpy');
+
+    cy.mount(LocationSelector, {
+      props: {
+        includeGreenhouses: true,
+        onReady: readySpy,
+        'onUpdate:selected': updateSpy,
+      },
+    });
+    cy.get('@readySpy')
+      .should('have.been.calledOnce')
+      .then(() => {
+        cy.get('[data-cy="selector-input"]').select('CHUAU');
+        cy.get('@updateSpy').should('have.been.calledOnce');
+        cy.get('@updateSpy').should('have.been.calledWith', 'CHUAU');
+      });
+  });
+});

--- a/components/LocationSelector/LocationSelector.vue
+++ b/components/LocationSelector/LocationSelector.vue
@@ -1,0 +1,188 @@
+<template>
+  <SelectorBase
+    id="location-selector"
+    data-cy="location-selector"
+    label="Location"
+    invalidFeedbackText="A location is required"
+    v-bind:addOptionUrl="addLocationUrl"
+    v-bind:options="locationList"
+    v-bind:required="required"
+    v-bind:selected="selected"
+    v-bind:showValidityStyling="showValidityStyling"
+    v-on:update:selected="handleUpdateSelected($event)"
+    v-on:valid="handleValid($event)"
+  />
+</template>
+
+<script>
+import SelectorBase from '@comps/SelectorBase/SelectorBase.vue';
+import * as farmosUtil from '@libs/farmosUtil/farmosUtil.js';
+
+/**
+ * The LocationSelector component provides a UI element that allows the user to select a location.
+ *
+ * ## Usage Example
+ *
+ * ```html
+ * <LocationSelector
+ *   id="seeding-location"
+ *   data-cy="seeding-location"
+ *   required
+ *   includeGreenhouses
+ *   v-model:selected="form.location"
+ *   v-bind:showValidityStyling="validity.show"
+ *   v-on:valid="validity.location = $event"
+ *   v-on:ready="createdCount++"
+ *   v-on:error="
+ *     (msg) =>
+ *       uiUtil.showToast('Network Error', msg, 'top-center', 'danger', 5)
+ *   "
+ * />
+ * ```
+ *
+ * ## `data-cy` Attributes
+ *
+ * Attribute Name        | Description
+ * ----------------------| -----------
+ * `location-selector`   | The `SelectorBase` component containing the dropdown.
+ */
+export default {
+  name: 'LocationSelector',
+  components: { SelectorBase },
+  emits: ['ready', 'update:selected', 'valid'],
+  props: {
+    /**
+     * Whether to include fields in the list of locations.
+     */
+    includeFields: {
+      type: Boolean,
+      default: false,
+    },
+    /**
+     * Whether to include greenhouses in the list of locations.
+     */
+    includeGreenhouses: {
+      type: Boolean,
+      default: false,
+    },
+    /**
+     * Whether a location selection is required or not.
+     */
+    required: {
+      type: Boolean,
+      default: false,
+    },
+    /**
+     * The name of the selected location.
+     * This prop is watched and changes are relayed to the component's internal state.
+     */
+    selected: {
+      type: String,
+      default: null,
+    },
+    /**
+     * Whether validity styling should appear on the location dropdown.
+     */
+    showValidityStyling: {
+      type: Boolean,
+      default: false,
+    },
+  },
+  data() {
+    return {
+      locationList: [],
+    };
+  },
+  computed: {
+    addLocationUrl() {
+      // return the appropriate url for land, structure or just asset if both
+      if (this.includeFields && this.includeGreenhouses) {
+        return '/asset/add';
+      } else if (this.includeFields) {
+        return '/asset/add/land';
+      } else {
+        return '/asset/add/structure';
+      }
+    },
+  },
+  methods: {
+    handleUpdateSelected(event) {
+      /**
+       * The selected location has changed.
+       * @property {string} event the name of the new selected location.
+       */
+      this.$emit('update:selected', event);
+    },
+    handleValid(event) {
+      /**
+       * The validity of the selected location has changed.
+       * @property {boolean} event whether the selected location is valid or not.
+       */
+      this.$emit('valid', event);
+    },
+  },
+  watch: {},
+  created() {
+    farmosUtil
+      .getFarmOSInstance()
+      .then((farm) => {
+        if (this.includeFields) {
+          return farmosUtil
+            .getFieldOrBedNameToAssetMap(farm)
+            .then((fieldMap) => {
+              let fields = Array.from(fieldMap.keys());
+              return { farm, fields };
+            })
+            .catch((error) => {
+              console.error('LocationSelector: Error fetching fields.');
+              console.error(error);
+              /**
+               * An error occurred when communicating with the farmOS server.
+               * @property {string} msg an error message.
+               */
+              this.$emit('error', 'Unable to fetch fields.');
+            });
+        } else {
+          let fields = [];
+          return { farm, fields };
+        }
+      })
+      .then(({ farm, fields }) => {
+        if (this.includeGreenhouses) {
+          return farmosUtil
+            .getGreenhouseNameToAssetMap(farm)
+            .then((greenhouseMap) => {
+              let greenhouses = Array.from(greenhouseMap.keys());
+              let allLocations = [...fields, ...greenhouses];
+              return allLocations;
+            })
+            .catch((error) => {
+              console.error('LocationSelector: Error fetching greenhouses.');
+              console.error(error);
+              /**
+               * An error occurred when communicating with the farmOS server.
+               * @property {string} msg an error message.
+               */
+              this.$emit('error', 'Unable to fetch greenhouses.');
+            });
+        } else {
+          let allLocations = fields;
+          return allLocations;
+        }
+      })
+      .then((allLocations) => {
+        this.locationList = allLocations.sort();
+
+        /**
+         * The select has been populated with the list of locations and the component is ready to be used.
+         */
+        this.$emit('ready');
+      })
+      .catch((error) => {
+        console.error('LocationSelector: Error connecting to farm.');
+        console.error(error);
+        this.$emit('error', 'Unable to connect to farmOS server.');
+      });
+  },
+};
+</script>


### PR DESCRIPTION
**Pull Request Description**

Adds the LocationSelector component to `components`.  The LocationSelector provides a dropdown select for choosing one of the locations from the farmOS vocabularies: 
- `type: 'asset--land', land_type: 'bed',`
- `type: 'asset--land', land_type: 'field',`
- `type: 'asset--structure', structure_type: 'greenhouse',`

The types of locations that are appear in the dropdown is controlled by the component's props.

---

**Licensing Certification**

FarmData2 is a [Free Cultural Work](https://freedomdefined.org/Definition) and all accepted contributions are licensed as described in the LICENSE.md file. This requires that the contributor holds the rights to do so. By submitting this pull request **I certify that I satisfy the terms of the [Developer Certificate of Origin](https://developercertificate.org/)** for its contents.