### PR TITLE
fix: creates new farmOS instance of url, client or user change

### DIFF
--- a/library/farmosUtil/farmosUtil.getFarmInstance.unit.cy.js
+++ b/library/farmosUtil/farmosUtil.getFarmInstance.unit.cy.js
@@ -60,9 +60,7 @@ describe('Test getFarmOSInstance', () => {
     expect(localStorage.getItem('token')).to.be.null;
     expect(sessionStorage.getItem('schema')).to.be.null;
 
-    cy.wrap(
-      farmosUtil.getFarmOSInstance('http://farmos', 'farm', 'admin', 'admin')
-    ).then((newFarm) => {
+    cy.wrap(farmosUtil.getFarmOSInstance()).then((newFarm) => {
       expect(newFarm).to.not.be.null;
       expect(newFarm.remote.getToken()).to.not.be.null;
       expect(newFarm.schema.get()).to.not.be.null;
@@ -101,9 +99,7 @@ describe('Test getFarmOSInstance', () => {
       expect(localStorage.getItem('token')).to.not.be.null;
       expect(sessionStorage.getItem('schema')).to.not.be.null;
 
-      cy.wrap(
-        farmosUtil.getFarmOSInstance('http://farmos', 'farm', 'admin', 'admin')
-      ).then((newFarm) => {
+      cy.wrap(farmosUtil.getFarmOSInstance()).then((newFarm) => {
         expect(newFarm).to.not.be.null;
         expect(newFarm.remote.getToken()).to.not.be.null;
         expect(newFarm.schema.get()).to.not.be.null;
@@ -143,9 +139,7 @@ describe('Test getFarmOSInstance', () => {
     expect(localStorage.getItem('token')).to.be.null;
     expect(sessionStorage.getItem('schema')).to.not.be.null;
 
-    cy.wrap(
-      farmosUtil.getFarmOSInstance('http://farmos', 'farm', 'admin', 'admin')
-    ).then((newFarm) => {
+    cy.wrap(farmosUtil.getFarmOSInstance()).then((newFarm) => {
       expect(newFarm).to.not.be.null;
       expect(newFarm.remote.getToken()).to.not.be.null;
       expect(newFarm.schema.get()).to.not.be.null;
@@ -184,9 +178,7 @@ describe('Test getFarmOSInstance', () => {
     expect(localStorage.getItem('token')).to.not.be.null;
     expect(sessionStorage.getItem('schema')).to.not.be.null;
 
-    cy.wrap(
-      farmosUtil.getFarmOSInstance('http://farmos', 'farm', 'admin', 'admin')
-    ).then((newFarm) => {
+    cy.wrap(farmosUtil.getFarmOSInstance()).then((newFarm) => {
       expect(newFarm).to.not.be.null;
       expect(newFarm.remote.getToken()).to.not.be.null;
       expect(newFarm.schema.get()).to.not.be.null;
@@ -228,9 +220,7 @@ describe('Test getFarmOSInstance', () => {
     expect(localStorage.getItem('token')).to.not.be.null;
     expect(sessionStorage.getItem('schema')).to.be.null;
 
-    cy.wrap(
-      farmosUtil.getFarmOSInstance('http://farmos', 'farm', 'admin', 'admin')
-    ).then((newFarm) => {
+    cy.wrap(farmosUtil.getFarmOSInstance()).then((newFarm) => {
       expect(newFarm).to.not.be.null;
       expect(newFarm.remote.getToken()).to.not.be.null;
       expect(newFarm.schema.get()).to.not.be.null;
@@ -274,9 +264,7 @@ describe('Test getFarmOSInstance', () => {
     expect(localStorage.getItem('token')).to.be.null;
     expect(sessionStorage.getItem('schema')).to.be.null;
 
-    cy.wrap(
-      farmosUtil.getFarmOSInstance('http://farmos', 'farm', 'admin', 'admin')
-    ).then((newFarm) => {
+    cy.wrap(farmosUtil.getFarmOSInstance()).then((newFarm) => {
       expect(newFarm).to.not.be.null;
       expect(newFarm.remote.getToken()).to.not.be.null;
       expect(newFarm.schema.get()).to.not.be.null;
@@ -294,9 +282,7 @@ describe('Test getFarmOSInstance', () => {
   });
 
   it('Test writing to farmOS.', () => {
-    cy.wrap(
-      farmosUtil.getFarmOSInstance('http://farmos', 'farm', 'admin', 'admin')
-    ).then((newFarm) => {
+    cy.wrap(farmosUtil.getFarmOSInstance()).then((newFarm) => {
       // Create a log in farmOS.
       const p1 = {
         type: 'log--activity',
@@ -335,4 +321,38 @@ describe('Test getFarmOSInstance', () => {
         });
     });
   });
+
+  it.only('Creates new farmOSInstance when user changes.', () => {
+    cy.wrap(farmosUtil.getFarmOSInstance()).then((adminFarm) => {
+      cy.wrap(
+        farmosUtil.getFarmOSInstance(
+          'http://farmos',
+          'farm',
+          'guest',
+          'farmdata2'
+        )
+      ).then((guestFarm) => {
+        expect(guestFarm).to.not.equal(adminFarm);
+
+        cy.wrap(guestFarm.user.fetch({ filter: { type: 'user--user' } })).as(
+          'fetchUsers'
+        );
+      });
+    });
+
+    cy.get('@fetchUsers').then((users) => {
+      expect(users.data.length).to.equal(10);
+      // The guest user does not get role data when fetching but admin does.
+      expect(users.data[2].relationships.roles).to.not.exist;
+    });
+  });
+
+  /*
+   * Note: We only have one farmOS server and one client in that server so
+   * we can't really test for the cases where the hostURL or the client
+   * changes.  However, they are handled in the same place as the user change
+   * so if that works, we can have high confidence that the others work.
+   *
+   * They are also unlikely use cases.
+   */
 });

--- a/library/farmosUtil/farmosUtil.js
+++ b/library/farmosUtil/farmosUtil.js
@@ -132,6 +132,30 @@ export const getFarmOSInstance = runExclusive.build(
       }
     }
 
+    /*
+     * If there have been any changes in the hostURL, client or user
+     * then invalidate the old instance, so that a new instance
+     * is created for the new server, client and/or user.
+     */
+    const prevHostURL = libSessionStorage.getItem('hostURL');
+    const prevClient = libSessionStorage.getItem('client');
+    const prevUser = libSessionStorage.getItem('user');
+    if (prevHostURL !== hostURL || prevClient !== client || prevUser !== user) {
+      clearFarmGlobal();
+      libSessionStorage.setItem('hostURL', hostURL);
+      libSessionStorage.setItem('client', client);
+      libSessionStorage.setItem('user', user);
+      libLocalStorage.removeItem('token');
+      libSessionStorage.removeItem('schema');
+      clearCachedUsers();
+      clearCachedFieldsAndBeds();
+      clearCachedGreenhouses();
+      clearCachedCrops();
+      clearCachedTraySizes();
+      clearCachedUnits();
+      clearCachedLogCategories();
+    }
+
     // Only create a new farm object if we don't already have one in global_farm.
     let newfarm = false;
     if (!global_farm) {


### PR DESCRIPTION
**Pull Request Description**

Modified the `farmosUtil.getFarmOSInstance()` method so that if the `hostURL`, `client` or `user` change then a new farmOS instance is created and the old one is disposed of.  This allows code to log in as different users to test features that behave differently for different users.

---

**Licensing Certification**

FarmData2 is a [Free Cultural Work](https://freedomdefined.org/Definition) and all accepted contributions are licensed as described in the LICENSE.md file. This requires that the contributor holds the rights to do so. By submitting this pull request **I certify that I satisfy the terms of the [Developer Certificate of Origin](https://developercertificate.org/)** for its contents.
