### PR TITLE
fix: update to farmos2 image that includes CORS

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -17,7 +17,7 @@ services:
   farmos:
     depends_on:
       - db
-    image: farmdata2/farmos2:fd2.1
+    image: farmdata2/farmos2:fd2.2
     container_name: fd2_farmos
     volumes:
       # Mount a volume to hold the config information for farmos between runs.


### PR DESCRIPTION
**Pull Request Description**

Updates the `docker_comose.yml` file to use version `fd2.2` of the `farmos2` image.  This updated image includes CORS permissions in the farmOS server.  This allows the FarmData2 Vue apps to access the farmOS API from the dev and preview servers.

---

**Licensing Certification**

FarmData2 is a [Free Cultural Work](https://freedomdefined.org/Definition) and all accepted contributions are licensed as described in the LICENSE.md file. This requires that the contributor holds the rights to do so. By submitting this pull request **I certify that I satisfy the terms of the [Developer Certificate of Origin](https://developercertificate.org/)** for its contents.
