### PR TITLE
refactor(libs): caches fetched data

### DIFF
--- a/bin/printFarmosLogs.js
+++ b/bin/printFarmosLogs.js
@@ -2,8 +2,6 @@
 
 import * as farmosUtil from '../library/farmosUtil/farmosUtil.js';
 import { LocalStorage } from 'node-localstorage';
-import { dirname } from 'path';
-import { fileURLToPath } from 'url';
 
 /*
  * Setup the information for connecting to the farmOS instance
@@ -17,10 +15,9 @@ const pass = 'admin';
 
 /*
  * Get a local storage object that we'll use to simulate the
- *browser's localStorage and sessionStorage when running in node.
+ * browser's localStorage and sessionStorage when running in node.
  */
-const rootDir = dirname(dirname(dirname(fileURLToPath(import.meta.url))));
-let ls = new LocalStorage(rootDir + '/scratch');
+let ls = new LocalStorage('scratch');
 
 /*
  * Get a fully initialized and logged in instance of the farmOS.js

--- a/library/farmosUtil/farmosUtil.crops.unit.cy.js
+++ b/library/farmosUtil/farmosUtil.crops.unit.cy.js
@@ -36,20 +36,31 @@ describe('Test the crop utility functions', () => {
   });
 
   it('Test that getCrop throws error if fetch fails', () => {
+    farmosUtil.clearCachedCrops();
+
     cy.intercept('GET', '**/api/taxonomy_term/plant_type?*', {
       forceNetworkError: true,
     });
 
-    cy.wrap(
-      farmosUtil
-        .getCrops(farm)
-        .then(() => {
-          throw new Error('Fetching crops should have failed.');
-        })
-        .catch((error) => {
-          expect(error.message).to.equal('Unable to fetch crops.');
-        })
-    );
+    farmosUtil
+      .getCrops(farm)
+      .then(() => {
+        throw new Error('Fetching crops should have failed.');
+      })
+      .catch((error) => {
+        expect(error.message).to.equal('Unable to fetch crops.');
+      });
+  });
+
+  it('Test that getCrops result is cached', () => {
+    farmosUtil.clearCachedCrops();
+    expect(farmosUtil.getGlobalCrops()).to.be.null;
+    expect(sessionStorage.getItem('crops')).to.be.null;
+
+    farmosUtil.getCrops(farm).then(() => {
+      expect(farmosUtil.getGlobalCrops()).to.not.be.null;
+      expect(sessionStorage.getItem('crops')).to.not.be.null;
+    });
   });
 
   it('Get the cropNameMap', () => {

--- a/library/farmosUtil/farmosUtil.fieldAndBed.unit.cy.js
+++ b/library/farmosUtil/farmosUtil.fieldAndBed.unit.cy.js
@@ -36,6 +36,8 @@ describe('Test the land utility functions', () => {
   });
 
   it('Test that get fields and beds throws error if fetch fails', () => {
+    farmosUtil.clearCachedFieldsAndBeds();
+
     cy.intercept('GET', '**/api/asset/land?*', {
       forceNetworkError: true,
     });
@@ -50,6 +52,17 @@ describe('Test the land utility functions', () => {
           expect(error.message).to.equal('Unable to fetch fields and beds.');
         })
     );
+  });
+
+  it('Test that getFieldsAndBeds are cached', () => {
+    farmosUtil.clearCachedFieldsAndBeds();
+    expect(farmosUtil.getGlobalFieldsAndBeds()).to.be.null;
+    expect(sessionStorage.getItem('fields_and_beds')).to.be.null;
+
+    farmosUtil.getFieldsAndBeds(farm).then(() => {
+      expect(farmosUtil.getGlobalFieldsAndBeds()).to.not.be.null;
+      expect(sessionStorage.getItem('fields_and_beds')).to.not.be.null;
+    });
   });
 
   it('Get the FieldOrBedNameToAsset map', () => {
@@ -88,70 +101,6 @@ describe('Test the land utility functions', () => {
             'CHUAU-1'
           );
           expect(landIdMap.get(landChuau1Id).type).to.equal('asset--land');
-        }
-      );
-    });
-  });
-
-  it('Get the greenhouse structure assets', () => {
-    cy.wrap(farmosUtil.getGreenhouses(farm)).then((gh) => {
-      expect(gh).to.not.be.null;
-      expect(gh.length).to.equal(5);
-
-      expect(gh[0].attributes.name).to.equal('CHUAU');
-      expect(gh[0].type).to.equal('asset--structure');
-
-      expect(gh[4].attributes.name).to.equal('SEEDING BENCH');
-      expect(gh[4].type).to.equal('asset--structure');
-    });
-  });
-
-  it('Test that getGreenhouses throws error if fetch fails', () => {
-    cy.intercept('GET', '**/api/asset/structure?*', {
-      forceNetworkError: true,
-    });
-
-    cy.wrap(
-      farmosUtil
-        .getGreenhouses(farm)
-        .then(() => {
-          throw new Error('Fetching greenhouses should have failed.');
-        })
-        .catch((error) => {
-          expect(error.message).to.equal('Unable to fetch greenhouses.');
-        })
-    );
-  });
-
-  it('Get the GreenhouseNameToAsset map', () => {
-    cy.wrap(farmosUtil.getGreenhouseNameToAssetMap(farm)).then((ghNameMap) => {
-      expect(ghNameMap).to.not.be.null;
-      expect(ghNameMap.size).to.equal(5);
-
-      expect(ghNameMap.get('CHUAU')).to.not.be.null;
-      expect(ghNameMap.get('CHUAU').type).to.equal('asset--structure');
-
-      expect(ghNameMap.get('SEEDING BENCH')).to.not.be.null;
-      expect(ghNameMap.get('SEEDING BENCH').type).to.equal('asset--structure');
-
-      expect(ghNameMap.get('A')).to.be.undefined;
-    });
-  });
-
-  it('Get the GreenhouseIdToAsset map', () => {
-    cy.wrap(farmosUtil.getGreenhouseIdToAssetMap(farm)).then((ghIdMap) => {
-      expect(ghIdMap).to.not.be.null;
-      expect(ghIdMap.size).to.equal(5);
-
-      cy.wrap(farmosUtil.getGreenhouseNameToAssetMap(farm)).then(
-        (ghNameMap) => {
-          const chuauId = ghNameMap.get('CHUAU').id;
-          expect(ghIdMap.get(chuauId).attributes.name).to.equal('CHUAU');
-          expect(ghIdMap.get(chuauId).type).to.equal('asset--structure');
-
-          const sbId = ghNameMap.get('SEEDING BENCH').id;
-          expect(ghIdMap.get(sbId).attributes.name).to.equal('SEEDING BENCH');
-          expect(ghIdMap.get(sbId).type).to.equal('asset--structure');
         }
       );
     });

--- a/library/farmosUtil/farmosUtil.fieldAndBed.unit.cy.js
+++ b/library/farmosUtil/farmosUtil.fieldAndBed.unit.cy.js
@@ -42,16 +42,14 @@ describe('Test the land utility functions', () => {
       forceNetworkError: true,
     });
 
-    cy.wrap(
-      farmosUtil
-        .getFieldsAndBeds(farm)
-        .then(() => {
-          throw new Error('Fetching fields and beds should have failed.');
-        })
-        .catch((error) => {
-          expect(error.message).to.equal('Unable to fetch fields and beds.');
-        })
-    );
+    farmosUtil
+      .getFieldsAndBeds(farm)
+      .then(() => {
+        throw new Error('Fetching fields and beds should have failed.');
+      })
+      .catch((error) => {
+        expect(error.message).to.equal('Unable to fetch fields and beds.');
+      });
   });
 
   it('Test that getFieldsAndBeds are cached', () => {

--- a/library/farmosUtil/farmosUtil.greenhouses.unit.cy.js
+++ b/library/farmosUtil/farmosUtil.greenhouses.unit.cy.js
@@ -1,0 +1,101 @@
+import * as farmosUtil from './farmosUtil.js';
+
+describe('Test the greenhouse utility functions', () => {
+  var farm = null;
+  before(() => {
+    cy.wrap(
+      farmosUtil
+        .getFarmOSInstance('http://farmos', 'farm', 'admin', 'admin')
+        .then((newFarm) => {
+          farm = newFarm;
+        })
+    );
+  });
+
+  beforeEach(() => {
+    cy.restoreLocalStorage();
+    cy.restoreSessionStorage();
+  });
+
+  afterEach(() => {
+    cy.saveLocalStorage();
+    cy.saveSessionStorage();
+  });
+
+  it('Get the greenhouse structure assets', () => {
+    cy.wrap(farmosUtil.getGreenhouses(farm)).then((gh) => {
+      expect(gh).to.not.be.null;
+      expect(gh.length).to.equal(5);
+
+      expect(gh[0].attributes.name).to.equal('CHUAU');
+      expect(gh[0].type).to.equal('asset--structure');
+
+      expect(gh[4].attributes.name).to.equal('SEEDING BENCH');
+      expect(gh[4].type).to.equal('asset--structure');
+    });
+  });
+
+  it('Test that getGreenhouses throws error if fetch fails', () => {
+    farmosUtil.clearCachedGreenhouses();
+
+    cy.intercept('GET', '**/api/asset/structure?*', {
+      forceNetworkError: true,
+    });
+
+    cy.wrap(
+      farmosUtil
+        .getGreenhouses(farm)
+        .then(() => {
+          throw new Error('Fetching greenhouses should have failed.');
+        })
+        .catch((error) => {
+          expect(error.message).to.equal('Unable to fetch greenhouses.');
+        })
+    );
+  });
+
+  it('Test that getGreenhouses result is cached', () => {
+    farmosUtil.clearCachedGreenhouses();
+    expect(farmosUtil.getGlobalGreenhouses()).to.be.null;
+    expect(sessionStorage.getItem('greenhouses')).to.be.null;
+
+    farmosUtil.getGreenhouses(farm).then(() => {
+      expect(farmosUtil.getGlobalGreenhouses()).to.not.be.null;
+      expect(sessionStorage.getItem('greenhouses')).to.not.be.null;
+    });
+  });
+
+  it('Get the GreenhouseNameToAsset map', () => {
+    cy.wrap(farmosUtil.getGreenhouseNameToAssetMap(farm)).then((ghNameMap) => {
+      expect(ghNameMap).to.not.be.null;
+      expect(ghNameMap.size).to.equal(5);
+
+      expect(ghNameMap.get('CHUAU')).to.not.be.null;
+      expect(ghNameMap.get('CHUAU').type).to.equal('asset--structure');
+
+      expect(ghNameMap.get('SEEDING BENCH')).to.not.be.null;
+      expect(ghNameMap.get('SEEDING BENCH').type).to.equal('asset--structure');
+
+      expect(ghNameMap.get('A')).to.be.undefined;
+    });
+  });
+
+  it('Get the GreenhouseIdToAsset map', () => {
+    cy.wrap(farmosUtil.getGreenhouseIdToAssetMap(farm)).then((ghIdMap) => {
+      expect(ghIdMap).to.not.be.null;
+      expect(ghIdMap.size).to.equal(5);
+
+      cy.wrap(farmosUtil.getGreenhouseNameToAssetMap(farm)).then(
+        (ghNameMap) => {
+          const chuauId = ghNameMap.get('CHUAU').id;
+          expect(ghIdMap.get(chuauId).attributes.name).to.equal('CHUAU');
+          expect(ghIdMap.get(chuauId).type).to.equal('asset--structure');
+
+          const sbId = ghNameMap.get('SEEDING BENCH').id;
+          expect(ghIdMap.get(sbId).attributes.name).to.equal('SEEDING BENCH');
+          expect(ghIdMap.get(sbId).type).to.equal('asset--structure');
+        }
+      );
+    });
+  });
+});

--- a/library/farmosUtil/farmosUtil.greenhouses.unit.cy.js
+++ b/library/farmosUtil/farmosUtil.greenhouses.unit.cy.js
@@ -42,16 +42,14 @@ describe('Test the greenhouse utility functions', () => {
       forceNetworkError: true,
     });
 
-    cy.wrap(
-      farmosUtil
-        .getGreenhouses(farm)
-        .then(() => {
-          throw new Error('Fetching greenhouses should have failed.');
-        })
-        .catch((error) => {
-          expect(error.message).to.equal('Unable to fetch greenhouses.');
-        })
-    );
+    farmosUtil
+      .getGreenhouses(farm)
+      .then(() => {
+        throw new Error('Fetching greenhouses should have failed.');
+      })
+      .catch((error) => {
+        expect(error.message).to.equal('Unable to fetch greenhouses.');
+      });
   });
 
   it('Test that getGreenhouses result is cached', () => {

--- a/library/farmosUtil/farmosUtil.js
+++ b/library/farmosUtil/farmosUtil.js
@@ -311,7 +311,7 @@ export async function getUserIdToUserMap(farm) {
 var global_fields_and_beds = null;
 
 /**
- * Clear the cached results from prior calls to the `getUsers` function.
+ * Clear the cached results from prior calls to the `getFieldsAndBeds` function.
  * This is useful when an action may change the users that exist in the
  * system
  */
@@ -427,6 +427,31 @@ export async function getFieldOrBedIdToAssetMap(farm) {
   return map;
 }
 
+// Used to cache result of the getGreenhouses function.
+var global_greenhouses = null;
+
+/**
+ * Clear the cached results from prior calls to the `getGreenhouses` function.
+ * This is useful when an action may change the users that exist in the
+ * system
+ */
+export function clearCachedGreenhouses() {
+  global_greenhouses = null;
+  libSessionStorage.removeItem('greenhouses');
+}
+
+/**
+ * @private
+ *
+ * Get the `global_greenhouses` object.  This is useful for testing to ensure
+ * that the global is set by the appropriate functions.
+ *
+ * @returns the `global_greenhouses` object
+ */
+export function getGlobalGreenhouses() {
+  return global_greenhouses;
+}
+
 /**
  * Get the asset objects for all of the active structures that represent greenhouses.
  * These are the assets of type `asset--structure` that have `structure_type` of
@@ -441,6 +466,15 @@ export async function getFieldOrBedIdToAssetMap(farm) {
  * @returns an array of all of land assets representing greenhouses.
  */
 export async function getGreenhouses(farm) {
+  if (global_greenhouses) {
+    return global_greenhouses;
+  }
+
+  if (libSessionStorage.getItem('greenhouses') != null) {
+    global_greenhouses = JSON.parse(libSessionStorage.getItem('greenhouses'));
+    return global_greenhouses;
+  }
+
   const greenhouses = await farm.asset.fetch({
     filter: {
       type: 'asset--structure',
@@ -458,7 +492,9 @@ export async function getGreenhouses(farm) {
     o1.attributes.name.localeCompare(o2.attributes.name)
   );
 
-  return greenhouses.data;
+  libSessionStorage.setItem('greenhouses', JSON.stringify(greenhouses.data));
+  global_greenhouses = greenhouses.data;
+  return global_greenhouses;
 }
 
 /**

--- a/library/farmosUtil/farmosUtil.logCategories.unit.cy.js
+++ b/library/farmosUtil/farmosUtil.logCategories.unit.cy.js
@@ -42,20 +42,31 @@ describe('Test the log categories utility functions', () => {
   });
 
   it('Test that get units throws error if fetch fails', () => {
+    farmosUtil.clearCachedLogCategories();
+
     cy.intercept('GET', '**/api/taxonomy_term/log_category?*', {
       forceNetworkError: true,
     });
 
-    cy.wrap(
-      farmosUtil
-        .getLogCategories(farm)
-        .then(() => {
-          throw new Error('Fetching log categories should have failed.');
-        })
-        .catch((error) => {
-          expect(error.message).to.equal('Unable to fetch log categories.');
-        })
-    );
+    farmosUtil
+      .getLogCategories(farm)
+      .then(() => {
+        throw new Error('Fetching log categories should have failed.');
+      })
+      .catch((error) => {
+        expect(error.message).to.equal('Unable to fetch log categories.');
+      });
+  });
+
+  it('Test that getLogCategories result is cached', () => {
+    farmosUtil.clearCachedLogCategories();
+    expect(farmosUtil.getGlobalLogCategories()).to.be.null;
+    expect(sessionStorage.getItem('log_categories')).to.be.null;
+
+    farmosUtil.getLogCategories(farm).then(() => {
+      expect(farmosUtil.getGlobalLogCategories()).to.not.be.null;
+      expect(sessionStorage.getItem('log_categories')).to.not.be.null;
+    });
   });
 
   it('Get the logCategoryToTerm map', () => {

--- a/library/farmosUtil/farmosUtil.traySizes.unit.cy.js
+++ b/library/farmosUtil/farmosUtil.traySizes.unit.cy.js
@@ -42,20 +42,31 @@ describe('Test the tray sizes utility functions', () => {
   });
 
   it('Test that get tray sizes throws error if fetch fails', () => {
+    farmosUtil.clearCachedTraySizes();
+
     cy.intercept('GET', '**/api/taxonomy_term/tray_size?*', {
       forceNetworkError: true,
     });
 
-    cy.wrap(
-      farmosUtil
-        .getTraySizes(farm)
-        .then(() => {
-          throw new Error('Fetching tray sizes should have failed.');
-        })
-        .catch((error) => {
-          expect(error.message).to.equal('Unable to fetch tray sizes.');
-        })
-    );
+    farmosUtil
+      .getTraySizes(farm)
+      .then(() => {
+        throw new Error('Fetching tray sizes should have failed.');
+      })
+      .catch((error) => {
+        expect(error.message).to.equal('Unable to fetch tray sizes.');
+      });
+  });
+
+  it('Test that getTraySizes result is cached', () => {
+    farmosUtil.clearCachedTraySizes();
+    expect(farmosUtil.getGlobalTraySizes()).to.be.null;
+    expect(sessionStorage.getItem('tray_sizes')).to.be.null;
+
+    farmosUtil.getTraySizes(farm).then(() => {
+      expect(farmosUtil.getGlobalTraySizes()).to.not.be.null;
+      expect(sessionStorage.getItem('tray_sizes')).to.not.be.null;
+    });
   });
 
   it('Get the TraySizeToTerm map', () => {

--- a/library/farmosUtil/farmosUtil.units.unit.cy.js
+++ b/library/farmosUtil/farmosUtil.units.unit.cy.js
@@ -42,20 +42,31 @@ describe('Test the units utility functions', () => {
   });
 
   it('Test that get units throws error if fetch fails', () => {
+    farmosUtil.clearCachedUnits();
+
     cy.intercept('GET', '**/api/taxonomy_term/unit?*', {
       forceNetworkError: true,
     });
 
-    cy.wrap(
-      farmosUtil
-        .getUnits(farm)
-        .then(() => {
-          throw new Error('Fetching units should have failed.');
-        })
-        .catch((error) => {
-          expect(error.message).to.equal('Unable to fetch units.');
-        })
-    );
+    farmosUtil
+      .getUnits(farm)
+      .then(() => {
+        throw new Error('Fetching units should have failed.');
+      })
+      .catch((error) => {
+        expect(error.message).to.equal('Unable to fetch units.');
+      });
+  });
+
+  it('Test that getUnits result is cached', () => {
+    farmosUtil.clearCachedUnits();
+    expect(farmosUtil.getGlobalUnits()).to.be.null;
+    expect(sessionStorage.getItem('units')).to.be.null;
+
+    farmosUtil.getUnits(farm).then(() => {
+      expect(farmosUtil.getGlobalUnits()).to.not.be.null;
+      expect(sessionStorage.getItem('units')).to.not.be.null;
+    });
   });
 
   it('Get the unitToTerm map', () => {

--- a/library/farmosUtil/farmosUtil.users.unit.cy.js
+++ b/library/farmosUtil/farmosUtil.users.unit.cy.js
@@ -43,11 +43,11 @@ describe('Test the user utility functions', () => {
   });
 
   it('Test that getUsers throws error if fetch fails', () => {
+    farmosUtil.clearCachedUsers();
+
     cy.intercept('GET', '**/api/user/user?*', {
       forceNetworkError: true,
     });
-
-    farmosUtil.clearCachedUsers();
 
     farmosUtil
       .getUsers(farm)

--- a/library/farmosUtil/farmosUtil.users.unit.cy.js
+++ b/library/farmosUtil/farmosUtil.users.unit.cy.js
@@ -42,22 +42,32 @@ describe('Test the user utility functions', () => {
     });
   });
 
-  // eslint-disable-next-line cypress/no-async-tests
   it('Test that getUsers throws error if fetch fails', () => {
     cy.intercept('GET', '**/api/user/user?*', {
       forceNetworkError: true,
     });
 
-    cy.wrap(
-      farmosUtil
-        .getUsers(farm)
-        .then(() => {
-          throw new Error('Fetching users should have failed.');
-        })
-        .catch((error) => {
-          expect(error.message).to.equal('Unable to fetch users.');
-        })
-    );
+    farmosUtil.clearCachedUsers();
+
+    farmosUtil
+      .getUsers(farm)
+      .then(() => {
+        throw new Error('Fetching users should have failed.');
+      })
+      .catch((error) => {
+        expect(error.message).to.equal('Unable to fetch users.');
+      });
+  });
+
+  it('Test that getUsers is cached', () => {
+    farmosUtil.clearCachedUsers();
+    expect(farmosUtil.getGlobalUsers()).to.be.null;
+    expect(sessionStorage.getItem('users')).to.be.null;
+
+    farmosUtil.getUsers(farm).then(() => {
+      expect(farmosUtil.getGlobalUsers()).to.not.be.null;
+      expect(sessionStorage.getItem('users')).to.not.be.null;
+    });
   });
 
   it('Get the usernameMap', () => {


### PR DESCRIPTION
**Pull Request Description**

All of the functions that make API requests have been updated to cache their results in both a global variable (as a JS object) and in the `sessionStorage` as stringified JSON.  This ensures that when multiple components or library functions make requests for the same data, an actual API request only occurs once.

Closes #68 

---

**Licensing Certification**

FarmData2 is a [Free Cultural Work](https://freedomdefined.org/Definition) and all accepted contributions are licensed as described in the LICENSE.md file. This requires that the contributor holds the rights to do so. By submitting this pull request **I certify that I satisfy the terms of the [Developer Certificate of Origin](https://developercertificate.org/)** for its contents.
