### PR TITLE
test: runs unit tests as component tests

### DIFF
--- a/bin/test.bash
+++ b/bin/test.bash
@@ -183,7 +183,7 @@ elif [ -n "$COMPONENT_TESTS" ]; then
   CYPRESS_TEST_TYPE="component"
 else
   echo "Unit testing requested."
-  CYPRESS_TEST_TYPE="e2e"
+  CYPRESS_TEST_TYPE="component"
 
   if [ -n "$TEST_FD2" ]; then
     echo "  Testing the farm_fd2 module."

--- a/library/cypress.config.js
+++ b/library/cypress.config.js
@@ -4,8 +4,7 @@ export default defineConfig({
   screenshotOnRunFailure: false,
   video: false,
   trashAssetsBeforeRuns: true,
-  e2e: {
-    baseUrl: 'http://farmos',
+  component: {
     specPattern: '**/*.unit.cy.js',
     devServer: {
       bundler: 'vite',

--- a/library/cypress/support/component-index.html
+++ b/library/cypress/support/component-index.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <meta
+      http-equiv="X-UA-Compatible"
+      content="IE=edge"
+    />
+    <meta
+      name="viewport"
+      content="width=device-width,initial-scale=1.0"
+    />
+    <title>Components App</title>
+  </head>
+  <body>
+    <div data-cy-root></div>
+  </body>
+</html>

--- a/library/cypress/support/component.js
+++ b/library/cypress/support/component.js
@@ -1,0 +1,32 @@
+/* eslint-disable no-undef */
+// ***********************************************************
+// This example support/component.js is processed and
+// loaded automatically before your test files.
+//
+// This is a great place to put global configuration and
+// behavior that modifies Cypress.
+//
+// You can change the location of this file or turn off
+// automatically serving support files with the
+// 'supportFile' configuration option.
+//
+// You can read more here:
+// https://on.cypress.io/configuration
+// ***********************************************************
+
+// Import commands.js using ES2015 syntax:
+import './commands';
+
+// Alternatively you can use CommonJS syntax:
+// require('./commands')
+
+import { mount } from 'cypress/vue';
+
+Cypress.Commands.add('mount', mount);
+
+// Example use:
+// cy.mount(MyComponent)
+
+// Import the bootstrap Vue CSS files
+import 'bootstrap/dist/css/bootstrap.css';
+import 'bootstrap-vue-next/dist/bootstrap-vue-next.css';

--- a/library/farmosUtil/farmosUtil.units.unit.cy.js
+++ b/library/farmosUtil/farmosUtil.units.unit.cy.js
@@ -14,17 +14,17 @@ describe('Test the units utility functions', () => {
   it('Get the units', () => {
     cy.wrap(farmosUtil.getUnits()).then((units) => {
       expect(units).to.not.be.null;
-      expect(units.length).to.equal(5);
+      expect(units.length).to.equal(7);
 
-      expect(units[0].attributes.name).to.equal('CELLS/TRAY');
+      expect(units[0].attributes.name).to.equal('CELLS');
       expect(units[0].attributes.description.value).to.equal(
-        'The number of cells in a tray.'
+        'A number of seeding tray cells.'
       );
       expect(units[0].type).to.equal('taxonomy_term--unit');
 
-      expect(units[4].attributes.name).to.equal('TRAYS');
+      expect(units[4].attributes.name).to.equal('SEEDS');
       expect(units[4].attributes.description.value).to.equal(
-        'A number of seeding trays.'
+        'A number of seeds.'
       );
       expect(units[4].type).to.equal('taxonomy_term--unit');
     });
@@ -113,7 +113,7 @@ describe('Test the units utility functions', () => {
   it('Get the unitToTerm map', () => {
     cy.wrap(farmosUtil.getUnitToTermMap()).then((unitMap) => {
       expect(unitMap).to.not.be.null;
-      expect(unitMap.size).to.equal(5);
+      expect(unitMap.size).to.equal(7);
 
       expect(unitMap.get('Count')).to.not.be.null;
       expect(unitMap.get('Count').type).to.equal('taxonomy_term--unit');
@@ -126,7 +126,7 @@ describe('Test the units utility functions', () => {
   it('Get the UnitIdToAsset map', () => {
     cy.wrap(farmosUtil.getUnitIdToTermMap()).then((unitIdMap) => {
       expect(unitIdMap).to.not.be.null;
-      expect(unitIdMap.size).to.equal(5);
+      expect(unitIdMap.size).to.equal(7);
 
       cy.wrap(farmosUtil.getUnitToTermMap()).then((unitNameMap) => {
         const countId = unitNameMap.get('Count').id;

--- a/modules/cypress.unit.config.js
+++ b/modules/cypress.unit.config.js
@@ -4,9 +4,9 @@ export default defineConfig({
   screenshotOnRunFailure: false,
   video: false,
   trashAssetsBeforeRuns: true,
-  e2e: {
-    baseUrl: 'http://farmos',
-    supportFile: '../cypress/support/e2e.js',
+  component: {
+    supportFile: '../cypress/support/component.js',
+    indexHtmlFile: '../cypress/support/component-index.html',
     specPattern: '**/*.unit.cy.js',
     devServer: {
       bundler: 'vite',


### PR DESCRIPTION
**Pull Request Description**

Changes all unit tests to run as component tests instead of as e2e tests.  This is a better way to run the unit tests because they do not need to access actual application pages.

Also, touches up a unit test to match a change in the units in the sample database.

---

**Licensing Certification**

FarmData2 is a [Free Cultural Work](https://freedomdefined.org/Definition) and all accepted contributions are licensed as described in the LICENSE.md file. This requires that the contributor holds the rights to do so. By submitting this pull request **I certify that I satisfy the terms of the [Developer Certificate of Origin](https://developercertificate.org/)** for its contents.
