### PR TITLE
refactor(lib): removes need to pass  to farmosUtil functoins

### DIFF
--- a/components/CropSelector/CropSelector.events.comp.cy.js
+++ b/components/CropSelector/CropSelector.events.comp.cy.js
@@ -1,4 +1,5 @@
 import CropSelector from '@comps/CropSelector/CropSelector.vue';
+import * as farmosUtil from '@libs/farmosUtil/farmosUtil.js';
 
 describe('Test the CropSelector events', () => {
   beforeEach(() => {
@@ -47,5 +48,25 @@ describe('Test the CropSelector events', () => {
         cy.get('@updateSpy').should('have.been.calledOnce');
         cy.get('@updateSpy').should('have.been.calledWith', 'ASPARAGUS');
       });
+  });
+
+  it('Test that error event is emitted', () => {
+    farmosUtil.clearCachedCrops();
+
+    const errorSpy = cy.spy().as('errorSpy');
+
+    cy.intercept('GET', '**/api/taxonomy_term/plant_type?*', {
+      forceNetworkError: true,
+    });
+
+    cy.mount(CropSelector, {
+      props: {
+        onError: errorSpy,
+      },
+    }).then(() => {
+      cy.get('@errorSpy')
+        .should('have.been.calledOnce')
+        .should('have.been.calledWith', 'Unable to fetch crops.');
+    });
   });
 });

--- a/components/CropSelector/CropSelector.vue
+++ b/components/CropSelector/CropSelector.vue
@@ -102,32 +102,23 @@ export default {
   watch: {},
   created() {
     farmosUtil
-      .getFarmOSInstance()
-      .then((farm) => {
-        farmosUtil
-          .getCropNameToTermMap(farm)
-          .then((cropMap) => {
-            this.cropList = Array.from(cropMap.keys());
+      .getCropNameToTermMap()
+      .then((cropMap) => {
+        this.cropList = Array.from(cropMap.keys());
 
-            /**
-             * The select has been populated with the list of crops and the component is ready to be used.
-             */
-            this.$emit('ready');
-          })
-          .catch((error) => {
-            console.error('CropSelector: Error fetching crops.');
-            console.error(error);
-            /**
-             * An error occurred when communicating with the farmOS server.
-             * @property {string} msg an error message.
-             */
-            this.$emit('error', 'Unable to fetch crops.');
-          });
+        /**
+         * The select has been populated with the list of crops and the component is ready to be used.
+         */
+        this.$emit('ready');
       })
       .catch((error) => {
-        console.error('CropSelector: Error connecting to farm.');
+        console.error('CropSelector: Error fetching crops.');
         console.error(error);
-        this.$emit('error', 'Unable to connect to farmOS server.');
+        /**
+         * An error occurred when communicating with the farmOS server.
+         * @property {string} msg an error message.
+         */
+        this.$emit('error', 'Unable to fetch crops.');
       });
   },
 };

--- a/components/LocationSelector/LocationSelector.events.comp.cy.js
+++ b/components/LocationSelector/LocationSelector.events.comp.cy.js
@@ -1,4 +1,5 @@
 import LocationSelector from '@comps/LocationSelector/LocationSelector.vue';
+import * as farmosUtil from '@libs/farmosUtil/farmosUtil.js';
 
 describe('Test the LocationSelector component events', () => {
   beforeEach(() => {
@@ -49,5 +50,47 @@ describe('Test the LocationSelector component events', () => {
         cy.get('@updateSpy').should('have.been.calledOnce');
         cy.get('@updateSpy').should('have.been.calledWith', 'CHUAU');
       });
+  });
+
+  it('Test that error event is emitted when fetching fields and beds fails', () => {
+    farmosUtil.clearCachedFieldsAndBeds();
+
+    const errorSpy = cy.spy().as('errorSpy');
+
+    cy.intercept('GET', '**/api/asset/land?*', {
+      forceNetworkError: true,
+    });
+
+    cy.mount(LocationSelector, {
+      props: {
+        includeFields: true,
+        onError: errorSpy,
+      },
+    }).then(() => {
+      cy.get('@errorSpy')
+        .should('have.been.calledOnce')
+        .should('have.been.calledWith', 'Unable to fetch locations.');
+    });
+  });
+
+  it('Test that error event is emitted when fetching greenhouses fails', () => {
+    farmosUtil.clearCachedGreenhouses();
+
+    const errorSpy = cy.spy().as('errorSpy');
+
+    cy.intercept('GET', '**/api/asset/structure?*', {
+      forceNetworkError: true,
+    });
+
+    cy.mount(LocationSelector, {
+      props: {
+        includeGreenhouses: true,
+        onError: errorSpy,
+      },
+    }).then(() => {
+      cy.get('@errorSpy')
+        .should('have.been.calledOnce')
+        .should('have.been.calledWith', 'Unable to fetch locations.');
+    });
   });
 });

--- a/components/TraySizeSelector/TraySizeSelector.events.comp.cy.js
+++ b/components/TraySizeSelector/TraySizeSelector.events.comp.cy.js
@@ -1,4 +1,5 @@
 import TraySizeSelector from '@comps/TraySizeSelector/TraySizeSelector.vue';
+import * as farmosUtil from '@libs/farmosUtil/farmosUtil.js';
 
 describe('Test the TraySizeSelector events', () => {
   beforeEach(() => {
@@ -47,5 +48,25 @@ describe('Test the TraySizeSelector events', () => {
         cy.get('@updateSpy').should('have.been.calledOnce');
         cy.get('@updateSpy').should('have.been.calledWith', '50');
       });
+  });
+
+  it('Test that error event is emitted', () => {
+    farmosUtil.clearCachedTraySizes();
+
+    const errorSpy = cy.spy().as('errorSpy');
+
+    cy.intercept('GET', '**/api/taxonomy_term/tray_size?*', {
+      forceNetworkError: true,
+    });
+
+    cy.mount(TraySizeSelector, {
+      props: {
+        onError: errorSpy,
+      },
+    }).then(() => {
+      cy.get('@errorSpy')
+        .should('have.been.calledOnce')
+        .should('have.been.calledWith', 'Unable to fetch tray sizes.');
+    });
   });
 });

--- a/components/TraySizeSelector/TraySizeSelector.vue
+++ b/components/TraySizeSelector/TraySizeSelector.vue
@@ -104,32 +104,23 @@ export default {
   watch: {},
   created() {
     farmosUtil
-      .getFarmOSInstance()
-      .then((farm) => {
-        farmosUtil
-          .getTraySizeToTermMap(farm)
-          .then((traySizeMap) => {
-            this.traySizeList = Array.from(traySizeMap.keys());
+      .getTraySizeToTermMap()
+      .then((traySizeMap) => {
+        this.traySizeList = Array.from(traySizeMap.keys());
 
-            /**
-             * The select has been populated with the list of tray sizes and the component is ready to be used.
-             */
-            this.$emit('ready');
-          })
-          .catch((error) => {
-            console.error('TraySizeSelector: Error fetching tray sizes.');
-            console.error(error);
-            /**
-             * An error occurred when communicating with the farmOS server.
-             * @property {string} msg an error message.
-             */
-            this.$emit('error', 'Unable to fetch tray sizes.');
-          });
+        /**
+         * The select has been populated with the list of tray sizes and the component is ready to be used.
+         */
+        this.$emit('ready');
       })
       .catch((error) => {
-        console.error('TraySizeSelector: Error connecting to farm.');
+        console.error('TraySizeSelector: Error fetching tray sizes.');
         console.error(error);
-        this.$emit('error', 'Unable to connect to farmOS server.');
+        /**
+         * An error occurred when communicating with the farmOS server.
+         * @property {string} msg an error message.
+         */
+        this.$emit('error', 'Unable to fetch tray sizes.');
       });
   },
 };

--- a/library/farmosUtil/farmosUtil.crops.unit.cy.js
+++ b/library/farmosUtil/farmosUtil.crops.unit.cy.js
@@ -1,17 +1,6 @@
 import * as farmosUtil from './farmosUtil.js';
 
 describe('Test the crop utility functions', () => {
-  var farm = null;
-  before(() => {
-    cy.wrap(
-      farmosUtil
-        .getFarmOSInstance('http://farmos', 'farm', 'admin', 'admin')
-        .then((newFarm) => {
-          farm = newFarm;
-        })
-    );
-  });
-
   beforeEach(() => {
     cy.restoreLocalStorage();
     cy.restoreSessionStorage();
@@ -23,7 +12,7 @@ describe('Test the crop utility functions', () => {
   });
 
   it('Get the crops', () => {
-    cy.wrap(farmosUtil.getCrops(farm)).then((crops) => {
+    cy.wrap(farmosUtil.getCrops()).then((crops) => {
       expect(crops).to.not.be.null;
       expect(crops.length).to.equal(111);
 
@@ -43,7 +32,7 @@ describe('Test the crop utility functions', () => {
     });
 
     farmosUtil
-      .getCrops(farm)
+      .getCrops()
       .then(() => {
         throw new Error('Fetching crops should have failed.');
       })
@@ -57,14 +46,14 @@ describe('Test the crop utility functions', () => {
     expect(farmosUtil.getGlobalCrops()).to.be.null;
     expect(sessionStorage.getItem('crops')).to.be.null;
 
-    farmosUtil.getCrops(farm).then(() => {
+    farmosUtil.getCrops().then(() => {
       expect(farmosUtil.getGlobalCrops()).to.not.be.null;
       expect(sessionStorage.getItem('crops')).to.not.be.null;
     });
   });
 
   it('Get the cropNameMap', () => {
-    cy.wrap(farmosUtil.getCropNameToTermMap(farm)).then((cropNameMap) => {
+    cy.wrap(farmosUtil.getCropNameToTermMap()).then((cropNameMap) => {
       expect(cropNameMap).to.not.be.null;
       expect(cropNameMap.size).to.equal(111);
 
@@ -87,11 +76,11 @@ describe('Test the crop utility functions', () => {
   });
 
   it('Get the cropIdMap', () => {
-    cy.wrap(farmosUtil.getCropIdToTermMap(farm)).then((cropIdMap) => {
+    cy.wrap(farmosUtil.getCropIdToTermMap()).then((cropIdMap) => {
       expect(cropIdMap).to.not.be.null;
       expect(cropIdMap.size).to.equal(111);
 
-      cy.wrap(farmosUtil.getCropNameToTermMap(farm)).then((cropNameMap) => {
+      cy.wrap(farmosUtil.getCropNameToTermMap()).then((cropNameMap) => {
         const arugulaId = cropNameMap.get('ARUGULA').id;
         expect(cropIdMap.get(arugulaId).attributes.name).to.equal('ARUGULA');
         expect(cropIdMap.get(arugulaId).type).to.equal(

--- a/library/farmosUtil/farmosUtil.fieldsAndBeds.unit.cy.js
+++ b/library/farmosUtil/farmosUtil.fieldsAndBeds.unit.cy.js
@@ -1,17 +1,6 @@
 import * as farmosUtil from './farmosUtil.js';
 
 describe('Test the land utility functions', () => {
-  var farm = null;
-  before(() => {
-    cy.wrap(
-      farmosUtil
-        .getFarmOSInstance('http://farmos', 'farm', 'admin', 'admin')
-        .then((newFarm) => {
-          farm = newFarm;
-        })
-    );
-  });
-
   beforeEach(() => {
     cy.restoreLocalStorage();
     cy.restoreSessionStorage();
@@ -23,7 +12,7 @@ describe('Test the land utility functions', () => {
   });
 
   it('Get the field and bed land assets', () => {
-    cy.wrap(farmosUtil.getFieldsAndBeds(farm)).then((land) => {
+    cy.wrap(farmosUtil.getFieldsAndBeds()).then((land) => {
       expect(land).to.not.be.null;
       expect(land.length).to.equal(65);
 
@@ -43,7 +32,7 @@ describe('Test the land utility functions', () => {
     });
 
     farmosUtil
-      .getFieldsAndBeds(farm)
+      .getFieldsAndBeds()
       .then(() => {
         throw new Error('Fetching fields and beds should have failed.');
       })
@@ -57,50 +46,44 @@ describe('Test the land utility functions', () => {
     expect(farmosUtil.getGlobalFieldsAndBeds()).to.be.null;
     expect(sessionStorage.getItem('fields_and_beds')).to.be.null;
 
-    farmosUtil.getFieldsAndBeds(farm).then(() => {
+    farmosUtil.getFieldsAndBeds().then(() => {
       expect(farmosUtil.getGlobalFieldsAndBeds()).to.not.be.null;
       expect(sessionStorage.getItem('fields_and_beds')).to.not.be.null;
     });
   });
 
   it('Get the FieldOrBedNameToAsset map', () => {
-    cy.wrap(farmosUtil.getFieldOrBedNameToAssetMap(farm)).then(
-      (landNameMap) => {
-        expect(landNameMap).to.not.be.null;
-        expect(landNameMap.size).to.equal(65);
+    cy.wrap(farmosUtil.getFieldOrBedNameToAssetMap()).then((landNameMap) => {
+      expect(landNameMap).to.not.be.null;
+      expect(landNameMap.size).to.equal(65);
 
-        expect(landNameMap.get('A')).to.not.be.null;
-        expect(landNameMap.get('A').type).to.equal('asset--land');
+      expect(landNameMap.get('A')).to.not.be.null;
+      expect(landNameMap.get('A').type).to.equal('asset--land');
 
-        expect(landNameMap.get('Z')).to.not.be.null;
-        expect(landNameMap.get('Z').type).to.equal('asset--land');
+      expect(landNameMap.get('Z')).to.not.be.null;
+      expect(landNameMap.get('Z').type).to.equal('asset--land');
 
-        expect(landNameMap.get('CHUAU-1')).to.not.be.null;
-        expect(landNameMap.get('CHUAU-1').type).to.equal('asset--land');
+      expect(landNameMap.get('CHUAU-1')).to.not.be.null;
+      expect(landNameMap.get('CHUAU-1').type).to.equal('asset--land');
 
-        expect(landNameMap.get('CHUAU')).to.be.undefined;
-      }
-    );
+      expect(landNameMap.get('CHUAU')).to.be.undefined;
+    });
   });
 
   it('Get the FieldOrBedIdToAsset map', () => {
-    cy.wrap(farmosUtil.getFieldOrBedIdToAssetMap(farm)).then((landIdMap) => {
+    cy.wrap(farmosUtil.getFieldOrBedIdToAssetMap()).then((landIdMap) => {
       expect(landIdMap).to.not.be.null;
       expect(landIdMap.size).to.equal(65);
 
-      cy.wrap(farmosUtil.getFieldOrBedNameToAssetMap(farm)).then(
-        (landNameMap) => {
-          const landAId = landNameMap.get('A').id;
-          expect(landIdMap.get(landAId).attributes.name).to.equal('A');
-          expect(landIdMap.get(landAId).type).to.equal('asset--land');
+      cy.wrap(farmosUtil.getFieldOrBedNameToAssetMap()).then((landNameMap) => {
+        const landAId = landNameMap.get('A').id;
+        expect(landIdMap.get(landAId).attributes.name).to.equal('A');
+        expect(landIdMap.get(landAId).type).to.equal('asset--land');
 
-          const landChuau1Id = landNameMap.get('CHUAU-1').id;
-          expect(landIdMap.get(landChuau1Id).attributes.name).to.equal(
-            'CHUAU-1'
-          );
-          expect(landIdMap.get(landChuau1Id).type).to.equal('asset--land');
-        }
-      );
+        const landChuau1Id = landNameMap.get('CHUAU-1').id;
+        expect(landIdMap.get(landChuau1Id).attributes.name).to.equal('CHUAU-1');
+        expect(landIdMap.get(landChuau1Id).type).to.equal('asset--land');
+      });
     });
   });
 });

--- a/library/farmosUtil/farmosUtil.greenhouses.unit.cy.js
+++ b/library/farmosUtil/farmosUtil.greenhouses.unit.cy.js
@@ -1,17 +1,6 @@
 import * as farmosUtil from './farmosUtil.js';
 
 describe('Test the greenhouse utility functions', () => {
-  var farm = null;
-  before(() => {
-    cy.wrap(
-      farmosUtil
-        .getFarmOSInstance('http://farmos', 'farm', 'admin', 'admin')
-        .then((newFarm) => {
-          farm = newFarm;
-        })
-    );
-  });
-
   beforeEach(() => {
     cy.restoreLocalStorage();
     cy.restoreSessionStorage();
@@ -23,7 +12,7 @@ describe('Test the greenhouse utility functions', () => {
   });
 
   it('Get the greenhouse structure assets', () => {
-    cy.wrap(farmosUtil.getGreenhouses(farm)).then((gh) => {
+    cy.wrap(farmosUtil.getGreenhouses()).then((gh) => {
       expect(gh).to.not.be.null;
       expect(gh.length).to.equal(5);
 
@@ -43,7 +32,7 @@ describe('Test the greenhouse utility functions', () => {
     });
 
     farmosUtil
-      .getGreenhouses(farm)
+      .getGreenhouses()
       .then(() => {
         throw new Error('Fetching greenhouses should have failed.');
       })
@@ -57,14 +46,14 @@ describe('Test the greenhouse utility functions', () => {
     expect(farmosUtil.getGlobalGreenhouses()).to.be.null;
     expect(sessionStorage.getItem('greenhouses')).to.be.null;
 
-    farmosUtil.getGreenhouses(farm).then(() => {
+    farmosUtil.getGreenhouses().then(() => {
       expect(farmosUtil.getGlobalGreenhouses()).to.not.be.null;
       expect(sessionStorage.getItem('greenhouses')).to.not.be.null;
     });
   });
 
   it('Get the GreenhouseNameToAsset map', () => {
-    cy.wrap(farmosUtil.getGreenhouseNameToAssetMap(farm)).then((ghNameMap) => {
+    cy.wrap(farmosUtil.getGreenhouseNameToAssetMap()).then((ghNameMap) => {
       expect(ghNameMap).to.not.be.null;
       expect(ghNameMap.size).to.equal(5);
 
@@ -79,21 +68,19 @@ describe('Test the greenhouse utility functions', () => {
   });
 
   it('Get the GreenhouseIdToAsset map', () => {
-    cy.wrap(farmosUtil.getGreenhouseIdToAssetMap(farm)).then((ghIdMap) => {
+    cy.wrap(farmosUtil.getGreenhouseIdToAssetMap()).then((ghIdMap) => {
       expect(ghIdMap).to.not.be.null;
       expect(ghIdMap.size).to.equal(5);
 
-      cy.wrap(farmosUtil.getGreenhouseNameToAssetMap(farm)).then(
-        (ghNameMap) => {
-          const chuauId = ghNameMap.get('CHUAU').id;
-          expect(ghIdMap.get(chuauId).attributes.name).to.equal('CHUAU');
-          expect(ghIdMap.get(chuauId).type).to.equal('asset--structure');
+      cy.wrap(farmosUtil.getGreenhouseNameToAssetMap()).then((ghNameMap) => {
+        const chuauId = ghNameMap.get('CHUAU').id;
+        expect(ghIdMap.get(chuauId).attributes.name).to.equal('CHUAU');
+        expect(ghIdMap.get(chuauId).type).to.equal('asset--structure');
 
-          const sbId = ghNameMap.get('SEEDING BENCH').id;
-          expect(ghIdMap.get(sbId).attributes.name).to.equal('SEEDING BENCH');
-          expect(ghIdMap.get(sbId).type).to.equal('asset--structure');
-        }
-      );
+        const sbId = ghNameMap.get('SEEDING BENCH').id;
+        expect(ghIdMap.get(sbId).attributes.name).to.equal('SEEDING BENCH');
+        expect(ghIdMap.get(sbId).type).to.equal('asset--structure');
+      });
     });
   });
 });

--- a/library/farmosUtil/farmosUtil.js
+++ b/library/farmosUtil/farmosUtil.js
@@ -87,19 +87,19 @@ export async function getFarmOSInstance(
     libSessionStorage = sessionStorage;
   }
 
-  const config = {
-    host: hostURL,
-    clientId: client,
-    getToken: () => JSON.parse(libLocalStorage.getItem('token')),
-    setToken: (token) =>
-      libLocalStorage.setItem('token', JSON.stringify(token)),
-  };
-  const options = { remote: config };
-
   // Only create a new farm object if we don't already have one in global_farm.
   let newfarm = false;
   if (!global_farm) {
     newfarm = true;
+
+    const config = {
+      host: hostURL,
+      clientId: client,
+      getToken: () => JSON.parse(libLocalStorage.getItem('token')),
+      setToken: (token) =>
+        libLocalStorage.setItem('token', JSON.stringify(token)),
+    };
+    const options = { remote: config };
 
     /*
      * Enable this to be used both in Node, where farmOS is
@@ -236,13 +236,14 @@ export function getGlobalUsers() {
  * Use the [`clearCachedUsers`]{@link #module_farmosUtil.clearCachedUsers}
  * function to clear the cache.
  *
- * @param {object} farm a `farmOS` object returned from `getFarmOSInstance`.
  * @returns an array of farmOS `user--user` objects.
  */
-export async function getUsers(farm) {
+export async function getUsers() {
   if (global_users) {
     return global_users;
   }
+
+  const farm = await getFarmOSInstance();
 
   if (libSessionStorage.getItem('users') != null) {
     global_users = JSON.parse(libSessionStorage.getItem('users'));
@@ -277,11 +278,10 @@ export async function getUsers(farm) {
  * NOTE: The returned `Map` is built on the value returned by
  * [getUsers]{@link #module_farmosUtil.getUsers}.
  *
- * @param {object} farm a `farmOS` object returned from `getFarmOSInstance`.
  * @returns an `Map` from the user `display_name` to the `user--user` object.
  */
-export async function getUsernameToUserMap(farm) {
-  const users = await getUsers(farm);
+export async function getUsernameToUserMap() {
+  const users = await getUsers();
 
   const map = new Map(
     users.map((user) => [user.attributes.display_name, user])
@@ -296,11 +296,10 @@ export async function getUsernameToUserMap(farm) {
  * NOTE: The returned `Map` is built on the value returned by
  * [getUsers]{@link #module_farmosUtil.getUsers}.
  *
- * @param {object} farm a `farmOS` object returned from `getFarmOSInstance`.
  * @returns an `Map` from the user `display_name` to the `user--user` object.
  */
-export async function getUserIdToUserMap(farm) {
-  const users = await getUsers(farm);
+export async function getUserIdToUserMap() {
+  const users = await getUsers();
 
   const map = new Map(users.map((user) => [user.id, user]));
 
@@ -342,16 +341,17 @@ export function getGlobalFieldsAndBeds() {
  * Use the [`clearCachedFieldsAndBeds`]{@link #module_farmosUtil.clearCachedFieldsAndBeds}
  * function to clear the cache.
  *
- * @param {object} farm a `farmOS` object returned from `getFarmOSInstance`.
  * @returns a array of all of land assets representing fields or beds.
  */
-export async function getFieldsAndBeds(farm) {
+export async function getFieldsAndBeds() {
   // Done as two requests for now because of a bug in the farmOS.js library.
   // https://github.com/farmOS/farmOS.js/issues/86
 
   if (global_fields_and_beds) {
     return global_fields_and_beds;
   }
+
+  const farm = await getFarmOSInstance();
 
   if (libSessionStorage.getItem('fields_and_beds') != null) {
     global_fields_and_beds = JSON.parse(
@@ -397,11 +397,10 @@ export async function getFieldsAndBeds(farm) {
  *
  * NOTE: The returned `Map` is built on the value returned by {@link #module_farmosUtil.getFieldsAndBeds}.
  *
- * @param {object} farm a `farmOS` object returned from `getFarmOSInstance`.
  * @returns a `Map` from the field or bed `name` to the `asset--land` object.
  */
-export async function getFieldOrBedNameToAssetMap(farm) {
-  const fieldsAndBeds = await getFieldsAndBeds(farm);
+export async function getFieldOrBedNameToAssetMap() {
+  const fieldsAndBeds = await getFieldsAndBeds();
 
   const map = new Map(
     fieldsAndBeds.map((land) => [land.attributes.name, land])
@@ -416,11 +415,10 @@ export async function getFieldOrBedNameToAssetMap(farm) {
  *
  * NOTE: The returned `Map` is built on the value returned by {@link #module_farmosUtil.getFieldsAndBeds}.
  *
- * @param {object} farm a `farmOS` object returned from `getFarmOSInstance`.
  * @returns a `Map` from the field or bed `id` to the `asset--land` object.
  */
-export async function getFieldOrBedIdToAssetMap(farm) {
-  const fieldsAndBeds = await getFieldsAndBeds(farm);
+export async function getFieldOrBedIdToAssetMap() {
+  const fieldsAndBeds = await getFieldsAndBeds();
 
   const map = new Map(fieldsAndBeds.map((land) => [land.id, land]));
 
@@ -462,13 +460,14 @@ export function getGlobalGreenhouses() {
  * if the array is to be used multiple times it should be cached
  * by the calling code.
  *
- * @param {object} farm a `farmOS` object returned from `getFarmOSInstance`.
  * @returns an array of all of land assets representing greenhouses.
  */
-export async function getGreenhouses(farm) {
+export async function getGreenhouses() {
   if (global_greenhouses) {
     return global_greenhouses;
   }
+
+  const farm = await getFarmOSInstance();
 
   if (libSessionStorage.getItem('greenhouses') != null) {
     global_greenhouses = JSON.parse(libSessionStorage.getItem('greenhouses'));
@@ -503,11 +502,10 @@ export async function getGreenhouses(farm) {
  *
  * NOTE: The returned `Map` is built on the value returned by {@link #module_farmosUtil.getGreenhouses}.
  *
- * @param {object} farm a `farmOS` object returned from `getFarmOSInstance`.
  * @returns a `Map` from the greenhouse `name` to the `asset--structure` object.
  */
-export async function getGreenhouseNameToAssetMap(farm) {
-  const greenhouses = await getGreenhouses(farm);
+export async function getGreenhouseNameToAssetMap() {
+  const greenhouses = await getGreenhouses();
 
   const map = new Map(greenhouses.map((gh) => [gh.attributes.name, gh]));
 
@@ -520,11 +518,10 @@ export async function getGreenhouseNameToAssetMap(farm) {
  *
  * NOTE: The returned `Map` is built on the value returned by {@link #module_farmosUtil.getGreenhouses}.
  *
- * @param {object} farm a `farmOS` object returned from `getFarmOSInstance`.
  * @returns a `Map` from the greenhouse `id` to the `asset--structure` object.
  */
-export async function getGreenhouseIdToAssetMap(farm) {
-  const greenhouses = await getGreenhouses(farm);
+export async function getGreenhouseIdToAssetMap() {
+  const greenhouses = await getGreenhouses();
 
   const map = new Map(greenhouses.map((gh) => [gh.id, gh]));
 
@@ -566,14 +563,15 @@ export function getGlobalCrops() {
  * if the array is to be used multiple times it should be cached
  * by the calling code.
  *
- * @param {object} farm a `farmOS` object returned from `getFarmOSInstance`.
  * @throws {Error} if unable to fetch the crops.
  * @returns an array of all of taxonomy terms representing crops.
  */
-export async function getCrops(farm) {
+export async function getCrops() {
   if (global_crops) {
     return global_crops;
   }
+
+  const farm = await getFarmOSInstance();
 
   if (libSessionStorage.getItem('crops') != null) {
     global_crops = JSON.parse(libSessionStorage.getItem('crops'));
@@ -606,11 +604,10 @@ export async function getCrops(farm) {
  *
  * NOTE: The returned `Map` is built on the value returned by {@link #module_farmosUtil.getCrops}.
  *
- * @param {object} farm a `farmOS` object returned from `getFarmOSInstance`.
  * @returns a `Map` from the crop `name` to the `taxonomy_term--plant_type` object.
  */
-export async function getCropNameToTermMap(farm) {
-  const crops = await getCrops(farm);
+export async function getCropNameToTermMap() {
+  const crops = await getCrops();
 
   const map = new Map(crops.map((cr) => [cr.attributes.name, cr]));
 
@@ -623,11 +620,10 @@ export async function getCropNameToTermMap(farm) {
  *
  * NOTE: The returned `Map` is built on the value returned by {@link #module_farmosUtil.getCrops}.
  *
- * @param {object} farm a `farmOS` object returned from `getFarmOSInstance`.
  * @returns a `Map` from the crop `id` to the `taxonomy_term--plant_type` object.
  */
-export async function getCropIdToTermMap(farm) {
-  const crops = await getCrops(farm);
+export async function getCropIdToTermMap() {
+  const crops = await getCrops();
 
   const map = new Map(crops.map((cr) => [cr.id, cr]));
 
@@ -669,14 +665,15 @@ export function getGlobalTraySizes() {
  * if the array is to be used multiple times it should be cached
  * by the calling code.
  *
- * @param {object} farm a `farmOS` object returned from `getFarmOSInstance`.
  * @throws {Error} if unable to fetch the tray sizes.
  * @returns an array of all of taxonomy terms representing tray sizes.
  */
-export async function getTraySizes(farm) {
+export async function getTraySizes() {
   if (global_tray_sizes) {
     return global_tray_sizes;
   }
+
+  const farm = await getFarmOSInstance();
 
   if (libSessionStorage.getItem('tray_sizes') != null) {
     global_tray_sizes = JSON.parse(libSessionStorage.getItem('tray_sizes'));
@@ -711,11 +708,10 @@ export async function getTraySizes(farm) {
  *
  * NOTE: The returned `Map` is built on the value returned by {@link #module_farmosUtil.getTraySizes}.
  *
- * @param {object} farm a `farmOS` object returned from `getFarmOSInstance`.
  * @returns a `Map` from the tray size `name` to the `taxonomy_term--tray-size` object.
  */
-export async function getTraySizeToTermMap(farm) {
-  const sizes = await getTraySizes(farm);
+export async function getTraySizeToTermMap() {
+  const sizes = await getTraySizes();
 
   const map = new Map(sizes.map((sz) => [sz.attributes.name, sz]));
 
@@ -728,11 +724,10 @@ export async function getTraySizeToTermMap(farm) {
  *
  * NOTE: The returned `Map` is built on the value returned by {@link #module_farmosUtil.getTraySizes}.
  *
- * @param {object} farm a `farmOS` object returned from `getFarmOSInstance`.
  * @returns a `Map` from the tray size `id` to the `taxonomy_term--tray_size` object.
  */
-export async function getTraySizeIdToTermMap(farm) {
-  const sizes = await getTraySizes(farm);
+export async function getTraySizeIdToTermMap() {
+  const sizes = await getTraySizes();
 
   const map = new Map(sizes.map((sz) => [sz.id, sz]));
 
@@ -773,14 +768,15 @@ export function getGlobalUnits() {
  * if the array is to be used multiple times it should be cached
  * by the calling code.
  *
- * @param {object} farm a `farmOS` object returned from `getFarmOSInstance`.
  * @throws {Error} if unable to fetch the units.
  * @returns an array of all of taxonomy terms representing units.
  */
-export async function getUnits(farm) {
+export async function getUnits() {
   if (global_units) {
     return global_units;
   }
+
+  const farm = await getFarmOSInstance();
 
   if (libSessionStorage.getItem('units') != null) {
     global_units = JSON.parse(libSessionStorage.getItem('units'));
@@ -813,11 +809,10 @@ export async function getUnits(farm) {
  *
  * NOTE: The returned `Map` is built on the value returned by {@link #module_farmosUtil.getUnits}.
  *
- * @param {object} farm a `farmOS` object returned from `getFarmOSInstance`.
  * @returns a `Map` from the unit `name` to the `taxonomy_term--unit` object.
  */
-export async function getUnitToTermMap(farm) {
-  const sizes = await getUnits(farm);
+export async function getUnitToTermMap() {
+  const sizes = await getUnits();
 
   const map = new Map(sizes.map((unit) => [unit.attributes.name, unit]));
 
@@ -830,11 +825,10 @@ export async function getUnitToTermMap(farm) {
  *
  * NOTE: The returned `Map` is built on the value returned by {@link #module_farmosUtil.getUnits}.
  *
- * @param {object} farm a `farmOS` object returned from `getFarmOSInstance`.
  * @returns a `Map` from the unit `id` to the `taxonomy_term--unit` object.
  */
-export async function getUnitIdToTermMap(farm) {
-  const units = await getUnits(farm);
+export async function getUnitIdToTermMap() {
+  const units = await getUnits();
 
   const map = new Map(units.map((unit) => [unit.id, unit]));
 
@@ -875,14 +869,15 @@ export function getGlobalLogCategories() {
  * if the array is to be used multiple times it should be cached
  * by the calling code.
  *
- * @param {object} farm a `farmOS` object returned from `getFarmOSInstance`.
  * @throws {Error} if unable to fetch the log categories.
  * @returns an array of all of taxonomy terms representing log categories.
  */
-export async function getLogCategories(farm) {
+export async function getLogCategories() {
   if (global_log_categories) {
     return global_log_categories;
   }
+
+  const farm = await getFarmOSInstance();
 
   if (libSessionStorage.getItem('log_categories') != null) {
     global_log_categories = JSON.parse(
@@ -917,11 +912,10 @@ export async function getLogCategories(farm) {
  *
  * NOTE: The returned `Map` is built on the value returned by {@link #module_farmosUtil.getLogCategories}.
  *
- * @param {object} farm a `farmOS` object returned from `getFarmOSInstance`.
  * @returns a `Map` from the log category `name` to the `taxonomy_term--log_category` object.
  */
-export async function getLogCategoryToTermMap(farm) {
-  const categories = await getLogCategories(farm);
+export async function getLogCategoryToTermMap() {
+  const categories = await getLogCategories();
 
   const map = new Map(
     categories.map((category) => [category.attributes.name, category])
@@ -936,11 +930,10 @@ export async function getLogCategoryToTermMap(farm) {
  *
  * NOTE: The returned `Map` is built on the value returned by {@link #module_farmosUtil.getLogCategories}.
  *
- * @param {object} farm a `farmOS` object returned from `getFarmOSInstance`.
  * @returns a `Map` from the log category `id` to the `taxonomy_term--log_category` object.
  */
-export async function getLogCategoryIdToTermMap(farm) {
-  const categories = await getLogCategories(farm);
+export async function getLogCategoryIdToTermMap() {
+  const categories = await getLogCategories();
 
   const map = new Map(categories.map((category) => [category.id, category]));
 

--- a/library/farmosUtil/farmosUtil.js
+++ b/library/farmosUtil/farmosUtil.js
@@ -50,7 +50,7 @@ var libLocalStorage = null;
 var libSessionStorage = null;
 
 /**
- * Get an instance of the `farmos.js` `farmOS` object that can be used
+ * Create and return an instance of the `farmos.js` `farmOS` object that will be used
  * to interact with the farmOS host.  The `farmOS` instance will have the
  * same permissions as the `user`/`pass` that are used for authentication.
  * The default 'farm' client is sufficient for most uses, but any client
@@ -58,7 +58,7 @@ var libSessionStorage = null;
  * configured).  The `farmOS` object will also have its schema set.
  *
  * NOTE: There will only be a single instance of `farmOS` object created on the
- * first call to this function from a given page.  Subsequent calls will
+ * first call to this function from a given page. Subsequent calls will
  * authenticate if necessary and then return the same`farmOS` object.
  *
  * @param {string} hostURL url of the farmOS instance to which to connect.

--- a/library/farmosUtil/farmosUtil.logCategories.unit.cy.js
+++ b/library/farmosUtil/farmosUtil.logCategories.unit.cy.js
@@ -1,17 +1,6 @@
 import * as farmosUtil from './farmosUtil.js';
 
 describe('Test the log categories utility functions', () => {
-  var farm = null;
-  before(() => {
-    cy.wrap(
-      farmosUtil
-        .getFarmOSInstance('http://farmos', 'farm', 'admin', 'admin')
-        .then((newFarm) => {
-          farm = newFarm;
-        })
-    );
-  });
-
   beforeEach(() => {
     cy.restoreLocalStorage();
     cy.restoreSessionStorage();
@@ -23,7 +12,7 @@ describe('Test the log categories utility functions', () => {
   });
 
   it('Get the log categories', () => {
-    cy.wrap(farmosUtil.getLogCategories(farm)).then((categories) => {
+    cy.wrap(farmosUtil.getLogCategories()).then((categories) => {
       expect(categories).to.not.be.null;
       expect(categories.length).to.equal(3);
 
@@ -49,7 +38,7 @@ describe('Test the log categories utility functions', () => {
     });
 
     farmosUtil
-      .getLogCategories(farm)
+      .getLogCategories()
       .then(() => {
         throw new Error('Fetching log categories should have failed.');
       })
@@ -63,14 +52,14 @@ describe('Test the log categories utility functions', () => {
     expect(farmosUtil.getGlobalLogCategories()).to.be.null;
     expect(sessionStorage.getItem('log_categories')).to.be.null;
 
-    farmosUtil.getLogCategories(farm).then(() => {
+    farmosUtil.getLogCategories().then(() => {
       expect(farmosUtil.getGlobalLogCategories()).to.not.be.null;
       expect(sessionStorage.getItem('log_categories')).to.not.be.null;
     });
   });
 
   it('Get the logCategoryToTerm map', () => {
-    cy.wrap(farmosUtil.getLogCategoryToTermMap(farm)).then((categoryMap) => {
+    cy.wrap(farmosUtil.getLogCategoryToTermMap()).then((categoryMap) => {
       expect(categoryMap).to.not.be.null;
       expect(categoryMap.size).to.equal(3);
 
@@ -87,31 +76,27 @@ describe('Test the log categories utility functions', () => {
   });
 
   it('Get the logCategoryIdToAsset map', () => {
-    cy.wrap(farmosUtil.getLogCategoryIdToTermMap(farm)).then(
-      (categoryIdMap) => {
-        expect(categoryIdMap).to.not.be.null;
-        expect(categoryIdMap.size).to.equal(3);
+    cy.wrap(farmosUtil.getLogCategoryIdToTermMap()).then((categoryIdMap) => {
+      expect(categoryIdMap).to.not.be.null;
+      expect(categoryIdMap.size).to.equal(3);
 
-        cy.wrap(farmosUtil.getLogCategoryToTermMap(farm)).then(
-          (categoryNameMap) => {
-            const coverId = categoryNameMap.get('seeding_cover_crop').id;
-            expect(categoryIdMap.get(coverId).attributes.name).to.equal(
-              'seeding_cover_crop'
-            );
-            expect(categoryIdMap.get(coverId).type).to.equal(
-              'taxonomy_term--log_category'
-            );
-
-            const trayId = categoryNameMap.get('seeding_tray').id;
-            expect(categoryIdMap.get(trayId).attributes.name).to.equal(
-              'seeding_tray'
-            );
-            expect(categoryIdMap.get(trayId).type).to.equal(
-              'taxonomy_term--log_category'
-            );
-          }
+      cy.wrap(farmosUtil.getLogCategoryToTermMap()).then((categoryNameMap) => {
+        const coverId = categoryNameMap.get('seeding_cover_crop').id;
+        expect(categoryIdMap.get(coverId).attributes.name).to.equal(
+          'seeding_cover_crop'
         );
-      }
-    );
+        expect(categoryIdMap.get(coverId).type).to.equal(
+          'taxonomy_term--log_category'
+        );
+
+        const trayId = categoryNameMap.get('seeding_tray').id;
+        expect(categoryIdMap.get(trayId).attributes.name).to.equal(
+          'seeding_tray'
+        );
+        expect(categoryIdMap.get(trayId).type).to.equal(
+          'taxonomy_term--log_category'
+        );
+      });
+    });
   });
 });

--- a/library/farmosUtil/farmosUtil.traySizes.unit.cy.js
+++ b/library/farmosUtil/farmosUtil.traySizes.unit.cy.js
@@ -1,17 +1,6 @@
 import * as farmosUtil from './farmosUtil.js';
 
 describe('Test the tray sizes utility functions', () => {
-  var farm = null;
-  before(() => {
-    cy.wrap(
-      farmosUtil
-        .getFarmOSInstance('http://farmos', 'farm', 'admin', 'admin')
-        .then((newFarm) => {
-          farm = newFarm;
-        })
-    );
-  });
-
   beforeEach(() => {
     cy.restoreLocalStorage();
     cy.restoreSessionStorage();
@@ -23,7 +12,7 @@ describe('Test the tray sizes utility functions', () => {
   });
 
   it('Get the tray sizes', () => {
-    cy.wrap(farmosUtil.getTraySizes(farm)).then((traySizes) => {
+    cy.wrap(farmosUtil.getTraySizes()).then((traySizes) => {
       expect(traySizes).to.not.be.null;
       expect(traySizes.length).to.equal(6);
 
@@ -49,7 +38,7 @@ describe('Test the tray sizes utility functions', () => {
     });
 
     farmosUtil
-      .getTraySizes(farm)
+      .getTraySizes()
       .then(() => {
         throw new Error('Fetching tray sizes should have failed.');
       })
@@ -63,14 +52,14 @@ describe('Test the tray sizes utility functions', () => {
     expect(farmosUtil.getGlobalTraySizes()).to.be.null;
     expect(sessionStorage.getItem('tray_sizes')).to.be.null;
 
-    farmosUtil.getTraySizes(farm).then(() => {
+    farmosUtil.getTraySizes().then(() => {
       expect(farmosUtil.getGlobalTraySizes()).to.not.be.null;
       expect(sessionStorage.getItem('tray_sizes')).to.not.be.null;
     });
   });
 
   it('Get the TraySizeToTerm map', () => {
-    cy.wrap(farmosUtil.getTraySizeToTermMap(farm)).then((traySizeMap) => {
+    cy.wrap(farmosUtil.getTraySizeToTermMap()).then((traySizeMap) => {
       expect(traySizeMap).to.not.be.null;
       expect(traySizeMap.size).to.equal(6);
 
@@ -83,11 +72,11 @@ describe('Test the tray sizes utility functions', () => {
   });
 
   it('Get the TraySizeIdToAsset map', () => {
-    cy.wrap(farmosUtil.getTraySizeIdToTermMap(farm)).then((trayIdMap) => {
+    cy.wrap(farmosUtil.getTraySizeIdToTermMap()).then((trayIdMap) => {
       expect(trayIdMap).to.not.be.null;
       expect(trayIdMap.size).to.equal(6);
 
-      cy.wrap(farmosUtil.getTraySizeToTermMap(farm)).then((trayNameMap) => {
+      cy.wrap(farmosUtil.getTraySizeToTermMap()).then((trayNameMap) => {
         const tray50Id = trayNameMap.get('50').id;
         expect(trayIdMap.get(tray50Id).attributes.name).to.equal('50');
         expect(trayIdMap.get(tray50Id).type).to.equal(

--- a/library/farmosUtil/farmosUtil.units.unit.cy.js
+++ b/library/farmosUtil/farmosUtil.units.unit.cy.js
@@ -1,17 +1,6 @@
 import * as farmosUtil from './farmosUtil.js';
 
 describe('Test the units utility functions', () => {
-  var farm = null;
-  before(() => {
-    cy.wrap(
-      farmosUtil
-        .getFarmOSInstance('http://farmos', 'farm', 'admin', 'admin')
-        .then((newFarm) => {
-          farm = newFarm;
-        })
-    );
-  });
-
   beforeEach(() => {
     cy.restoreLocalStorage();
     cy.restoreSessionStorage();
@@ -23,7 +12,7 @@ describe('Test the units utility functions', () => {
   });
 
   it('Get the units', () => {
-    cy.wrap(farmosUtil.getUnits(farm)).then((units) => {
+    cy.wrap(farmosUtil.getUnits()).then((units) => {
       expect(units).to.not.be.null;
       expect(units.length).to.equal(5);
 
@@ -49,7 +38,7 @@ describe('Test the units utility functions', () => {
     });
 
     farmosUtil
-      .getUnits(farm)
+      .getUnits()
       .then(() => {
         throw new Error('Fetching units should have failed.');
       })
@@ -63,14 +52,14 @@ describe('Test the units utility functions', () => {
     expect(farmosUtil.getGlobalUnits()).to.be.null;
     expect(sessionStorage.getItem('units')).to.be.null;
 
-    farmosUtil.getUnits(farm).then(() => {
+    farmosUtil.getUnits().then(() => {
       expect(farmosUtil.getGlobalUnits()).to.not.be.null;
       expect(sessionStorage.getItem('units')).to.not.be.null;
     });
   });
 
   it('Get the unitToTerm map', () => {
-    cy.wrap(farmosUtil.getUnitToTermMap(farm)).then((unitMap) => {
+    cy.wrap(farmosUtil.getUnitToTermMap()).then((unitMap) => {
       expect(unitMap).to.not.be.null;
       expect(unitMap.size).to.equal(5);
 
@@ -83,11 +72,11 @@ describe('Test the units utility functions', () => {
   });
 
   it('Get the UnitIdToAsset map', () => {
-    cy.wrap(farmosUtil.getUnitIdToTermMap(farm)).then((unitIdMap) => {
+    cy.wrap(farmosUtil.getUnitIdToTermMap()).then((unitIdMap) => {
       expect(unitIdMap).to.not.be.null;
       expect(unitIdMap.size).to.equal(5);
 
-      cy.wrap(farmosUtil.getUnitToTermMap(farm)).then((unitNameMap) => {
+      cy.wrap(farmosUtil.getUnitToTermMap()).then((unitNameMap) => {
         const countId = unitNameMap.get('Count').id;
         expect(unitIdMap.get(countId).attributes.name).to.equal('Count');
         expect(unitIdMap.get(countId).type).to.equal('taxonomy_term--unit');

--- a/library/farmosUtil/farmosUtil.users.unit.cy.js
+++ b/library/farmosUtil/farmosUtil.users.unit.cy.js
@@ -1,17 +1,6 @@
 import * as farmosUtil from './farmosUtil.js';
 
 describe('Test the user utility functions', () => {
-  var farm = null;
-  before(() => {
-    cy.wrap(
-      farmosUtil
-        .getFarmOSInstance('http://farmos', 'farm', 'admin', 'admin')
-        .then((newFarm) => {
-          farm = newFarm;
-        })
-    );
-  });
-
   beforeEach(() => {
     cy.restoreLocalStorage();
     cy.restoreSessionStorage();
@@ -23,7 +12,7 @@ describe('Test the user utility functions', () => {
   });
 
   it('Get the users', () => {
-    cy.wrap(farmosUtil.getUsers(farm)).then((users) => {
+    cy.wrap(farmosUtil.getUsers()).then((users) => {
       expect(users).to.not.be.null;
 
       expect(users[0].attributes.name).to.equal('admin');
@@ -50,7 +39,7 @@ describe('Test the user utility functions', () => {
     });
 
     farmosUtil
-      .getUsers(farm)
+      .getUsers()
       .then(() => {
         throw new Error('Fetching users should have failed.');
       })
@@ -64,14 +53,14 @@ describe('Test the user utility functions', () => {
     expect(farmosUtil.getGlobalUsers()).to.be.null;
     expect(sessionStorage.getItem('users')).to.be.null;
 
-    farmosUtil.getUsers(farm).then(() => {
+    farmosUtil.getUsers().then(() => {
       expect(farmosUtil.getGlobalUsers()).to.not.be.null;
       expect(sessionStorage.getItem('users')).to.not.be.null;
     });
   });
 
   it('Get the usernameMap', () => {
-    cy.wrap(farmosUtil.getUsernameToUserMap(farm)).then((usernameMap) => {
+    cy.wrap(farmosUtil.getUsernameToUserMap()).then((usernameMap) => {
       expect(usernameMap).to.not.be.null;
 
       expect(usernameMap.get('Anonymous')).to.be.undefined;
@@ -89,10 +78,10 @@ describe('Test the user utility functions', () => {
   });
 
   it('Get the userIdMap', () => {
-    cy.wrap(farmosUtil.getUserIdToUserMap(farm)).then((userIdMap) => {
+    cy.wrap(farmosUtil.getUserIdToUserMap()).then((userIdMap) => {
       expect(userIdMap).to.not.be.null;
 
-      cy.wrap(farmosUtil.getUsernameToUserMap(farm)).then((usernameMap) => {
+      cy.wrap(farmosUtil.getUsernameToUserMap()).then((usernameMap) => {
         expect(usernameMap.get('Anonymous')).to.be.undefined;
 
         const adminId = usernameMap.get('admin').id;


### PR DESCRIPTION
**Pull Request Description**

This PR refactors the `farmosUtil.js` library so that the utility functions implicitly call `getFarmOSInstance` to get the `farm` instance that they need.  Prior to this callers were required to provide the `farm` instance`.  Because the `farmosUtil.js` library caches the `farm` object, there is little overhead in having each utility method get its own `farm` object instead of requiring the calling code to construct it.  This simplifies component and entry point development.

Closes #70

---

**Licensing Certification**

FarmData2 is a [Free Cultural Work](https://freedomdefined.org/Definition) and all accepted contributions are licensed as described in the LICENSE.md file. This requires that the contributor holds the rights to do so. By submitting this pull request **I certify that I satisfy the terms of the [Developer Certificate of Origin](https://developercertificate.org/)** for its contents.
