### PR TITLE
feat(libs): adds function for creating asset--plant records

### DIFF
--- a/library/farmosUtil/farmosUtil.createPlantAsset.unit.cy.js
+++ b/library/farmosUtil/farmosUtil.createPlantAsset.unit.cy.js
@@ -1,0 +1,166 @@
+import * as farmosUtil from './farmosUtil.js';
+
+describe('Test the creation of plant assets', () => {
+  var farm = null;
+  var cropMap = null;
+
+  before(() => {
+    cy.wrap(
+      farmosUtil
+        .getFarmOSInstance('http://farmos', 'farm', 'admin', 'admin')
+        .then((newFarm) => {
+          farm = newFarm;
+        })
+    );
+
+    cy.wrap(
+      farmosUtil.getCropNameToTermMap().then((map) => {
+        cropMap = map;
+      })
+    );
+  });
+
+  beforeEach(() => {
+    cy.restoreLocalStorage();
+    cy.restoreSessionStorage();
+  });
+
+  afterEach(() => {
+    cy.saveLocalStorage();
+    cy.saveSessionStorage();
+  });
+
+  it('creates an asset--plant', () => {
+    cy.wrap(
+      farmosUtil
+        .createPlantAsset('testPlant', 'active', 'BROCCOLI')
+        .then((result) => {
+          expect(result.id).not.to.be.null;
+          expect(result.type).to.equal('asset--plant');
+          expect(result.attributes.name).to.equal('testPlant');
+          expect(result.attributes.status).to.equal('active');
+          expect(result.relationships.plant_type[0].type).to.equal(
+            'taxonomy_term--plant_type'
+          );
+          expect(result.relationships.plant_type[0].id).to.equal(
+            cropMap.get('BROCCOLI').id
+          );
+
+          return result.id;
+        })
+    ).then((id) => {
+      cy.wrap(farm.asset.delete('plant', id));
+    });
+  });
+
+  it('creates a plant--asset with additional opts', () => {
+    cy.wrap(
+      farmosUtil
+        .createPlantAsset('testPlant', 'active', 'BROCCOLI', {
+          notes: 'test note',
+          data: 'test data',
+        })
+        .then((result) => {
+          expect(result.id).not.to.be.null;
+          expect(result.type).to.equal('asset--plant');
+          expect(result.attributes.name).to.equal('testPlant');
+          expect(result.attributes.status).to.equal('active');
+          expect(result.relationships.plant_type[0].type).to.equal(
+            'taxonomy_term--plant_type'
+          );
+          expect(result.relationships.plant_type[0].id).to.equal(
+            cropMap.get('BROCCOLI').id
+          );
+
+          expect(result.attributes.notes.value).to.equal('test note');
+          expect(result.attributes.data).to.equal('test data');
+
+          return result.id;
+        })
+    ).then((id) => {
+      cy.wrap(farm.asset.delete('plant', id));
+    });
+  });
+
+  it('throws error if no assetName is provided', () => {
+    cy.wrap(
+      farmosUtil
+        .createPlantAsset(null, 'active', 'BROCCOLI')
+        .then(() => {
+          throw Error('Should throw error if assetName is not provided.');
+        })
+        .catch((err) => {
+          expect(err.message).to.equal('assetName is required.');
+        })
+    );
+  });
+
+  it('throws error if an unknown status is provided', () => {
+    cy.wrap(
+      farmosUtil
+        .createPlantAsset('testPlant', 'unknownStatus', 'BROCCOLI')
+        .then(() => {
+          throw Error('Should throw error if a valid status is not provided.');
+        })
+        .catch((err) => {
+          expect(err.message).to.equal(
+            'status is unknownStatus but must be one of [ "active" | "archived" ].'
+          );
+        })
+    );
+  });
+
+  it('throws error if an unknown cropName is provided', () => {
+    cy.wrap(
+      farmosUtil
+        .createPlantAsset('testPlant', 'active', 'NO_SUCH_CROP')
+        .then(() => {
+          throw Error('Should throw error if cropName is unknown.');
+        })
+        .catch((err) => {
+          expect(err.message).to.equal(
+            'Unable to find crop with name NO_SUCH_CROP.'
+          );
+        })
+    );
+  });
+
+  it('throws error on invalid property in additional opts', () => {
+    cy.wrap(
+      farmosUtil
+        .createPlantAsset('testPlant', 'active', 'BROCCOLI', {
+          parent: 'abc',
+        })
+        .then(() => {
+          throw Error(
+            'Should throw error when opts contains invalid property name.'
+          );
+        })
+        .catch((err) => {
+          expect(err.message).to.equal('Unable to create plant asset.');
+          expect(err.cause).not.to.be.null;
+        })
+    );
+  });
+
+  it('throws error on network error', () => {
+    cy.intercept('POST', '**/api/asset/*', {
+      // Note: forceNetworkError allows request to be sent and the
+      // asset is created.  So need to stub this response instead.
+      statusCode: 500,
+      body: 'bad request',
+    });
+
+    cy.wrap(
+      farmosUtil
+        .createPlantAsset('testPlant', 'active', 'BROCCOLI')
+        .then(() => {
+          throw Error('Should throw error on network failure.');
+        })
+        .catch((err) => {
+          expect(err.message).to.equal('Unable to create plant asset.');
+          expect(err.cause).not.to.be.null;
+        })
+    );
+  });
+});

--- a/library/farmosUtil/farmosUtil.js
+++ b/library/farmosUtil/farmosUtil.js
@@ -1047,11 +1047,46 @@ export async function getLogCategoryIdToTermMap() {
   return map;
 }
 
-export async function createPlantAsset(
-  farm,
-  { assetName, status, cropName },
-  opts = {}
-) {
+/**
+ * Creates a plant asset via the farmOS API.
+ * An `asset--plant` record will be created in the farmOS database.
+ *
+ * @param {string} assetName - The name of the plant asset.
+ * @param {string} status - The status of the plant asset. One of [ 'active' | 'archived' ]
+ * @param {string} cropName - The name of the crop that was planted.
+ * @param {Object} opts - Additional optional properties to be used when creating the plant asset.
+ *   Use `npm run printlog asset--plant` to see all properties available
+ *   for creating plant assets. Note: Properties nested in `attributes` and
+ *   `relationships` should not be nested when passed in `opts`
+ * @returns {Promise<Object>} The resulting `asset--plant` object.
+ * @throws {Error} if unable to create the plant asset.  If a network or farmOS
+ * server error occurs the original error object is provided by the
+ * `options.cause` property of the error object.
+ *
+ * @example
+ * ```JavaScript
+ * farmosUtil.createPlantAsset('testPlant', 'active', 'BROCCOLI',)
+ * .then((result) => {...})
+ * .catch((err) => {...})
+ * ```
+ */
+export async function createPlantAsset(assetName, status, cropName, opts = {}) {
+  if (!assetName) {
+    throw new Error('assetName is required.');
+  }
+
+  if (status != 'active' && status != 'archived') {
+    throw new Error(
+      `status is ${status} but must be one of [ "active" | "archived" ].`
+    );
+  }
+
+  const crop = (await getCropNameToTermMap()).get(cropName);
+  if (!crop) {
+    throw new Error(`Unable to find crop with name ${cropName}.`);
+  }
+  const cropId = crop.id;
+
   const plant = {
     ...{
       type: 'asset--plant',
@@ -1059,19 +1094,19 @@ export async function createPlantAsset(
       status: status,
       plant_type: {
         type: 'taxonomy_term--plant_type',
-        id: getCropNameToTermMap(farm).get(cropName).id,
+        id: cropId,
       },
     },
     ...opts,
   };
 
+  const farm = await getFarmOSInstance();
   const planting_asset = farm.asset.create(plant);
 
   try {
     const result = await farm.asset.send(planting_asset);
     return result;
   } catch (e) {
-    console.log(e);
-    throw new Error('Unable to create plant asset.');
+    throw new Error(`Unable to create plant asset.`, { cause: e });
   }
 }


### PR DESCRIPTION
**Pull Request Description**

Adds a function and associated tests to `farmosUtil.js` that simplifies the creation of `asset--plant` records.

---

**Licensing Certification**

FarmData2 is a [Free Cultural Work](https://freedomdefined.org/Definition) and all accepted contributions are licensed as described in the LICENSE.md file. This requires that the contributor holds the rights to do so. By submitting this pull request **I certify that I satisfy the terms of the [Developer Certificate of Origin](https://developercertificate.org/)** for its contents.
