### PR TITLE
feat(libs): adds utility functions for unit and log-category taxonomy terms

### DIFF
--- a/library/farmosUtil/farmosUtil.js
+++ b/library/farmosUtil/farmosUtil.js
@@ -543,3 +543,137 @@ export async function getTraySizeIdToTermMap(farm) {
 
   return map;
 }
+
+/**
+ * Get taxonomy term objects for all of the units.
+ * These are the taxonomy terms of type `taxonomy_term--unit`.
+ * The units will appear in alphabetical order.
+ *
+ * NOTE: This function makes an API call to the farmOS host.  Thus,
+ * if the array is to be used multiple times it should be cached
+ * by the calling code.
+ *
+ * @param {object} farm a `farmOS` object returned from `getFarmOSInstance`.
+ * @throws {Error} if unable to fetch the units.
+ * @returns an array of all of taxonomy terms representing units.
+ */
+export async function getUnits(farm) {
+  const units = await farm.term.fetch({
+    filter: {
+      type: 'taxonomy_term--unit',
+    },
+    limit: Infinity,
+  });
+
+  if (units.rejected.length != 0) {
+    throw new Error('Unable to fetch units.', units.rejected);
+  }
+
+  units.data.sort((o1, o2) =>
+    o1.attributes.name.localeCompare(o2.attributes.name)
+  );
+
+  return units.data;
+}
+
+/**
+ * Get a map from the name of a unit taxonomy term to the
+ * farmOS unit term object.
+ *
+ * NOTE: The returned `Map` is built on the value returned by {@link #module_farmosUtil.getUnits}.
+ *
+ * @param {object} farm a `farmOS` object returned from `getFarmOSInstance`.
+ * @returns a `Map` from the unit `name` to the `taxonomy_term--unit` object.
+ */
+export async function getUnitToTermMap(farm) {
+  const sizes = await getUnits(farm);
+
+  const map = new Map(sizes.map((unit) => [unit.attributes.name, unit]));
+
+  return map;
+}
+
+/**
+ * Get a map from the id of a unit taxonomy term to the
+ * farmOS taxonomy term object.
+ *
+ * NOTE: The returned `Map` is built on the value returned by {@link #module_farmosUtil.getUnits}.
+ *
+ * @param {object} farm a `farmOS` object returned from `getFarmOSInstance`.
+ * @returns a `Map` from the unit `id` to the `taxonomy_term--unit` object.
+ */
+export async function getUnitIdToTermMap(farm) {
+  const units = await getUnits(farm);
+
+  const map = new Map(units.map((unit) => [unit.id, unit]));
+
+  return map;
+}
+
+/**
+ * Get taxonomy term objects for all of the log categories.
+ * These are the taxonomy terms of type `taxonomy_term--log_category`.
+ * The log categories will appear in alphabetical order.
+ *
+ * NOTE: This function makes an API call to the farmOS host.  Thus,
+ * if the array is to be used multiple times it should be cached
+ * by the calling code.
+ *
+ * @param {object} farm a `farmOS` object returned from `getFarmOSInstance`.
+ * @throws {Error} if unable to fetch the log categories.
+ * @returns an array of all of taxonomy terms representing log categories.
+ */
+export async function getLogCategories(farm) {
+  const categories = await farm.term.fetch({
+    filter: {
+      type: 'taxonomy_term--log_category',
+    },
+    limit: Infinity,
+  });
+
+  if (categories.rejected.length != 0) {
+    throw new Error('Unable to fetch log categories.', categories.rejected);
+  }
+
+  categories.data.sort((o1, o2) =>
+    o1.attributes.name.localeCompare(o2.attributes.name)
+  );
+
+  return categories.data;
+}
+
+/**
+ * Get a map from the name of a log category taxonomy term to the
+ * farmOS unit term object.
+ *
+ * NOTE: The returned `Map` is built on the value returned by {@link #module_farmosUtil.getLogCategories}.
+ *
+ * @param {object} farm a `farmOS` object returned from `getFarmOSInstance`.
+ * @returns a `Map` from the log category `name` to the `taxonomy_term--log_category` object.
+ */
+export async function getLogCategoryToTermMap(farm) {
+  const categories = await getLogCategories(farm);
+
+  const map = new Map(
+    categories.map((category) => [category.attributes.name, category])
+  );
+
+  return map;
+}
+
+/**
+ * Get a map from the id of a log category taxonomy term to the
+ * farmOS taxonomy term object.
+ *
+ * NOTE: The returned `Map` is built on the value returned by {@link #module_farmosUtil.getLogCategories}.
+ *
+ * @param {object} farm a `farmOS` object returned from `getFarmOSInstance`.
+ * @returns a `Map` from the log category `id` to the `taxonomy_term--log_category` object.
+ */
+export async function getLogCategoryIdToTermMap(farm) {
+  const categories = await getLogCategories(farm);
+
+  const map = new Map(categories.map((category) => [category.id, category]));
+
+  return map;
+}

--- a/library/farmosUtil/farmosUtil.logCategories.unit.cy.js
+++ b/library/farmosUtil/farmosUtil.logCategories.unit.cy.js
@@ -1,0 +1,106 @@
+import * as farmosUtil from './farmosUtil.js';
+
+describe('Test the log categories utility functions', () => {
+  var farm = null;
+  before(() => {
+    cy.wrap(
+      farmosUtil
+        .getFarmOSInstance('http://farmos', 'farm', 'admin', 'admin')
+        .then((newFarm) => {
+          farm = newFarm;
+        })
+    );
+  });
+
+  beforeEach(() => {
+    cy.restoreLocalStorage();
+    cy.restoreSessionStorage();
+  });
+
+  afterEach(() => {
+    cy.saveLocalStorage();
+    cy.saveSessionStorage();
+  });
+
+  it('Get the log categories', () => {
+    cy.wrap(farmosUtil.getLogCategories(farm)).then((categories) => {
+      expect(categories).to.not.be.null;
+      expect(categories.length).to.equal(3);
+
+      expect(categories[0].attributes.name).to.equal('seeding_cover_crop');
+      expect(categories[0].attributes.description.value).to.equal(
+        'For seeding logs representing seedings of cover crops.'
+      );
+      expect(categories[0].type).to.equal('taxonomy_term--log_category');
+
+      expect(categories[2].attributes.name).to.equal('seeding_tray');
+      expect(categories[2].attributes.description.value).to.equal(
+        'For seeding logs representing seedings in trays.'
+      );
+      expect(categories[2].type).to.equal('taxonomy_term--log_category');
+    });
+  });
+
+  it('Test that get units throws error if fetch fails', () => {
+    cy.intercept('GET', '**/api/taxonomy_term/log_category?*', {
+      forceNetworkError: true,
+    });
+
+    cy.wrap(
+      farmosUtil
+        .getLogCategories(farm)
+        .then(() => {
+          throw new Error('Fetching log categories should have failed.');
+        })
+        .catch((error) => {
+          expect(error.message).to.equal('Unable to fetch log categories.');
+        })
+    );
+  });
+
+  it('Get the logCategoryToTerm map', () => {
+    cy.wrap(farmosUtil.getLogCategoryToTermMap(farm)).then((categoryMap) => {
+      expect(categoryMap).to.not.be.null;
+      expect(categoryMap.size).to.equal(3);
+
+      expect(categoryMap.get('seeding_cover_crop')).to.not.be.null;
+      expect(categoryMap.get('seeding_cover_crop').type).to.equal(
+        'taxonomy_term--log_category'
+      );
+
+      expect(categoryMap.get('seeding_tray')).to.not.be.null;
+      expect(categoryMap.get('seeding_tray').type).to.equal(
+        'taxonomy_term--log_category'
+      );
+    });
+  });
+
+  it('Get the logCategoryIdToAsset map', () => {
+    cy.wrap(farmosUtil.getLogCategoryIdToTermMap(farm)).then(
+      (categoryIdMap) => {
+        expect(categoryIdMap).to.not.be.null;
+        expect(categoryIdMap.size).to.equal(3);
+
+        cy.wrap(farmosUtil.getLogCategoryToTermMap(farm)).then(
+          (categoryNameMap) => {
+            const coverId = categoryNameMap.get('seeding_cover_crop').id;
+            expect(categoryIdMap.get(coverId).attributes.name).to.equal(
+              'seeding_cover_crop'
+            );
+            expect(categoryIdMap.get(coverId).type).to.equal(
+              'taxonomy_term--log_category'
+            );
+
+            const trayId = categoryNameMap.get('seeding_tray').id;
+            expect(categoryIdMap.get(trayId).attributes.name).to.equal(
+              'seeding_tray'
+            );
+            expect(categoryIdMap.get(trayId).type).to.equal(
+              'taxonomy_term--log_category'
+            );
+          }
+        );
+      }
+    );
+  });
+});

--- a/library/farmosUtil/farmosUtil.units.unit.cy.js
+++ b/library/farmosUtil/farmosUtil.units.unit.cy.js
@@ -1,0 +1,94 @@
+import * as farmosUtil from './farmosUtil.js';
+
+describe('Test the units utility functions', () => {
+  var farm = null;
+  before(() => {
+    cy.wrap(
+      farmosUtil
+        .getFarmOSInstance('http://farmos', 'farm', 'admin', 'admin')
+        .then((newFarm) => {
+          farm = newFarm;
+        })
+    );
+  });
+
+  beforeEach(() => {
+    cy.restoreLocalStorage();
+    cy.restoreSessionStorage();
+  });
+
+  afterEach(() => {
+    cy.saveLocalStorage();
+    cy.saveSessionStorage();
+  });
+
+  it('Get the units', () => {
+    cy.wrap(farmosUtil.getUnits(farm)).then((units) => {
+      expect(units).to.not.be.null;
+      expect(units.length).to.equal(5);
+
+      expect(units[0].attributes.name).to.equal('CELLS/TRAY');
+      expect(units[0].attributes.description.value).to.equal(
+        'The number of cells in a tray.'
+      );
+      expect(units[0].type).to.equal('taxonomy_term--unit');
+
+      expect(units[4].attributes.name).to.equal('TRAYS');
+      expect(units[4].attributes.description.value).to.equal(
+        'A number of seeding trays.'
+      );
+      expect(units[4].type).to.equal('taxonomy_term--unit');
+    });
+  });
+
+  it('Test that get units throws error if fetch fails', () => {
+    cy.intercept('GET', '**/api/taxonomy_term/unit?*', {
+      forceNetworkError: true,
+    });
+
+    cy.wrap(
+      farmosUtil
+        .getUnits(farm)
+        .then(() => {
+          throw new Error('Fetching units should have failed.');
+        })
+        .catch((error) => {
+          expect(error.message).to.equal('Unable to fetch units.');
+        })
+    );
+  });
+
+  it('Get the unitToTerm map', () => {
+    cy.wrap(farmosUtil.getUnitToTermMap(farm)).then((unitMap) => {
+      expect(unitMap).to.not.be.null;
+      expect(unitMap.size).to.equal(5);
+
+      expect(unitMap.get('Count')).to.not.be.null;
+      expect(unitMap.get('Count').type).to.equal('taxonomy_term--unit');
+
+      expect(unitMap.get('CELLS/TRAY')).to.not.be.null;
+      expect(unitMap.get('CELLS/TRAY').type).to.equal('taxonomy_term--unit');
+    });
+  });
+
+  it('Get the UnitIdToAsset map', () => {
+    cy.wrap(farmosUtil.getUnitIdToTermMap(farm)).then((unitIdMap) => {
+      expect(unitIdMap).to.not.be.null;
+      expect(unitIdMap.size).to.equal(5);
+
+      cy.wrap(farmosUtil.getUnitToTermMap(farm)).then((unitNameMap) => {
+        const countId = unitNameMap.get('Count').id;
+        expect(unitIdMap.get(countId).attributes.name).to.equal('Count');
+        expect(unitIdMap.get(countId).type).to.equal('taxonomy_term--unit');
+
+        const cellsPerTrayId = unitNameMap.get('CELLS/TRAY').id;
+        expect(unitIdMap.get(cellsPerTrayId).attributes.name).to.equal(
+          'CELLS/TRAY'
+        );
+        expect(unitIdMap.get(cellsPerTrayId).type).to.equal(
+          'taxonomy_term--unit'
+        );
+      });
+    });
+  });
+});


### PR DESCRIPTION
**Pull Request Description**

Adds functions and tests for them to the `farmosUtil.js` library for interacting with the taxonomy terms for units and for log types.

---

**Licensing Certification**

FarmData2 is a [Free Cultural Work](https://freedomdefined.org/Definition) and all accepted contributions are licensed as described in the LICENSE.md file. This requires that the contributor holds the rights to do so. By submitting this pull request **I certify that I satisfy the terms of the [Developer Certificate of Origin](https://developercertificate.org/)** for its contents.
