### PR TITLE
fix(comps): ensures display is reactive to  prop changes

### DIFF
--- a/components/TextDisplay/TextDisplay.vue
+++ b/components/TextDisplay/TextDisplay.vue
@@ -14,7 +14,7 @@
       data-cy="text-text"
       disabled
       plaintext
-      v-model="displayText"
+      v-model="processedText"
     />
   </BFormGroup>
 </template>
@@ -62,13 +62,8 @@ export default {
       required: true,
     },
   },
-  data() {
-    return {
-      displayText: this.processedText(),
-    };
-  },
-  computed: {},
-  methods: {
+  data() {},
+  computed: {
     processedText() {
       if (this.text == null || this.text == 'NaN') {
         return '';
@@ -77,6 +72,7 @@ export default {
       }
     },
   },
+  methods: {},
   watch: {},
   created() {
     /**


### PR DESCRIPTION
**Pull Request Description**

The text displayed was not reactive to changes in the `text` prop.  Changed the displayed text to be given by a computed property instead of a method return value to fix this issue.

---

**Licensing Certification**

FarmData2 is a [Free Cultural Work](https://freedomdefined.org/Definition) and all accepted contributions are licensed as described in the LICENSE.md file. This requires that the contributor holds the rights to do so. By submitting this pull request **I certify that I satisfy the terms of the [Developer Certificate of Origin](https://developercertificate.org/)** for its contents.
