### PR TITLE
fix: corrects group for docker/db directory

### DIFF
--- a/bin/installDB.bash
+++ b/bin/installDB.bash
@@ -86,10 +86,10 @@ echo "  Stopped."
 
 # # Make sure that the FarmData2/docker/db directory has appropriate permissions.
 echo "Setting permissions on $REPO_DIR/docker/db..."
+sudo chgrp fd2grp "$REPO_DIR/docker/db"
+error_check "Unable to change group."
 sudo chmod g+rwx "$REPO_DIR/docker/db"
 error_check "Unable to set permissions."
-sudo chgrp fd2dev "$REPO_DIR/docker/db"
-error_check "Unable to change group."
 echo "  Set."
 
 safe_cd "$DB_DIR"


### PR DESCRIPTION
**Pull Request Description**

The `bin/installDB.bash` script assigned the incorrect group to the `docker/db` directory.  This PR corrects that so that the `docker/db` directory has the group `fd2grp`.  This enables that directory to be written by the `fd2dev` user within the `fd2dev` container.

---

**Licensing Certification**

FarmData2 is a [Free Cultural Work](https://freedomdefined.org/Definition) and all accepted contributions are licensed as described in the LICENSE.md file. This requires that the contributor holds the rights to do so. By submitting this pull request **I certify that I satisfy the terms of the [Developer Certificate of Origin](https://developercertificate.org/)** for its contents.
