### PR TITLE
feat(comps): adds TraySizeSelector component

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -29,7 +29,8 @@
     "docs/components",
     "docs/library",
     "docs/FarmData2.md",
-    "modules/**/components.d.ts"
+    "modules/**/components.d.ts",
+    "modules/**/module/config"
   ],
   "enableFiletypes": [
     "dockercompose",

--- a/components/TraySizeSelector/TraySizeSelector.behavior.comp.cy.js
+++ b/components/TraySizeSelector/TraySizeSelector.behavior.comp.cy.js
@@ -1,0 +1,36 @@
+import TraySizeSelector from '@comps/TraySizeSelector/TraySizeSelector.vue';
+
+describe('Test the TraySizeSelector behaviors', () => {
+  beforeEach(() => {
+    cy.restoreLocalStorage();
+    cy.restoreSessionStorage();
+  });
+
+  afterEach(() => {
+    cy.saveLocalStorage();
+    cy.saveSessionStorage();
+  });
+
+  it('Clicking add tray size button goes to the add tray size form', () => {
+    const readySpy = cy.spy().as('readySpy');
+
+    cy.intercept('GET', '**/taxonomy/manage/tray_size/add', {
+      statusCode: 200,
+      body: 'Add Tray Size Form',
+    }).as('urlIntercept');
+
+    cy.mount(TraySizeSelector, {
+      props: {
+        onReady: readySpy,
+      },
+    }).then(() => {
+      cy.get('@readySpy')
+        .should('have.been.calledOnce')
+        .then(() => {
+          cy.get('[data-cy="selector-add-button"]').should('exist');
+          cy.get('[data-cy="selector-add-button"]').click();
+          cy.wait('@urlIntercept').its('response.statusCode').should('eq', 200);
+        });
+    });
+  });
+});

--- a/components/TraySizeSelector/TraySizeSelector.content.comp.cy.js
+++ b/components/TraySizeSelector/TraySizeSelector.content.comp.cy.js
@@ -1,0 +1,86 @@
+import TraySizeSelector from '@comps/TraySizeSelector/TraySizeSelector.vue';
+
+describe('Test the TraySizeSelector content', () => {
+  beforeEach(() => {
+    cy.restoreLocalStorage();
+    cy.restoreSessionStorage();
+  });
+
+  afterEach(() => {
+    cy.saveLocalStorage();
+    cy.saveSessionStorage();
+  });
+
+  it('Check for the SelectorBase element being used for the TraySizeSelector', () => {
+    const readySpy = cy.spy().as('readySpy');
+
+    cy.mount(TraySizeSelector, {
+      props: {
+        onReady: readySpy,
+      },
+    });
+
+    cy.get('@readySpy')
+      .should('have.been.calledOnce')
+      .then(() => {
+        cy.get('[data-cy="tray-size-selector"]').should('exist');
+      });
+  });
+
+  it('Check that required prop is false by default', () => {
+    const readySpy = cy.spy().as('readySpy');
+
+    cy.mount(TraySizeSelector, {
+      props: {
+        onReady: readySpy,
+      },
+    });
+
+    cy.get('@readySpy')
+      .should('have.been.calledOnce')
+      .then(() => {
+        cy.get('[data-cy="selector-required"]').should('not.exist');
+      });
+  });
+
+  it('Check that props are passed through to the SelectorBase', () => {
+    const readySpy = cy.spy().as('readySpy');
+
+    cy.mount(TraySizeSelector, {
+      props: {
+        required: true,
+        onReady: readySpy,
+      },
+    });
+
+    cy.get('@readySpy')
+      .should('have.been.calledOnce')
+      .then(() => {
+        cy.get('[data-cy="selector-label"]').should('have.text', 'Tray Size:');
+        cy.get('[data-cy="selector-required"]').should('have.text', '*');
+        cy.get('[data-cy="selector-invalid-feedback"]').should(
+          'contain.text',
+          'A tray size is required'
+        );
+      });
+  });
+
+  it('Test add url for tray sizes', () => {
+    const readySpy = cy.spy().as('readySpy');
+
+    cy.mount(TraySizeSelector, {
+      props: {
+        onReady: readySpy,
+      },
+    });
+
+    cy.get('@readySpy')
+      .should('have.been.calledOnce')
+      .then(() => {
+        cy.get('[data-cy="selector-add-button"]')
+          .should('have.attr', 'href')
+          .then((href) => href)
+          .should('eq', '/admin/structure/taxonomy/manage/tray_size/add');
+      });
+  });
+});

--- a/components/TraySizeSelector/TraySizeSelector.events.comp.cy.js
+++ b/components/TraySizeSelector/TraySizeSelector.events.comp.cy.js
@@ -1,0 +1,51 @@
+import TraySizeSelector from '@comps/TraySizeSelector/TraySizeSelector.vue';
+
+describe('Test the TraySizeSelector events', () => {
+  beforeEach(() => {
+    cy.restoreLocalStorage();
+    cy.restoreSessionStorage();
+  });
+
+  afterEach(() => {
+    cy.saveLocalStorage();
+    cy.saveSessionStorage();
+  });
+
+  it('Test that "valid" event is propagated', () => {
+    const readySpy = cy.spy().as('readySpy');
+    const validSpy = cy.spy().as('validSpy');
+
+    cy.mount(TraySizeSelector, {
+      props: {
+        onReady: readySpy,
+        onValid: validSpy,
+      },
+    });
+
+    cy.get('@readySpy')
+      .should('have.been.calledOnce')
+      .then(() => {
+        cy.get('@validSpy').should('have.been.calledOnce');
+        cy.get('@validSpy').should('have.been.calledWith', false);
+      });
+  });
+
+  it('Test that "update:selection" event is propagated', () => {
+    const readySpy = cy.spy().as('readySpy');
+    const updateSpy = cy.spy().as('updateSpy');
+
+    cy.mount(TraySizeSelector, {
+      props: {
+        onReady: readySpy,
+        'onUpdate:selected': updateSpy,
+      },
+    });
+    cy.get('@readySpy')
+      .should('have.been.calledOnce')
+      .then(() => {
+        cy.get('[data-cy="selector-input"]').select('50');
+        cy.get('@updateSpy').should('have.been.calledOnce');
+        cy.get('@updateSpy').should('have.been.calledWith', '50');
+      });
+  });
+});

--- a/components/TraySizeSelector/TraySizeSelector.vue
+++ b/components/TraySizeSelector/TraySizeSelector.vue
@@ -1,0 +1,136 @@
+<template>
+  <SelectorBase
+    id="tray-size-selector"
+    data-cy="tray-size-selector"
+    label="Tray Size"
+    invalidFeedbackText="A tray size is required"
+    v-bind:addOptionUrl="addTraySizeUrl"
+    v-bind:options="traySizeList"
+    v-bind:required="required"
+    v-bind:selected="selected"
+    v-bind:showValidityStyling="showValidityStyling"
+    v-on:update:selected="handleUpdateSelected($event)"
+    v-on:valid="handleValid($event)"
+  />
+</template>
+
+<script>
+import SelectorBase from '@comps/SelectorBase/SelectorBase.vue';
+import * as farmosUtil from '@libs/farmosUtil/farmosUtil.js';
+
+/**
+ * The TraySizeSelector component is a UI element that allows the user to select a tray size (i.e. number of cells) for a tray seeding.
+ *
+ * It fetches the list of tray sizes (farmOS `taxonomy_term--tray_size` records) from the farmOS server.
+ *
+ * ## Usage Example
+ *
+ * ```html
+ * <TraySizeSelector
+ *   id="seeding-tray-size"
+ *   data-cy="seeding-tray-size"
+ *   required
+ *   v-model:selected="form.traySize"
+ *   v-bind:showValidityStyling="validity.show"
+ *   v-on:valid="validity.traySize = $event"
+ *   v-on:ready="createdCount++"
+ *   v-on:error="
+ *     (msg) =>
+ *       uiUtil.showToast('Network Error', msg, 'top-center', 'danger', 5)
+ *   "
+ * />
+ * ```
+ *
+ * ## `data-cy` Attributes
+ *
+ * Attribute Name        | Description
+ * ----------------------| -----------
+ * tray-size-selector    | The `SelectorBase` component containing the dropdown for the tray sizes.
+ */
+export default {
+  name: 'TraySizeSelector',
+  components: { SelectorBase },
+  emits: ['error', 'ready', 'update:selected', 'valid'],
+  props: {
+    /**
+     * Whether a tray size selection is required or not.
+     */
+    required: {
+      type: Boolean,
+      default: false,
+    },
+    /**
+     * The name of the selected tray size.
+     * This prop is watched and changes are relayed to the component's internal state.
+     */
+    selected: {
+      type: String,
+      default: null,
+    },
+    /**
+     * Whether validity styling should appear on input elements.
+     */
+    showValidityStyling: {
+      type: Boolean,
+      default: false,
+    },
+  },
+  data() {
+    return {
+      traySizeList: [],
+    };
+  },
+  computed: {
+    addTraySizeUrl() {
+      return '/admin/structure/taxonomy/manage/tray_size/add';
+    },
+  },
+  methods: {
+    handleUpdateSelected(event) {
+      /**
+       * The selected crop has changed.
+       * @property {string} event the name of the new selected crop.
+       */
+      this.$emit('update:selected', event);
+    },
+    handleValid(event) {
+      /**
+       * The validity of the selected tray size has changed.
+       * @property {boolean} event whether the selected tray size is valid or not.
+       */
+      this.$emit('valid', event);
+    },
+  },
+  watch: {},
+  created() {
+    farmosUtil
+      .getFarmOSInstance()
+      .then((farm) => {
+        farmosUtil
+          .getTraySizeToTermMap(farm)
+          .then((traySizeMap) => {
+            this.traySizeList = Array.from(traySizeMap.keys());
+
+            /**
+             * The select has been populated with the list of tray sizes and the component is ready to be used.
+             */
+            this.$emit('ready');
+          })
+          .catch((error) => {
+            console.error('TraySizeSelector: Error fetching tray sizes.');
+            console.error(error);
+            /**
+             * An error occurred when communicating with the farmOS server.
+             * @property {string} msg an error message.
+             */
+            this.$emit('error', 'Unable to fetch tray sizes.');
+          });
+      })
+      .catch((error) => {
+        console.error('TraySizeSelector: Error connecting to farm.');
+        console.error(error);
+        this.$emit('error', 'Unable to connect to farmOS server.');
+      });
+  },
+};
+</script>

--- a/library/farmosUtil/farmosUtil.js
+++ b/library/farmosUtil/farmosUtil.js
@@ -488,3 +488,72 @@ export async function getCropIdToTermMap(farm) {
 
   return map;
 }
+
+/**
+ * Get taxonomy term objects for all of the tray sizes.
+ * These are the taxonomy terms of type `taxonomy_term--tray_size`.
+ * The tray sizes will appear in numerical order
+ * by the value of the `attributes.name` property.
+ *
+ * NOTE: This function makes an API call to the farmOS host.  Thus,
+ * if the array is to be used multiple times it should be cached
+ * by the calling code.
+ *
+ * @param {object} farm a `farmOS` object returned from `getFarmOSInstance`.
+ * @throws {Error} if unable to fetch the tray sizes.
+ * @returns an array of all of taxonomy terms representing tray sizes.
+ */
+export async function getTraySizes(farm) {
+  const traySizes = await farm.term.fetch({
+    filter: {
+      type: 'taxonomy_term--tray_size',
+    },
+    limit: Infinity,
+  });
+
+  if (traySizes.rejected.length != 0) {
+    throw new Error('Unable to fetch tray sizes.', traySizes.rejected);
+  }
+
+  traySizes.data.sort((o1, o2) => {
+    let size1 = parseFloat(o1.attributes.name);
+    let size2 = parseFloat(o2.attributes.name);
+    return size1 - size2;
+  });
+
+  return traySizes.data;
+}
+
+/**
+ * Get a map from the name of a tray size taxonomy term to the
+ * farmOS taxonomy term object.
+ *
+ * NOTE: The returned `Map` is built on the value returned by {@link getTraySizes}.
+ *
+ * @param {object} farm a `farmOS` object returned from `getFarmOSInstance`.
+ * @returns a `Map` from the tray size `name` to the `taxonomy_term--tray-size` object.
+ */
+export async function getTraySizeToTermMap(farm) {
+  const sizes = await getTraySizes(farm);
+
+  const map = new Map(sizes.map((sz) => [sz.attributes.name, sz]));
+
+  return map;
+}
+
+/**
+ * Get a map from the id of a tray size taxonomy term to the
+ * farmOS taxonomy term object.
+ *
+ * NOTE: The returned `Map` is built on the value returned by {@link getTraySizes}.
+ *
+ * @param {object} farm a `farmOS` object returned from `getFarmOSInstance`.
+ * @returns a `Map` from the tray size `id` to the `taxonomy_term--tray_size` object.
+ */
+export async function getTraySizeIdToTermMap(farm) {
+  const sizes = await getTraySizes(farm);
+
+  const map = new Map(sizes.map((sz) => [sz.id, sz]));
+
+  return map;
+}

--- a/library/farmosUtil/farmosUtil.traySizes.unit.cy.js
+++ b/library/farmosUtil/farmosUtil.traySizes.unit.cy.js
@@ -1,0 +1,94 @@
+import * as farmosUtil from './farmosUtil.js';
+
+describe('Test the tray sizes utility functions', () => {
+  var farm = null;
+  before(() => {
+    cy.wrap(
+      farmosUtil
+        .getFarmOSInstance('http://farmos', 'farm', 'admin', 'admin')
+        .then((newFarm) => {
+          farm = newFarm;
+        })
+    );
+  });
+
+  beforeEach(() => {
+    cy.restoreLocalStorage();
+    cy.restoreSessionStorage();
+  });
+
+  afterEach(() => {
+    cy.saveLocalStorage();
+    cy.saveSessionStorage();
+  });
+
+  it('Get the tray sizes', () => {
+    cy.wrap(farmosUtil.getTraySizes(farm)).then((traySizes) => {
+      expect(traySizes).to.not.be.null;
+      expect(traySizes.length).to.equal(6);
+
+      expect(traySizes[0].attributes.name).to.equal('50');
+      expect(traySizes[0].attributes.description.value).to.equal(
+        '50 cell tray'
+      );
+      expect(traySizes[0].type).to.equal('taxonomy_term--tray_size');
+
+      expect(traySizes[5].attributes.name).to.equal('288');
+      expect(traySizes[5].attributes.description.value).to.equal(
+        '288 cell tray'
+      );
+      expect(traySizes[5].type).to.equal('taxonomy_term--tray_size');
+    });
+  });
+
+  it('Test that get tray sizes throws error if fetch fails', () => {
+    cy.intercept('GET', '**/api/taxonomy_term/tray_size?*', {
+      forceNetworkError: true,
+    });
+
+    cy.wrap(
+      farmosUtil
+        .getTraySizes(farm)
+        .then(() => {
+          throw new Error('Fetching tray sizes should have failed.');
+        })
+        .catch((error) => {
+          expect(error.message).to.equal('Unable to fetch tray sizes.');
+        })
+    );
+  });
+
+  it('Get the TraySizeToTerm map', () => {
+    cy.wrap(farmosUtil.getTraySizeToTermMap(farm)).then((traySizeMap) => {
+      expect(traySizeMap).to.not.be.null;
+      expect(traySizeMap.size).to.equal(6);
+
+      expect(traySizeMap.get('50')).to.not.be.null;
+      expect(traySizeMap.get('50').type).to.equal('taxonomy_term--tray_size');
+
+      expect(traySizeMap.get('288')).to.not.be.null;
+      expect(traySizeMap.get('288').type).to.equal('taxonomy_term--tray_size');
+    });
+  });
+
+  it('Get the TraySizeIdToAsset map', () => {
+    cy.wrap(farmosUtil.getTraySizeIdToTermMap(farm)).then((trayIdMap) => {
+      expect(trayIdMap).to.not.be.null;
+      expect(trayIdMap.size).to.equal(6);
+
+      cy.wrap(farmosUtil.getTraySizeToTermMap(farm)).then((trayNameMap) => {
+        const tray50Id = trayNameMap.get('50').id;
+        expect(trayIdMap.get(tray50Id).attributes.name).to.equal('50');
+        expect(trayIdMap.get(tray50Id).type).to.equal(
+          'taxonomy_term--tray_size'
+        );
+
+        const tray288Id = trayNameMap.get('288').id;
+        expect(trayIdMap.get(tray288Id).attributes.name).to.equal('288');
+        expect(trayIdMap.get(tray288Id).type).to.equal(
+          'taxonomy_term--tray_size'
+        );
+      });
+    });
+  });
+});

--- a/modules/farm_fd2/src/module/config/optional/taxonomy.vocabulary.tray_size.yml
+++ b/modules/farm_fd2/src/module/config/optional/taxonomy.vocabulary.tray_size.yml
@@ -1,0 +1,7 @@
+langcode: en
+status: true
+dependencies: {}
+name: 'Tray Size'
+vid: tray_size
+description: 'Seeding tray sizes.'
+weight: 0

--- a/modules/farm_fd2/vite.config.js
+++ b/modules/farm_fd2/vite.config.js
@@ -28,6 +28,10 @@ let viteConfig = {
           dest: 'src/',
         },
         {
+          src: '../module/config',
+          dest: '.',
+        },
+        {
           src: '../composer.json',
           dest: '.',
         },


### PR DESCRIPTION
**Pull Request Description**

Adds the TraySizeSelector to `components`.  The TraySizeSelector provides a UI element for selecting the number of cells in a tray used for tray seeding.  The `tray_size` taxonomy was added to the module config so that it is created when the FarmData2 module is installed.  Functions for reading the `tray_size` vocabulary terms were also added to the `library/farmosUtil/farmosUtil.js` library.

---

**Licensing Certification**

FarmData2 is a [Free Cultural Work](https://freedomdefined.org/Definition) and all accepted contributions are licensed as described in the LICENSE.md file. This requires that the contributor holds the rights to do so. By submitting this pull request **I certify that I satisfy the terms of the [Developer Certificate of Origin](https://developercertificate.org/)** for its contents.
