### PR TITLE
fix(libs): fixes a race condition in getFarmOSInstance

### DIFF
--- a/library/README.md
+++ b/library/README.md
@@ -12,6 +12,8 @@ Javascript library of FarmData2 custom reusable functions.
 - `test.bash --unit --glob="**/farmosUtil/*.unit.cy.js"`
 - `test.bash --unit --glob="**/farmosUtil/farmosUtil.getFarmInstance.unit.cy.js"`
 
+Any `it` with an `intercept` should include `{ retries: 4 }` to tolerate some of the flake that appears to go with `cy.intercept`.
+
 ## Documentation
 
 - Docs are in `docs/library`

--- a/library/farmosUtil/farmosUtil.fieldsAndBeds.unit.cy.js
+++ b/library/farmosUtil/farmosUtil.fieldsAndBeds.unit.cy.js
@@ -24,33 +24,100 @@ describe('Test the land utility functions', () => {
     });
   });
 
-  it('Test that get fields and beds throws error if fetch fails', () => {
-    farmosUtil.clearCachedFieldsAndBeds();
+  it(
+    'Test that get fields and beds throws error if fetch fails',
+    { retries: 4 },
+    () => {
+      farmosUtil.clearCachedFieldsAndBeds();
 
-    cy.intercept('GET', '**/api/asset/land?*', {
-      forceNetworkError: true,
-    });
-
-    farmosUtil
-      .getFieldsAndBeds()
-      .then(() => {
-        throw new Error('Fetching fields and beds should have failed.');
-      })
-      .catch((error) => {
-        expect(error.message).to.equal('Unable to fetch fields and beds.');
+      cy.intercept('GET', '**/api/asset/land?*', {
+        forceNetworkError: true,
       });
-  });
 
-  it('Test that getFieldsAndBeds are cached', () => {
-    farmosUtil.clearCachedFieldsAndBeds();
-    expect(farmosUtil.getGlobalFieldsAndBeds()).to.be.null;
-    expect(sessionStorage.getItem('fields_and_beds')).to.be.null;
+      cy.wrap(
+        farmosUtil
+          .getFieldsAndBeds()
+          .then(() => {
+            throw new Error('Fetching fields and beds should have failed.');
+          })
+          .catch((error) => {
+            expect(error.message).to.equal('Unable to fetch fields and beds.');
+          })
+      );
+    }
+  );
 
-    farmosUtil.getFieldsAndBeds().then(() => {
-      expect(farmosUtil.getGlobalFieldsAndBeds()).to.not.be.null;
-      expect(sessionStorage.getItem('fields_and_beds')).to.not.be.null;
-    });
-  });
+  it(
+    'Test that getFieldsAndBeds uses global variable cache',
+    { retries: 4 },
+    () => {
+      farmosUtil.clearCachedFieldsAndBeds();
+      expect(farmosUtil.getGlobalFieldsAndBeds()).to.be.null;
+      expect(sessionStorage.getItem('fields_and_beds')).to.be.null;
+
+      cy.intercept(
+        'GET',
+        '**/api/asset/land?*',
+        cy.spy().as('fetchFieldsAndBeds')
+      );
+
+      // Get the first one to ensure the cache is populated.
+      cy.wrap(farmosUtil.getFieldsAndBeds())
+        .then(() => {
+          cy.get('@fetchFieldsAndBeds').its('callCount').should('equal', 2);
+          expect(farmosUtil.getGlobalFieldsAndBeds()).not.to.be.null;
+          expect(sessionStorage.getItem('fields_and_beds')).not.to.be.null;
+        })
+        .then(() => {
+          // Now check that the global is used.
+          sessionStorage.removeItem('fields_and_beds');
+          expect(farmosUtil.getGlobalFieldsAndBeds()).not.to.be.null;
+          expect(sessionStorage.getItem('fields_and_beds')).to.be.null;
+
+          cy.wrap(farmosUtil.getFieldsAndBeds()).then(() => {
+            cy.get('@fetchFieldsAndBeds').its('callCount').should('equal', 2);
+            expect(farmosUtil.getGlobalFieldsAndBeds()).to.not.be.null;
+            expect(sessionStorage.getItem('fields_and_beds')).to.be.null;
+          });
+        });
+    }
+  );
+
+  it(
+    'Test that getFieldsAndBeds uses session storage cache',
+    { retries: 4 },
+    () => {
+      farmosUtil.clearCachedFieldsAndBeds();
+      expect(farmosUtil.getGlobalFieldsAndBeds()).to.be.null;
+      expect(sessionStorage.getItem('fields_and_beds')).to.be.null;
+
+      cy.intercept(
+        'GET',
+        '**/api/asset/land?*',
+        cy.spy().as('fetchFieldsAndBeds')
+      );
+
+      // Get the first one to ensure the cache is populated.
+      cy.wrap(farmosUtil.getFieldsAndBeds())
+        .then(() => {
+          // Note fields and beds are fetched by separate API calls.
+          cy.get('@fetchFieldsAndBeds').its('callCount').should('equal', 2);
+          expect(farmosUtil.getGlobalFieldsAndBeds()).not.to.be.null;
+          expect(sessionStorage.getItem('fields_and_beds')).not.to.be.null;
+        })
+        .then(() => {
+          // Now check that the session storage is used.
+          farmosUtil.clearGlobalFieldsAndBeds();
+          expect(farmosUtil.getGlobalFieldsAndBeds()).to.be.null;
+          expect(sessionStorage.getItem('fields_and_beds')).not.to.be.null;
+          cy.wrap(farmosUtil.getFieldsAndBeds()).then(() => {
+            cy.get('@fetchFieldsAndBeds').its('callCount').should('equal', 2);
+            expect(farmosUtil.getGlobalFieldsAndBeds()).to.not.be.null;
+            expect(sessionStorage.getItem('fields_and_beds')).to.not.be.null;
+          });
+        });
+    }
+  );
 
   it('Get the FieldOrBedNameToAsset map', () => {
     cy.wrap(farmosUtil.getFieldOrBedNameToAssetMap()).then((landNameMap) => {

--- a/library/farmosUtil/farmosUtil.getFarmInstance.unit.cy.js
+++ b/library/farmosUtil/farmosUtil.getFarmInstance.unit.cy.js
@@ -39,7 +39,7 @@ describe('Test getFarmOSInstance', () => {
     });
   }
 
-  it('Check getting the first instance', () => {
+  it('Check getting the first instance', { retries: 4 }, () => {
     // Get the first instance
     // - check that farm_global does not exist
     // - check that token is not in local storage
@@ -79,45 +79,49 @@ describe('Test getFarmOSInstance', () => {
     });
   });
 
-  it('Get a second instance of farmOS with everything cached', () => {
-    // Get a second instance
-    // - check that farm global exists, token is cached, schema is cached.
-    // Get a farm object
-    // - check it has token & schema
-    // - check it is the same farm object as last instance
-    // - check that it can be used to get info from server
-    // - check that it didn't fetch token
-    // - check that it didn't fetch schema
-    // - check that token is saved in local storage
-    // - check that schema is saved in session storage
+  it(
+    'Get a second instance of farmOS with everything cached',
+    { retries: 4 },
+    () => {
+      // Get a second instance
+      // - check that farm global exists, token is cached, schema is cached.
+      // Get a farm object
+      // - check it has token & schema
+      // - check it is the same farm object as last instance
+      // - check that it can be used to get info from server
+      // - check that it didn't fetch token
+      // - check that it didn't fetch schema
+      // - check that token is saved in local storage
+      // - check that schema is saved in session storage
 
-    cy.intercept('POST', 'oauth/token').as('getToken');
-    cy.intercept('GET', '**/api/**/schema').as('fetchSchema');
+      cy.intercept('POST', 'oauth/token').as('getToken');
+      cy.intercept('GET', '**/api/**/schema').as('fetchSchema');
 
-    expect(farmosUtil.getFarmGlobal()).to.not.be.null;
-    expect(localStorage.getItem('token')).to.not.be.null;
-    expect(sessionStorage.getItem('schema')).to.not.be.null;
-
-    cy.wrap(
-      farmosUtil.getFarmOSInstance('http://farmos', 'farm', 'admin', 'admin')
-    ).then((newFarm) => {
-      expect(newFarm).to.not.be.null;
-      expect(newFarm.remote.getToken()).to.not.be.null;
-      expect(newFarm.schema.get()).to.not.be.null;
-
-      expect(newFarm === prev_farm).to.be.true;
-
-      useFarm(newFarm);
-
-      cy.get('@getToken.all').should('have.length', 0);
-      cy.get('@fetchSchema.all').should('have.length', 0);
-
+      expect(farmosUtil.getFarmGlobal()).to.not.be.null;
       expect(localStorage.getItem('token')).to.not.be.null;
       expect(sessionStorage.getItem('schema')).to.not.be.null;
-    });
-  });
 
-  it('Clear the local storage.', () => {
+      cy.wrap(
+        farmosUtil.getFarmOSInstance('http://farmos', 'farm', 'admin', 'admin')
+      ).then((newFarm) => {
+        expect(newFarm).to.not.be.null;
+        expect(newFarm.remote.getToken()).to.not.be.null;
+        expect(newFarm.schema.get()).to.not.be.null;
+
+        expect(newFarm === prev_farm).to.be.true;
+
+        useFarm(newFarm);
+
+        cy.get('@getToken.all').should('have.length', 0);
+        cy.get('@fetchSchema.all').should('have.length', 0);
+
+        expect(localStorage.getItem('token')).to.not.be.null;
+        expect(sessionStorage.getItem('schema')).to.not.be.null;
+      });
+    }
+  );
+
+  it('Clear the local storage.', { retries: 4 }, () => {
     // Clear localStorage
     // - check that farm global exists
     // - Check that schema is in session storage
@@ -158,7 +162,7 @@ describe('Test getFarmOSInstance', () => {
     });
   });
 
-  it('Clear the farm_global.', () => {
+  it('Clear the farm_global.', { retries: 4 }, () => {
     // Clear the farm global
     // - check that farm global does not exist
     // - Check that schema is in session storage
@@ -200,7 +204,7 @@ describe('Test getFarmOSInstance', () => {
     });
   });
 
-  it('Clear the farm_global and session storage.', () => {
+  it('Clear the farm_global and session storage.', { retries: 4 }, () => {
     // Clear the farm global
     // Clear the session storage
     // - check that farm global does not exist
@@ -244,7 +248,7 @@ describe('Test getFarmOSInstance', () => {
     });
   });
 
-  it('Clear everything.', () => {
+  it('Clear everything.', { retries: 4 }, () => {
     // Clear the farm global
     // Clear the session storage
     // Clear the local storage

--- a/library/farmosUtil/farmosUtil.greenhouses.unit.cy.js
+++ b/library/farmosUtil/farmosUtil.greenhouses.unit.cy.js
@@ -24,33 +24,97 @@ describe('Test the greenhouse utility functions', () => {
     });
   });
 
-  it('Test that getGreenhouses throws error if fetch fails', () => {
-    farmosUtil.clearCachedGreenhouses();
+  it(
+    'Test that getGreenhouses throws error if fetch fails',
+    { retries: 4 },
+    () => {
+      farmosUtil.clearCachedGreenhouses();
 
-    cy.intercept('GET', '**/api/asset/structure?*', {
-      forceNetworkError: true,
-    });
-
-    farmosUtil
-      .getGreenhouses()
-      .then(() => {
-        throw new Error('Fetching greenhouses should have failed.');
-      })
-      .catch((error) => {
-        expect(error.message).to.equal('Unable to fetch greenhouses.');
+      cy.intercept('GET', '**/api/asset/structure?*', {
+        forceNetworkError: true,
       });
-  });
 
-  it('Test that getGreenhouses result is cached', () => {
-    farmosUtil.clearCachedGreenhouses();
-    expect(farmosUtil.getGlobalGreenhouses()).to.be.null;
-    expect(sessionStorage.getItem('greenhouses')).to.be.null;
+      cy.wrap(
+        farmosUtil
+          .getGreenhouses()
+          .then(() => {
+            throw new Error('Fetching greenhouses should have failed.');
+          })
+          .catch((error) => {
+            expect(error.message).to.equal('Unable to fetch greenhouses.');
+          })
+      );
+    }
+  );
 
-    farmosUtil.getGreenhouses().then(() => {
-      expect(farmosUtil.getGlobalGreenhouses()).to.not.be.null;
-      expect(sessionStorage.getItem('greenhouses')).to.not.be.null;
-    });
-  });
+  it(
+    'Test that getGreenhouses uses global variable cache',
+    { retries: 4 },
+    () => {
+      farmosUtil.clearCachedGreenhouses();
+      expect(farmosUtil.getGlobalGreenhouses()).to.be.null;
+      expect(sessionStorage.getItem('greenhouses')).to.be.null;
+
+      cy.intercept(
+        'GET',
+        '**/api/asset/structure?*',
+        cy.spy().as('fetchGreenhouses')
+      );
+
+      // Get the first one to ensure the cache is populated.
+      cy.wrap(farmosUtil.getGreenhouses())
+        .then(() => {
+          cy.get('@fetchGreenhouses').its('callCount').should('equal', 1);
+          expect(farmosUtil.getGlobalGreenhouses()).not.to.be.null;
+          expect(sessionStorage.getItem('greenhouses')).not.to.be.null;
+        })
+        .then(() => {
+          // Now check that the global is used.
+          sessionStorage.removeItem('greenhouses');
+          cy.wrap(farmosUtil.getGreenhouses()).then(() => {
+            cy.get('@fetchGreenhouses').its('callCount').should('equal', 1);
+            expect(farmosUtil.getGlobalGreenhouses()).not.to.be.null;
+            expect(sessionStorage.getItem('greenhouses')).to.be.null;
+          });
+        });
+    }
+  );
+
+  it(
+    'Test that getGreenhouses uses session storage cache',
+    { retries: 4 },
+    () => {
+      farmosUtil.clearCachedGreenhouses();
+      expect(farmosUtil.getGlobalGreenhouses()).to.be.null;
+      expect(sessionStorage.getItem('greenhouses')).to.be.null;
+
+      cy.intercept(
+        'GET',
+        '**/api/asset/structure?*',
+        cy.spy().as('fetchGreenhouses')
+      );
+
+      // Get the first one to ensure the cache is populated.
+      cy.wrap(farmosUtil.getGreenhouses())
+        .then(() => {
+          cy.get('@fetchGreenhouses').its('callCount').should('equal', 1);
+          expect(farmosUtil.getGlobalGreenhouses()).not.to.be.null;
+          expect(sessionStorage.getItem('greenhouses')).not.to.be.null;
+        })
+        .then(() => {
+          farmosUtil.clearGlobalGreenhouses();
+          expect(farmosUtil.getGlobalGreenhouses()).to.be.null;
+          expect(sessionStorage.getItem('greenhouses')).not.to.be.null;
+
+          // Now check that the session storage is used.
+          cy.wrap(farmosUtil.getGreenhouses()).then(() => {
+            cy.get('@fetchGreenhouses').its('callCount').should('equal', 1);
+            expect(farmosUtil.getGlobalGreenhouses()).to.not.be.null;
+            expect(sessionStorage.getItem('greenhouses')).to.not.be.null;
+          });
+        });
+    }
+  );
 
   it('Get the GreenhouseNameToAsset map', () => {
     cy.wrap(farmosUtil.getGreenhouseNameToAssetMap()).then((ghNameMap) => {

--- a/library/farmosUtil/farmosUtil.logCategories.unit.cy.js
+++ b/library/farmosUtil/farmosUtil.logCategories.unit.cy.js
@@ -30,33 +30,95 @@ describe('Test the log categories utility functions', () => {
     });
   });
 
-  it('Test that get units throws error if fetch fails', () => {
+  it('Test that get units throws error if fetch fails', { retries: 4 }, () => {
     farmosUtil.clearCachedLogCategories();
 
     cy.intercept('GET', '**/api/taxonomy_term/log_category?*', {
       forceNetworkError: true,
     });
 
-    farmosUtil
-      .getLogCategories()
-      .then(() => {
-        throw new Error('Fetching log categories should have failed.');
-      })
-      .catch((error) => {
-        expect(error.message).to.equal('Unable to fetch log categories.');
-      });
+    cy.wrap(
+      farmosUtil
+        .getLogCategories()
+        .then(() => {
+          throw new Error('Fetching log categories should have failed.');
+        })
+        .catch((error) => {
+          expect(error.message).to.equal('Unable to fetch log categories.');
+        })
+    );
   });
 
-  it('Test that getLogCategories result is cached', () => {
-    farmosUtil.clearCachedLogCategories();
-    expect(farmosUtil.getGlobalLogCategories()).to.be.null;
-    expect(sessionStorage.getItem('log_categories')).to.be.null;
+  it(
+    'Test that getLogCategories uses global variable cache',
+    { retries: 4 },
+    () => {
+      cy.intercept(
+        'GET',
+        '**/api/taxonomy_term/log_category?',
+        cy.spy().as('fetchLogCategories')
+      );
 
-    farmosUtil.getLogCategories().then(() => {
-      expect(farmosUtil.getGlobalLogCategories()).to.not.be.null;
-      expect(sessionStorage.getItem('log_categories')).to.not.be.null;
-    });
-  });
+      farmosUtil.clearCachedLogCategories();
+      expect(farmosUtil.getGlobalLogCategories()).to.be.null;
+      expect(sessionStorage.getItem('log_categories')).to.be.null;
+
+      // Get the first one to ensure the cache is populated.
+      cy.wrap(farmosUtil.getLogCategories())
+        .then(() => {
+          cy.get('@fetchLogCategories').its('callCount').should('equal', 1);
+          expect(farmosUtil.getGlobalLogCategories()).not.to.be.null;
+          expect(sessionStorage.getItem('log_categories')).not.to.be.null;
+        })
+        .then(() => {
+          // Now check that the global is used.
+          sessionStorage.removeItem('log_categories');
+          cy.wrap(farmosUtil.getLogCategories()).then(() => {
+            cy.get('@fetchLogCategories').its('callCount').should('equal', 1);
+            expect(farmosUtil.getGlobalLogCategories()).not.to.be.null;
+            expect(sessionStorage.getItem('log_categories')).to.be.null;
+          });
+        });
+    }
+  );
+
+  it(
+    'Test that getLogCategories uses session storage cache',
+    { retries: 4 },
+    () => {
+      cy.intercept(
+        'GET',
+        '**/api/taxonomy_term/log_category?',
+        cy.spy().as('fetchLogCategories')
+      );
+
+      farmosUtil.clearCachedLogCategories();
+      expect(farmosUtil.getGlobalLogCategories()).to.be.null;
+      expect(sessionStorage.getItem('log_categories')).to.be.null;
+
+      // Get the first one to ensure the cache is populated.
+      cy.wrap(farmosUtil.getLogCategories())
+        .then(() => {
+          cy.get('@fetchLogCategories').should('have.been.calledOnce');
+          expect(farmosUtil.getGlobalLogCategories()).not.to.be.null;
+          expect(sessionStorage.getItem('log_categories')).not.to.be.null;
+        })
+        .then(() => {
+          farmosUtil.clearGlobalLogCategories();
+          expect(farmosUtil.getGlobalLogCategories()).to.be.null;
+          expect(sessionStorage.getItem('log_categories')).not.to.be.null;
+
+          // Now check that the session storage is used.
+          cy.wrap(farmosUtil.getLogCategories()).then(() => {
+            cy.get('@fetchLogCategories').should('have.been.calledOnce');
+            expect(farmosUtil.getGlobalLogCategories()).to.not.be.null;
+            expect(sessionStorage.getItem('log_categories')).to.not.be.null;
+          });
+        });
+
+      cy.get('@fetchLogCategories').should('have.been.calledOnce');
+    }
+  );
 
   it('Get the logCategoryToTerm map', () => {
     cy.wrap(farmosUtil.getLogCategoryToTermMap()).then((categoryMap) => {

--- a/modules/README.md
+++ b/modules/README.md
@@ -54,7 +54,10 @@ Inside each of the above module directories there are the following directories 
 - use bin/test.bash
 
 - use watch:fd2 by default and just run in live farmOS.
+
   - point to another document that discusses the use of the dev and preview servers.
+
+- Any `it` with an `intercept` should include `{ retries: 4 }` to tolerate some of the flake that appears to go with `cy.intercept`.
 
 ## Entry point structure
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "farmos": "^2.0.0-beta.16",
         "node-localstorage": "^3.0.5",
         "pinia": "^2.1.3",
+        "run-exclusive": "^2.2.19",
         "vue": "^3.3.4"
       },
       "devDependencies": {
@@ -13729,6 +13730,11 @@
         "node": ">=4"
       }
     },
+    "node_modules/minimal-polyfills": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/minimal-polyfills/-/minimal-polyfills-2.2.3.tgz",
+      "integrity": "sha512-oxdmJ9cL+xV72h0xYxp4tP2d5/fTBpP45H8DIOn9pASuF8a3IYTf+25fMGDYGiWW+MFsuog6KD6nfmhZJQ+uUw=="
+    },
     "node_modules/minimatch": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
@@ -20119,6 +20125,14 @@
       "dev": true,
       "engines": {
         "node": ">=0.12.0"
+      }
+    },
+    "node_modules/run-exclusive": {
+      "version": "2.2.19",
+      "resolved": "https://registry.npmjs.org/run-exclusive/-/run-exclusive-2.2.19.tgz",
+      "integrity": "sha512-K3mdoAi7tjJ/qT7Flj90L7QyPozwUaAG+CVhkdDje4HLKXUYC3N/Jzkau3flHVDLQVhiHBtcimVodMjN9egYbA==",
+      "dependencies": {
+        "minimal-polyfills": "^2.2.3"
       }
     },
     "node_modules/run-parallel": {

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "farmos": "^2.0.0-beta.16",
     "node-localstorage": "^3.0.5",
     "pinia": "^2.1.3",
+    "run-exclusive": "^2.2.19",
     "vue": "^3.3.4"
   },
   "devDependencies": {


### PR DESCRIPTION
**Pull Request Description**

This PR:
- Uses the `run-exclusive` package to fix a race condition that existed in the `getFarmOSInstance` method when multiple components were making concurrent calls to functions that created a farmOS instance.  The solution is essentially a mutex (or Java `synchronized` method) that allows only one thread of execution in the `getFarmOSInstance` at a time. This ensures that we do actually get only one farmOS instance.
- Enhances the testing of the caching of API results that is done by the various `get...` functions in the `farmosUtil.js` library.

---

**Licensing Certification**

FarmData2 is a [Free Cultural Work](https://freedomdefined.org/Definition) and all accepted contributions are licensed as described in the LICENSE.md file. This requires that the contributor holds the rights to do so. By submitting this pull request **I certify that I satisfy the terms of the [Developer Certificate of Origin](https://developercertificate.org/)** for its contents.
