### PR TITLE
feat(lib): updates to the library functions and tests

### DIFF
--- a/library/README.md
+++ b/library/README.md
@@ -14,8 +14,7 @@ Javascript library of FarmData2 custom reusable functions.
 
 Any `it` with an `intercept` should include `{ retries: 4 }` to tolerate some of the flake that appears to go with `cy.intercept`.
 
-The database is reset to the most recently installed db before running the tests.
-Any test that absolutely requires a clean database (i.e. cannot tolerate changes made by prior tests) can reset it in the `before` hook.
+Best practice is to [reset the database state before tests are run](https://docs.cypress.io/guides/references/best-practices#State-reset-should-go-before-each-test). Doing this before every test or even at the start of every file adds significantly to the runtime of the test suite. FarmData2 compromises by resetting the database to the DB that was most recently installed (i.e. using `installDB.bash`) before each test run. A test run is one cypress command (e.g. as is done by `test.bash --comp`). Any test that absolutely requires a clean database (i.e. cannot tolerate changes made by prior tests) can reset it in its `before` hook using the following code:
 
 ```Javascript
   before(() => {

--- a/library/farmosUtil/farmosUtil.crops.unit.cy.js
+++ b/library/farmosUtil/farmosUtil.crops.unit.cy.js
@@ -63,9 +63,10 @@ describe('Test the crop utility functions', () => {
         expect(sessionStorage.getItem('crops')).not.to.be.null;
       })
       .then(() => {
-        // Now check that the global is used.
+        // Now check that the global is used and sessionStorage cache is repopulated.
         sessionStorage.removeItem('crops');
         cy.wrap(farmosUtil.getCrops()).then(() => {
+          // No more api calls were made.
           cy.get('@fetchCrops').its('callCount').should('equal', 3);
           expect(farmosUtil.getGlobalCrops()).not.to.be.null;
           expect(sessionStorage.getItem('crops')).to.be.null;

--- a/library/farmosUtil/farmosUtil.getFarmInstance.unit.cy.js
+++ b/library/farmosUtil/farmosUtil.getFarmInstance.unit.cy.js
@@ -1,13 +1,5 @@
 import * as farmosUtil from './farmosUtil.js';
 
-/*
- * NOTE: The tests in this file assume that they are run
- * in order. This is a necessary assumption because they are
- * testing the caching behavior of the farmOS object, the
- * authentication token and the schema.  To do so, later tests
- * must rely on earlier tests having cached these items.
- */
-
 describe('Test getFarmOSInstance', () => {
   beforeEach(() => {
     cy.restoreLocalStorage();
@@ -354,7 +346,6 @@ describe('Test getFarmOSInstance', () => {
         cy.wrap(newFarm.log.send(a1)).as('sendLog');
       });
 
-    //cy.get('@sendLog').then(() => {
     cy.getAll(['@newFarm', '@sendLog']).then(([newFarm, sendLog]) => {
       // fetch the created log.
       cy.wrap(
@@ -368,22 +359,14 @@ describe('Test getFarmOSInstance', () => {
       ).as('fetchLog');
     });
 
-    //    cy.get('@fetchLog')
-    cy.getAll(['@newFarm', '@fetchLog'])
-      .then(([newFarm, fetchLog]) => {
-        expect(fetchLog.type).to.equal('log--activity');
-        expect(fetchLog.id).to.equal(fetchLog.id);
-        expect(fetchLog.attributes.name).to.equal('test log');
-        expect(fetchLog.attributes.notes.value).to.equal(
-          'testing writes to farmOS'
-        );
-        let id = fetchLog.id;
-        return { newFarm, id };
-      })
-      .then(({ newFarm, id }) => {
-        // delete the log.
-        cy.wrap(newFarm.log.delete('activity', id));
-      });
+    cy.get('@fetchLog').then((fetchLog) => {
+      expect(fetchLog.type).to.equal('log--activity');
+      expect(fetchLog.id).to.equal(fetchLog.id);
+      expect(fetchLog.attributes.name).to.equal('test log');
+      expect(fetchLog.attributes.notes.value).to.equal(
+        'testing writes to farmOS'
+      );
+    });
   });
 
   it('Test switching users.', () => {

--- a/library/uiUtil/uiUtil.js
+++ b/library/uiUtil/uiUtil.js
@@ -6,6 +6,8 @@
 
 import { useToast } from 'bootstrap-vue-next';
 
+let toast = undefined;
+
 /**
  * Shows a toast message with the given title, message, placement, variant, and duration.
  * The toast can be dismissed by clicking the _close_ button or it will be automatically
@@ -18,10 +20,10 @@ import { useToast } from 'bootstrap-vue-next';
  * `middle-right`, `bottom-left`, `bottom-center`, and`bottom-right`.
  * @param {string} variant - The variant of the toast message. Valid variants are:
  * `primary`, `secondary`, `success`, `danger`, `warning`, and `info`, `light`, and `dark`.
- * @param {number} duration - The duration of the toast message in seconds.
+ * @param {number} duration - The duration of the toast message in seconds. This defaults to 1 hour (i.e. until dismissed).
  */
-export function showToast(title, message, placement, variant, duration) {
-  useToast().show(message, {
+export function showToast(title, message, placement, variant, duration = 3600) {
+  toast = useToast().show(message, {
     variant: variant,
     pos: placement,
     title: title,
@@ -31,4 +33,14 @@ export function showToast(title, message, placement, variant, duration) {
       variant: 'secondary',
     },
   });
+}
+
+/**
+ * Hides the currently shown toast message.
+ */
+export function hideToast() {
+  if (toast) {
+    useToast().hide(toast);
+    toast = undefined;
+  }
 }


### PR DESCRIPTION
**Pull Request Description**

This PR: 
 - documents the way the sample database is reset when running cypress tests.
 - clarifies the operation of the `farmosUtil.crops.unit.cy.js` tests
 - simplifies and fixes the `inFarmOS` function used by `getFarmOSInstance`
 - removes database cleanup from `farmosUtil.getFarmInstance.unit.cy.js`
 - removes comment describing the order dependency in `farmosUtil.getFarmInstance.unit.cy.js` because the tests no longer have an order dependency.
 - adds the `hideToast` function to `uiUtil.js` to programmatically hide a toast.

Partially addresses #101

---

**Licensing Certification**

FarmData2 is a [Free Cultural Work](https://freedomdefined.org/Definition) and all accepted contributions are licensed as described in the LICENSE.md file. This requires that the contributor holds the rights to do so. By submitting this pull request **I certify that I satisfy the terms of the [Developer Certificate of Origin](https://developercertificate.org/)** for its contents.
