### PR TITLE
fix(comps): fixes empty data property in TextComponent

### DIFF
--- a/components/TextDisplay/TextDisplay.vue
+++ b/components/TextDisplay/TextDisplay.vue
@@ -62,7 +62,9 @@ export default {
       required: true,
     },
   },
-  data() {},
+  data() {
+    return {};
+  },
   computed: {
     processedText() {
       if (this.text == null || this.text == 'NaN') {


### PR DESCRIPTION
**Pull Request Description**

The TextComponent had an empty `data: {}` property.  However, it still needed to `return {}` to work properly with Vue.

---

**Licensing Certification**

FarmData2 is a [Free Cultural Work](https://freedomdefined.org/Definition) and all accepted contributions are licensed as described in the LICENSE.md file. This requires that the contributor holds the rights to do so. By submitting this pull request **I certify that I satisfy the terms of the [Developer Certificate of Origin](https://developercertificate.org/)** for its contents.
