### PR TITLE
fix(libs): patches the farmosUtil library to work in node and in browser

### DIFF
--- a/bin/printFarmosLogs.js
+++ b/bin/printFarmosLogs.js
@@ -1,6 +1,9 @@
 /** @module farmosUtil */
 
 import * as farmosUtil from '../library/farmosUtil/farmosUtil.js';
+import { LocalStorage } from 'node-localstorage';
+import { dirname } from 'path';
+import { fileURLToPath } from 'url';
 
 /*
  * Setup the information for connecting to the farmOS instance
@@ -13,10 +16,17 @@ const user = 'admin';
 const pass = 'admin';
 
 /*
+ * Get a local storage object that we'll use to simulate the
+ *browser's localStorage and sessionStorage when running in node.
+ */
+const rootDir = dirname(dirname(dirname(fileURLToPath(import.meta.url))));
+let ls = new LocalStorage(rootDir + '/scratch');
+
+/*
  * Get a fully initialized and logged in instance of the farmOS.js
  * farmOS object that will be used to write assets, logs, etc.
  */
-const farm = await farmosUtil.getFarmOSInstance(URL, client, user, pass);
+const farm = await farmosUtil.getFarmOSInstance(URL, client, user, pass, ls);
 
 let logTypes = [];
 let schema = farm.schema.get();

--- a/library/cypress.config.js
+++ b/library/cypress.config.js
@@ -1,12 +1,14 @@
-/* eslint-disable no-undef */
-const { defineConfig } = require('cypress');
+import { defineConfig } from 'cypress';
 
-module.exports = defineConfig({
+export default defineConfig({
   screenshotOnRunFailure: false,
   video: false,
   trashAssetsBeforeRuns: true,
   e2e: {
     baseUrl: 'http://farmos',
     specPattern: '**/*.unit.cy.js',
+    devServer: {
+      bundler: 'vite',
+    },
   },
 });

--- a/modules/cypress.config.cjs
+++ b/modules/cypress.config.cjs
@@ -15,6 +15,10 @@ module.exports = defineConfig({
   chromeWebSecurity: false,
   e2e: {
     specPattern: 'src/entrypoints/**/*.cy.js',
+    devServer: {
+      framework: 'vue',
+      bundler: 'vite',
+    },
   },
   component: {
     specPattern: '../../components/**/*.comp.cy.js',


### PR DESCRIPTION
**Pull Request Description**

This PR patches the `library/farmosUtil` library so that it will work both in the browser and in node.  The issue was working with `localStorage` and `sessionStorage` which do not exist in node.  So a separate library needed to be used to simulate them when running in node.  That had created issues with the js module types that was resolved by allowing a simulated `localStorage` object to be passed in.  In the process the Cypress config for the unit tests was also changed so that is uses vite instead of webpack.

---

**Licensing Certification**

FarmData2 is a [Free Cultural Work](https://freedomdefined.org/Definition) and all accepted contributions are licensed as described in the LICENSE.md file. This requires that the contributor holds the rights to do so. By submitting this pull request **I certify that I satisfy the terms of the [Developer Certificate of Origin](https://developercertificate.org/)** for its contents.
