### PR TITLE
refactor: clarifies implementation of getFarmOSIinstance w.r.t. password grant authentication

### DIFF
--- a/library/cypress/support/commands.js
+++ b/library/cypress/support/commands.js
@@ -61,3 +61,19 @@ Cypress.Commands.add('restoreSessionStorage', () => {
     sessionStorage.setItem(key, SESSION_STORAGE_MEMORY[key]);
   });
 });
+
+/*
+ * Cypress command that allows us to get multiple aliases
+ * using a single command such as:
+ * cy.getAll(['@alias1', '@alias2', '@alias3']), rather than a chain of
+ * cy.get('@alias1').then((name) => ...) commands.
+ *
+ * This simplifies the code in a number of test functions.
+ *
+ * Function adapted from: https://stackoverflow.com/a/76985546
+ */
+Cypress.Commands.add('getAll', function (aliasNames) {
+  return aliasNames.map((a) => {
+    return this[a.substring(1)];
+  });
+});


### PR DESCRIPTION
**Pull Request Description**

This PR:
- adds the `cy.getAll` command `commands.js` for all of the cypress configurations.
- refactors the `getFarmOSInstance()` function to more clearly delineate between running in farmOS and running in the dev environment or Node.  This made the code much more clear and easier to see that the password authentication is not being used when running inside of farmOS.

---

**Licensing Certification**

FarmData2 is a [Free Cultural Work](https://freedomdefined.org/Definition) and all accepted contributions are licensed as described in the LICENSE.md file. This requires that the contributor holds the rights to do so. By submitting this pull request **I certify that I satisfy the terms of the [Developer Certificate of Origin](https://developercertificate.org/)** for its contents.
