### PR TITLE
ci: updates lintstaged config to ignore files in libraries/cypress

### DIFF
--- a/.lintstagedrc.cjs
+++ b/.lintstagedrc.cjs
@@ -178,7 +178,7 @@ module.exports = {
   'components/**/*.comp.cy.js': (files) => {
     return getCompTestCommandsForCyJsFiles(files);
   },
-  'library/**/!(*unit.cy).js': (files) => {
+  'library/!(cypress)/!(*unit.cy).js': (files) => {
     return getLibTestCommandsForVueFiles(files);
   },
   'library/**/*.unit.cy.js': (files) => {

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -4,5 +4,8 @@
   "editor.detectIndentation": false,
   "editor.defaultFormatter": "esbenp.prettier-vscode",
   "editor.quickSuggestionsDelay": 3000,
-  "eslint.validate": ["markdown", "md"]
+  "eslint.validate": [
+    "markdown",
+    "md"
+  ],
 }


### PR DESCRIPTION
**Pull Request Description**

The lintstaged tool was picking up changes to the files in `libraries/cypress` and causing the pre-commit hook to fail because those files do not have any corresponding `unit.cy.js` tests.

Also throws in a formatting fix in the `.vscode/settings.json` because it was there.

---

**Licensing Certification**

FarmData2 is a [Free Cultural Work](https://freedomdefined.org/Definition) and all accepted contributions are licensed as described in the LICENSE.md file. This requires that the contributor holds the rights to do so. By submitting this pull request **I certify that I satisfy the terms of the [Developer Certificate of Origin](https://developercertificate.org/)** for its contents.
