### PR TITLE
feat(comps): adds the SubmitResetButtons component

### DIFF
--- a/components/SubmitResetButtons/SubmitResetButtons.content.comp.cy.js
+++ b/components/SubmitResetButtons/SubmitResetButtons.content.comp.cy.js
@@ -1,0 +1,81 @@
+import SubmitResetButtons from '@comps/SubmitResetButtons/SubmitResetButtons.vue';
+
+describe('Test the default SubmitResetButtons content', () => {
+  beforeEach(() => {
+    cy.restoreLocalStorage();
+    cy.restoreSessionStorage();
+  });
+
+  afterEach(() => {
+    cy.saveLocalStorage();
+    cy.saveSessionStorage();
+  });
+
+  it('Check all of the data-cy elements', () => {
+    const readySpy = cy.spy().as('readySpy');
+
+    cy.mount(SubmitResetButtons, {
+      props: {
+        onReady: readySpy,
+      },
+    });
+
+    cy.get('@readySpy')
+      .should('have.been.calledOnce')
+      .then(() => {
+        cy.get('[data-cy="submit-reset"]').should('exist');
+        cy.get('[data-cy="submit-button"]')
+          .should('exist')
+          .should('be.disabled')
+          .should('have.text', 'Submit');
+        cy.get('[data-cy="reset-button"]')
+          .should('exist')
+          .should('be.disabled')
+          .should('have.text', 'Reset');
+      });
+  });
+
+  it('Check enabled prop on submit button', () => {
+    const readySpy = cy.spy().as('readySpy');
+
+    cy.mount(SubmitResetButtons, {
+      props: {
+        enableSubmit: true,
+        onReady: readySpy,
+      },
+    });
+
+    cy.get('@readySpy')
+      .should('have.been.calledOnce')
+      .then(() => {
+        cy.get('[data-cy="submit-button"]')
+          .should('exist')
+          .should('not.be.disabled');
+        cy.get('[data-cy="reset-button"]')
+          .should('exist')
+          .should('be.disabled');
+      });
+  });
+
+  it('Check enabled prop on reset button', () => {
+    const readySpy = cy.spy().as('readySpy');
+
+    cy.mount(SubmitResetButtons, {
+      props: {
+        enableReset: true,
+        onReady: readySpy,
+      },
+    });
+
+    cy.get('@readySpy')
+      .should('have.been.calledOnce')
+      .then(() => {
+        cy.get('[data-cy="submit-button"]')
+          .should('exist')
+          .should('be.disabled');
+        cy.get('[data-cy="reset-button"]')
+          .should('exist')
+          .should('not.be.disabled');
+      });
+  });
+});

--- a/components/SubmitResetButtons/SubmitResetButtons.events.comp.cy.js
+++ b/components/SubmitResetButtons/SubmitResetButtons.events.comp.cy.js
@@ -1,0 +1,93 @@
+import SubmitResetButtons from '@comps/SubmitResetButtons/SubmitResetButtons.vue';
+
+describe('Test the SubmitResetButtons component events', () => {
+  beforeEach(() => {
+    cy.restoreLocalStorage();
+    cy.restoreSessionStorage();
+  });
+
+  afterEach(() => {
+    cy.saveLocalStorage();
+    cy.saveSessionStorage();
+  });
+
+  it('Check submitEnabled prop is watched', () => {
+    const readySpy = cy.spy().as('readySpy');
+
+    cy.mount(SubmitResetButtons, {
+      props: {
+        onReady: readySpy,
+      },
+    }).then(({ wrapper }) => {
+      cy.get('@readySpy')
+        .should('have.been.calledOnce')
+        .then(() => {
+          cy.get('[data-cy="submit-button"]').should('be.disabled');
+
+          wrapper.setProps({ enableSubmit: true });
+
+          cy.get('[data-cy="submit-button"]').should('not.be.disabled');
+        });
+    });
+  });
+
+  it('Check resetEnabled prop is watched', () => {
+    const readySpy = cy.spy().as('readySpy');
+
+    cy.mount(SubmitResetButtons, {
+      props: {
+        onReady: readySpy,
+      },
+    }).then(({ wrapper }) => {
+      cy.get('@readySpy')
+        .should('have.been.calledOnce')
+        .then(() => {
+          cy.get('[data-cy="reset-button"]').should('be.disabled');
+
+          wrapper.setProps({ enableReset: true });
+
+          cy.get('[data-cy="reset-button"]').should('not.be.disabled');
+        });
+    });
+  });
+
+  it('Emits "submit" when submit button is clicked', () => {
+    const readySpy = cy.spy().as('readySpy');
+    const submitSpy = cy.spy().as('submitSpy');
+
+    cy.mount(SubmitResetButtons, {
+      props: {
+        enableSubmit: true,
+        onSubmit: submitSpy,
+        onReady: readySpy,
+      },
+    });
+
+    cy.get('@readySpy')
+      .should('have.been.calledOnce')
+      .then(() => {
+        cy.get('[data-cy="submit-button"]').click();
+        cy.get('@submitSpy').should('have.been.calledOnce');
+      });
+  });
+
+  it('Emits "reset" when reset button is clicked', () => {
+    const readySpy = cy.spy().as('readySpy');
+    const resetSpy = cy.spy().as('resetSpy');
+
+    cy.mount(SubmitResetButtons, {
+      props: {
+        enableReset: true,
+        onReset: resetSpy,
+        onReady: readySpy,
+      },
+    });
+
+    cy.get('@readySpy')
+      .should('have.been.calledOnce')
+      .then(() => {
+        cy.get('[data-cy="reset-button"]').click();
+        cy.get('@resetSpy').should('have.been.calledOnce');
+      });
+  });
+});

--- a/components/SubmitResetButtons/SubmitResetButtons.vue
+++ b/components/SubmitResetButtons/SubmitResetButtons.vue
@@ -1,0 +1,129 @@
+<template>
+  <BRow
+    id="submit-reset"
+    data-cy="submit-reset"
+  >
+    <BCol cols="auto">
+      <BButton
+        id="submit-button"
+        data-cy="submit-button"
+        variant="primary"
+        size="lg"
+        class="fd2-submit"
+        v-on:click="submit()"
+        v-bind:disabled="!submitEnabled"
+        >Submit</BButton
+      >
+    </BCol>
+    <BCol
+      cols="auto"
+      alignSelf="center"
+    >
+      <BButton
+        id="reset-button"
+        data-cy="reset-button"
+        variant="warning"
+        v-on:click="reset()"
+        v-bind:disabled="!resetEnabled"
+        >Reset</BButton
+      >
+    </BCol>
+  </BRow>
+</template>
+
+<script>
+/**
+ * The SubmitResetButtons component provides the Submit and Reset buttons used on forms.
+ *
+ * ## Usage Example
+ *
+ * ```html
+ * <SubmitResetButtons
+ *   v-model:enableSubmit="enableSubmit"
+ *   v-model:enableReset="enableReset"
+ *   v-on:ready="createdCount++"
+ *   v-on:submit="submit()"
+ *   v-on:reset="reset()"
+ * />
+ * ```
+ *
+ * ## `data-cy` Attributes
+ *
+ * Attribute Name        | Description
+ * ----------------------| -----------
+ * submit-reset          | The `<row>` element containing the submit and reset buttons.
+ * submit-button         | The submit button.
+ * reset-button          | The reset button.
+ */
+export default {
+  name: 'SubmitResetButtons',
+  emits: ['submit', 'ready', 'reset'],
+  props: {
+    /**
+     * Indicates if the reset button should be enabled.
+     * This prop is watched by the component.
+     */
+    enableReset: {
+      type: Boolean,
+      default: false,
+    },
+    /**
+     * Indicates if the submit button should be enabled.
+     * This prop is watched by the component.
+     */
+    enableSubmit: {
+      type: Boolean,
+      default: false,
+    },
+  },
+  data() {
+    return {
+      submitEnabled: this.enableSubmit,
+      resetEnabled: this.enableReset,
+    };
+  },
+  computed: {},
+  methods: {
+    submit() {
+      /**
+       * The submit button has been clicked.
+       */
+      this.$emit('submit', this.submitEnabled);
+    },
+    reset() {
+      /**
+       * The reset button has been clicked.
+       */
+      this.$emit('reset', this.resetEnabled);
+    },
+  },
+  watch: {
+    enableSubmit() {
+      this.submitEnabled = this.enableSubmit;
+    },
+    enableReset() {
+      this.resetEnabled = this.enableReset;
+    },
+  },
+  created() {
+    /**
+     * This component is ready for use.
+     */
+    this.$emit('ready');
+  },
+};
+</script>
+
+<style scoped>
+.fd2-submit {
+  width: 245px !important;
+  min-width: 245px;
+  max-width: 245px;
+}
+
+.fd2-reset {
+  width: 50px !important;
+  min-width: 50px;
+  max-width: 50px;
+}
+</style>


### PR DESCRIPTION
**Pull Request Description**

Adds the SubmitResetButtons component to `components`.  The SubmitResetButtons component provides the Submit and Reset buttons that appear at the bottom of all forms.

---

**Licensing Certification**

FarmData2 is a [Free Cultural Work](https://freedomdefined.org/Definition) and all accepted contributions are licensed as described in the LICENSE.md file. This requires that the contributor holds the rights to do so. By submitting this pull request **I certify that I satisfy the terms of the [Developer Certificate of Origin](https://developercertificate.org/)** for its contents.
