### PR TITLE
chore: updates the farmos2 image in docker_compose.yml

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -17,7 +17,7 @@ services:
   farmos:
     depends_on:
       - db
-    image: farmdata2/farmos2:fd2.2
+    image: farmdata2/farmos2:fd2.3
     container_name: fd2_farmos
     volumes:
       # Mount a volume to hold the config information for farmos between runs.


### PR DESCRIPTION
**Pull Request Description**

This PR updates the `docker/docker_compose.yml` file to use a new version of the `farmos2` image.  The new version includes some database configuration information that simplifies the installation process.

---

**Licensing Certification**

FarmData2 is a [Free Cultural Work](https://freedomdefined.org/Definition) and all accepted contributions are licensed as described in the LICENSE.md file. This requires that the contributor holds the rights to do so. By submitting this pull request **I certify that I satisfy the terms of the [Developer Certificate of Origin](https://developercertificate.org/)** for its contents.
