### PR TITLE
chore: migrates to farmOS v3 and postgres v13

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,12 +1,12 @@
 version: '3'
 services:
   db:
-    image: farmdata2/postgres:fd2.1
+    image: farmdata2/postgres:fd2.2
     container_name: fd2_postgres
     volumes:
       # Use docker volume for performance.
       # Bump version here and in volumes if new image requires new db.
-      - farmos2_db_fd2.1:/var/lib/postgresql/data
+      - farmos3_db_fd2.1:/var/lib/postgresql/data
     ports:
       - '5432:5432'
     environment:
@@ -17,13 +17,13 @@ services:
   farmos:
     depends_on:
       - db
-    image: farmdata2/farmos2:fd2.3
+    image: farmdata2/farmos3:fd2.1
     container_name: fd2_farmos
     volumes:
       # Mount a volume to hold the config information for farmos between runs.
-      - farmos2_config_fd2.1:/opt/drupal/web/sites
+      - farmos3_config_fd2.1:/opt/drupal/web/sites
       # Mount a volume to hold the farmos api keys
-      - farmos2_keys_fd2.1:/opt/drupal/keys
+      - farmos3_keys_fd2.1:/opt/drupal/keys
       # Mount the dist directories containing the fd2 modules into the farmOS container.
       - ../modules/farm_fd2/dist/farmdata2:/opt/drupal/web/sites/all/modules/farmdata2
       - ../modules/farm_fd2_examples/dist/fd2_examples:/opt/drupal/web/sites/all/modules/fd2_examples
@@ -54,7 +54,7 @@ services:
       # This allows switching the database from within the dev container.
       # This has significantly better performance than mounting a host directory.
       # Bump the version here if a new db volume is required.
-      - farmos2_db_fd2.1:/home/fd2dev/FarmData2/docker/db
+      - farmos3_db_fd2.1:/home/fd2dev/FarmData2/docker/db
       # Mount the fd2 development environment configuration information.
       - ~/.fd2:/home/fd2dev/.fd2
     ports:
@@ -62,7 +62,7 @@ services:
       - 6901:6901
 
 volumes:
-  farmos2_db_fd2.1:
-  farmos2_config_fd2.1:
-  farmos2_keys_fd2.1:
+  farmos3_db_fd2.1:
+  farmos3_config_fd2.1:
+  farmos3_keys_fd2.1:
   fd2dev_home_fd2.3:


### PR DESCRIPTION
**Pull Request Description**

This PR updates the `docker/docker-compose.yml` file to use new images for the farmOS and postgres.
- The farmOS image updates to v3.x.
- The postgres image updates to v13 (required by farmOS v3.x)

Closes https://github.com/FarmData2/FarmData2/issues/64

---

**Licensing Certification**

FarmData2 is a [Free Cultural Work](https://freedomdefined.org/Definition) and all accepted contributions are licensed as described in the LICENSE.md file. This requires that the contributor holds the rights to do so. By submitting this pull request **I certify that I satisfy the terms of the [Developer Certificate of Origin](https://developercertificate.org/)** for its contents.
