### PR TITLE
feat(fd2): add the Tray Seeing entrypoint

### DIFF
--- a/docs/DataModel.md
+++ b/docs/DataModel.md
@@ -1,0 +1,72 @@
+# FarmData2 Data Model
+
+## Log Categories
+
+- Seeding Logs
+  - `seeding_tray`
+  - `seeding_direct`
+  - `seeding_cover_crop`
+
+## Units
+
+## Log/Asset Naming Conventions
+
+The general convention for naming logs and assets is:
+
+- `yyyy-mm-dd_<type>_<description>`
+  - `<type>` is an abbreviation for the type of operation
+    - `ts` - tray seeding
+    - `ds` - direct seeding
+    - `cs` - cover crop seeding
+    - `xp` - transplanting
+    - `ha` - harvesting
+    - `sd` - soil disturbance
+    - `sa` - soil amendment
+
+### Assets
+
+### Logs
+
+### Quantities
+
+## Seeding Operations
+
+### Tray Seeding
+
+A tray seeding represents the activity and product of planting seeds in trays in a greenhouse.
+
+A tray seeding consists of:
+
+- A `asset--plant` representing the seeded plant in the greenhouse.
+  - The `Inventory` of this asset represents the number of trays currently available for transplanting and is managed by quantities attached to logs via the farmOS Inventory module.
+  - Comments associated with the tray seeding are stored in the `asset--plant` asset.
+- A `log--seeding` representing the seeding activity.
+- Three `quantity--standard` records with the labels:
+
+  - `Trays`: The number of trays that were seeded. This quantity sets the plant asset's inventory.
+  - `Tray Size`:The number of cells in each tray.
+  - `Seeds`:The total number of seeds planted. Note: This is computed from the other data entered in the form (trays x cells per tray x seeds per cell).
+
+- Logs and assets associated with a tray seeding will be named: `yyyy-mm-dd_ts_cropName`
+
+See `modules/farm_fd2/src/entrypoints/tray_seeding/lib.js` for the details of how the asset, quantities and log are created.
+
+### Direct Seeding
+
+- Keep row/feet as inventory on the planting.
+
+### Cover Crop Seeding
+
+## Transplanting
+
+- Decrease Trays inventory on the planting and create new in ground planting for each transplant operation.
+
+NOTE: There is no transplant log type.
+
+- Possibly just use an some type of log with a transplanting log category?
+
+## Harvesting
+
+- Decrease row/feed inventory on the in ground planting.
+
+## Soil Disturbance

--- a/modules/css/fd2-mobile.css
+++ b/modules/css/fd2-mobile.css
@@ -1,0 +1,69 @@
+/* 
+ * This css adjusts and removes some of the default
+ * farmOS and Bootstrap Vue next styling so that we 
+ * get more screen real estate on small devices.
+ *
+ * It is designed to be the last piece imported and
+ * should override every other setting to ensure that
+ * the mobile pages are styled as intended.  Thus, all
+ * of the `!important`s.
+ */
+
+#block-gin-page-title {
+  display: none;
+}
+
+header.region {
+  display: none;
+}
+
+div.help {
+  display: none;
+}
+
+div.region {
+  margin-top: 0px !important;
+}
+
+hr {
+  margin-top: 8px !important;
+  margin-bottom: 8px !important;
+}
+
+h2.text-center {
+  margin-top: 0px !important;
+  margin-bottom: 3px !important;
+}
+
+.card-header {
+  padding: 0px !important;
+  margin: 0px !important;
+}
+
+.card {
+  border-radius: 0px !important;
+}
+
+.card-body {
+  padding-top: 5px !important;
+  padding-bottom: 5px !important;
+}
+
+.gin-secondary-toolbar {
+  height: 36px !important;
+}
+
+.layout-container {
+  margin-top: 0px !important;
+  margin-left: 0px !important;
+  margin-right: 0px !important;
+  margin-bottom: 0px !important;
+}
+
+#block-farm-powered {
+  margin-top: 0px !important;
+  padding-top: 0px !important;
+  margin-left: 0px !important;
+  padding-bottom: 0px !important;
+  border-top: 0px !important;
+}

--- a/modules/farm_fd2/src/composer.json
+++ b/modules/farm_fd2/src/composer.json
@@ -9,9 +9,6 @@
       "name": "Grant Braught",
       "email": "braughtg@gmail.com",
       "role": "Maintainer"
-    },
-    {
-      "name": "Joe Smith"
     }
   ],
   "homepage": "https://github.com/DickinsonCollege/FarmData2",
@@ -21,8 +18,5 @@
     "source": "https://github.com/DickinsonCollege/FarmData2",
     "forum": "https://farmdata2.zulipchat.com/",
     "chat": "https://farmdata2.zulipchat.com/"
-  },
-  "require": {
-    "drupal/core": "^9"
   }
 }

--- a/modules/farm_fd2/src/entrypoints/tray_seeding/App.vue
+++ b/modules/farm_fd2/src/entrypoints/tray_seeding/App.vue
@@ -1,0 +1,311 @@
+<template>
+  <div>
+    <BToaster />
+    <BCard
+      bg-variant="light"
+      header-tag="header"
+    >
+      <template #header>
+        <h2
+          data-cy="seeding-header"
+          class="text-center"
+        >
+          Tray Seeding
+        </h2>
+      </template>
+
+      <BForm>
+        <!-- Seeding Date -->
+        <DateSelector
+          id="seeding-date"
+          data-cy="seeding-date"
+          required
+          v-model:date="form.seedingDate"
+          v-bind:showValidityStyling="validity.show"
+          v-on:valid="validity.seedingDate = $event"
+          v-on:ready="createdCount++"
+        />
+
+        <!-- Crop Selection -->
+        <CropSelector
+          id="seeding-crop-name"
+          data-cy="seeding-crop-name"
+          required
+          v-model:selected="form.cropName"
+          v-bind:showValidityStyling="validity.show"
+          v-on:valid="validity.cropName = $event"
+          v-on:ready="createdCount++"
+          v-on:error="(msg) => showErrorToast('Network Error', msg)"
+        />
+
+        <!-- Location Selection -->
+        <LocationSelector
+          id="seeding-location-name"
+          data-cy="seeding-location-name"
+          required
+          includeGreenhouses
+          v-model:selected="form.locationName"
+          v-bind:showValidityStyling="validity.show"
+          v-on:valid="validity.locationName = $event"
+          v-on:ready="createdCount++"
+          v-on:error="(msg) => showErrorToast('Network Error', msg)"
+        />
+
+        <hr />
+
+        <!-- Number of Trays -->
+        <NumericInput
+          id="seeding-trays"
+          data-cy="seeding-trays"
+          required
+          label="Trays"
+          invalidFeedbackText="Trays must be positive."
+          v-model:value="form.trays"
+          v-bind:showValidityStyling="validity.show"
+          v-bind:decimalPlaces="2"
+          v-bind:incDecValues="[1, 5, 10]"
+          v-bind:minValue="0.01"
+          v-on:valid="validity.trays = $event"
+          v-on:ready="createdCount++"
+        />
+
+        <!-- Tray Size -->
+        <TraySizeSelector
+          id="seeding-tray-size"
+          data-cy="seeding-tray-size"
+          required
+          v-model:selected="form.traySize"
+          v-bind:showValidityStyling="validity.show"
+          v-on:valid="validity.traySize = $event"
+          v-on:ready="createdCount++"
+          v-on:error="(msg) => showErrorToast('Network Error', msg)"
+        />
+
+        <!-- Number of Seed / Cell -->
+        <NumericInput
+          id="seeding-seeds"
+          data-cy="seeding-seeds"
+          required
+          label="Seeds/Cell"
+          invalidFeedbackText="Seeds must be positive."
+          v-model:value="form.seedsPerCell"
+          v-bind:showValidityStyling="validity.show"
+          v-bind:decimalPlaces="0"
+          v-bind:incDecValues="[1]"
+          v-bind:minValue="1"
+          v-on:valid="validity.seedsPerCell = $event"
+          v-on:ready="createdCount++"
+        />
+
+        <!-- Total Seeds -->
+        <TextDisplay
+          id="seeding-total-seeds"
+          data-cy="seeding-total-seeds"
+          label="Total Seeds"
+          v-bind:text="totalSeeds"
+          v-on:ready="createdCount++"
+        />
+
+        <hr />
+        <!-- Comment Box -->
+        <CommentBox
+          id="seeding-comment"
+          data-cy="seeding-comment"
+          v-model:comment="form.comment"
+          v-on:valid="validity.comment = $event"
+          v-on:ready="createdCount++"
+        />
+
+        <!-- Submit and Reset Buttons -->
+        <SubmitResetButtons
+          id="seeding-submit-reset"
+          data-cy="seeding-submit-reset"
+          v-bind:enableSubmit="enableSubmit"
+          v-bind:enableReset="enableReset"
+          v-on:ready="createdCount++"
+          v-on:submit="submit()"
+          v-on:reset="reset()"
+        />
+      </BForm>
+    </BCard>
+
+    <div
+      data-cy="page-loaded"
+      v-show="false"
+    >
+      {{ pageDoneLoading }}
+    </div>
+  </div>
+</template>
+
+<script>
+import dayjs from 'dayjs';
+import CropSelector from '@comps/CropSelector/CropSelector.vue';
+import DateSelector from '@comps/DateSelector/DateSelector.vue';
+import LocationSelector from '@comps/LocationSelector/LocationSelector.vue';
+import NumericInput from '@comps/NumericInput/NumericInput.vue';
+import TraySizeSelector from '@comps/TraySizeSelector/TraySizeSelector.vue';
+import TextDisplay from '@comps/TextDisplay/TextDisplay.vue';
+import CommentBox from '@comps/CommentBox/CommentBox.vue';
+import SubmitResetButtons from '@comps/SubmitResetButtons/SubmitResetButtons.vue';
+import * as uiUtil from '@libs/uiUtil/uiUtil.js';
+import * as lib from './lib.js';
+
+export default {
+  components: {
+    CropSelector,
+    DateSelector,
+    LocationSelector,
+    NumericInput,
+    TraySizeSelector,
+    TextDisplay,
+    CommentBox,
+    SubmitResetButtons,
+  },
+  data() {
+    return {
+      form: {
+        seedingDate: dayjs().format('YYYY-MM-DD'),
+        cropName: null,
+        locationName: null,
+        trays: 1,
+        traySize: null,
+        seedsPerCell: 1,
+        comment: null,
+      },
+      validity: {
+        show: false,
+        seedingDate: false,
+        cropName: false,
+        locationName: false,
+        trays: false,
+        traySize: false,
+        seedsPerCell: false,
+        comment: false,
+      },
+      enableSubmit: true,
+      enableReset: true,
+      errorShown: false,
+      createdCount: 0,
+    };
+  },
+  computed: {
+    totalSeeds() {
+      return (
+        this.form.trays *
+        parseInt(this.form.traySize) *
+        this.form.seedsPerCell
+      ).toLocaleString(undefined);
+    },
+    pageDoneLoading() {
+      return this.createdCount == 10;
+    },
+  },
+  methods: {
+    submit() {
+      this.validity.show = true;
+
+      // If all of the form values are valid...
+      if (Object.values(this.validity).every((item) => item === true)) {
+        this.disableSubmit = true;
+        this.disableReset = true;
+
+        uiUtil.showToast(
+          'Submitting tray seeding...',
+          '',
+          'top-center',
+          'success'
+        );
+
+        lib
+          .submitForm(this.form)
+          .then(() => {
+            uiUtil.hideToast();
+            this.reset(true);
+            uiUtil.showToast(
+              'Tray seeding created.',
+              '',
+              'top-center',
+              'success',
+              2
+            );
+          })
+          .catch(() => {
+            uiUtil.hideToast();
+            this.showErrorToast(
+              'Error creating tray seeding.',
+              'Check your network connection and try again.'
+            );
+            this.enableSubmit = true;
+          });
+      } else {
+        // Some value is not valid...
+        this.enableSubmit = false;
+      }
+    },
+    reset(sticky = false) {
+      this.validity.show = false;
+
+      if (!sticky) {
+        this.form.seedingDate = dayjs().format('YYYY-MM-DD');
+        this.form.locationName = null;
+      }
+
+      this.form.cropName = null;
+      this.form.trays = 1;
+      this.form.traySize = null;
+      this.form.seedsPerCell = 1;
+      this.form.comment = null;
+      this.enableSubmit = true;
+    },
+
+    showErrorToast(title, message) {
+      if (!this.errorShown) {
+        this.errorShown = true;
+        this.enableSubmit = false;
+        this.enableReset = false;
+
+        uiUtil.showToast(title, message, 'top-center', 'danger', 5);
+      }
+    },
+  },
+  watch: {
+    validity: {
+      handler() {
+        if (Object.values(this.validity).every((item) => item === true)) {
+          this.enableSubmit = true;
+        }
+      },
+      deep: true,
+    },
+  },
+  created() {
+    this.createdCount++;
+  },
+};
+</script>
+
+<style>
+@import url('@css/fd2-mobile.css');
+
+#seeding-date {
+  margin-top: 2px;
+  margin-bottom: 8px;
+}
+
+#seeding-crop-name,
+#seeding-location-name,
+#seeding-tray-size,
+#seeding-seeds {
+  margin-bottom: 8px;
+}
+
+#seeding-trays {
+  margin-top: 2px;
+  margin-bottom: 8px;
+}
+
+#seeding-comment {
+  margin-bottom: 15px;
+}
+</style>

--- a/modules/farm_fd2/src/entrypoints/tray_seeding/index.html
+++ b/modules/farm_fd2/src/entrypoints/tray_seeding/index.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1.0"
+    />
+    <title>Tray Seeding</title>
+  </head>
+  <body>
+    <div id="app"></div>
+    <script
+      type="module"
+      src="/tray_seeding/tray_seeding.js"
+    ></script>
+  </body>
+</html>

--- a/modules/farm_fd2/src/entrypoints/tray_seeding/lib.js
+++ b/modules/farm_fd2/src/entrypoints/tray_seeding/lib.js
@@ -1,0 +1,303 @@
+import * as farmosUtil from '@libs/farmosUtil/farmosUtil';
+import dayjs from 'dayjs';
+
+/**
+ * Create the farmOS records (asset, quantities and log) to represent
+ * a tray seeding.
+ *
+ * @param {Object} formData the form data from the tray seeding form.
+ * @returns {Promise} a promise that resolves when the records are successfully created.
+ * The returned value is an object containing the asset, quantities and log that
+ * were sent to the server.  This object has the following properties:
+ * {
+ *   plantAsset: {asset--plant},
+ *   traysQuantity: {quantity--standard},
+ *   traySizeQuantity: {quantity--standard},
+ *   seedsQuantity: {quantity--standard},
+ *   seedingLog: {log--seeding}
+ * }
+ * @throws {Error} if an error occurs while creating the farmOS records.
+ */
+export async function submitForm(formData) {
+  let plantAsset = null;
+  let traysQuantity = null;
+  let traySizeQuantity = null;
+  let seedsQuantity = null;
+  let seedingLog = null;
+
+  try {
+    plantAsset = await createPlantAsset(formData);
+    traysQuantity = await createTraysQuantity(formData, plantAsset);
+    traySizeQuantity = await createTraySizeQuantity(formData);
+    seedsQuantity = await createSeedsQuantity(formData);
+    seedingLog = await createSeedingLog(
+      formData,
+      plantAsset,
+      traysQuantity,
+      traySizeQuantity,
+      seedsQuantity
+    );
+
+    return {
+      plantAsset: plantAsset,
+      traysQuantity: traysQuantity,
+      traySizeQuantity: traySizeQuantity,
+      seedsQuantity: seedsQuantity,
+      seedingLog: seedingLog,
+    };
+  } catch (error) {
+    console.log('TraySeeding: \n' + error.message);
+    console.dir(error);
+
+    // Handle errors here by deleting any records that were created.
+    if (seedingLog) {
+      try {
+        await farmosUtil
+          .getFarmOSInstance()
+          .log.delete('seeding', seedingLog.id);
+      } catch (error) {
+        console.log('TraySeeding: \n');
+        console.log('  Unable to delete seeding log with:');
+        console.log('    name: ' + seedingLog.name);
+        console.log('      id: ' + seedingLog.id);
+        console.log(error.message);
+        console.dir(error);
+      }
+    }
+
+    if (seedsQuantity) {
+      try {
+        await farmosUtil
+          .getFarmOSInstance()
+          .quantity.delete('standard', seedsQuantity.id);
+      } catch (error) {
+        console.log('TraySeeding: \n');
+        console.log('  Unable to delete Seeds quantity with:');
+        console.log('    id: ' + traysQuantity.id);
+        console.log(error.message);
+        console.dir(error);
+      }
+    }
+
+    if (traySizeQuantity) {
+      try {
+        await farmosUtil
+          .getFarmOSInstance()
+          .quantity.delete('standard', traySizeQuantity.id);
+      } catch (error) {
+        console.log('TraySeeding: \n');
+        console.log('  Unable to delete Tray Size quantity with:');
+        console.log('    id: ' + traysQuantity.id);
+        console.log(error.message);
+        console.dir(error);
+      }
+    }
+
+    if (traysQuantity) {
+      try {
+        await farmosUtil
+          .getFarmOSInstance()
+          .quantity.delete('standard', traysQuantity.id);
+      } catch (error) {
+        console.log('TraySeeding: \n');
+        console.log('  Unable to delete Trays quantity with:');
+        console.log('    id: ' + traysQuantity.id);
+        console.log(error.message);
+        console.dir(error);
+      }
+    }
+
+    if (plantAsset) {
+      try {
+        await farmosUtil
+          .getFarmOSInstance()
+          .asset.delete('plant', plantAsset.id);
+      } catch (error) {
+        console.log('TraySeeding: \n');
+        console.log('  Unable to delete plant asset with:');
+        console.log('    name: ' + plantAsset.name);
+        console.log('      id: ' + plantAsset.id);
+        console.log(error.message);
+        console.dir(error);
+      }
+    }
+
+    throw Error('Error creating tray seeding.', error);
+  }
+}
+
+/*
+ * The functions below are not expected to be called directly from the
+ * entry point. They are exported so that they can be unit tested.
+ */
+
+export async function createPlantAsset(formData) {
+  const farm = await farmosUtil.getFarmOSInstance();
+  const cropMap = await farmosUtil.getCropNameToTermMap();
+
+  const assetName = formData.seedingDate + '_ts_' + formData.cropName;
+
+  // create an asset--plant
+  const plantAsset = farm.asset.create({
+    type: 'asset--plant',
+    attributes: {
+      name: assetName,
+      status: 'active',
+      notes: { value: formData.comment },
+    },
+    relationships: {
+      plant_type: [
+        {
+          type: 'taxonomy_term--plant_type',
+          id: cropMap.get(formData.cropName).id,
+        },
+      ],
+    },
+  });
+
+  await farm.asset.send(plantAsset);
+
+  return plantAsset;
+}
+
+export async function createTraysQuantity(formData, plantAsset) {
+  const farm = await farmosUtil.getFarmOSInstance();
+  const unitMap = await farmosUtil.getUnitToTermMap();
+
+  // create the necessary quantities
+  const traysQuantity = farm.quantity.create({
+    type: 'quantity--standard',
+    attributes: {
+      measure: 'count',
+      value: {
+        decimal: formData.trays,
+      },
+      label: 'Trays',
+      inventory_adjustment: 'increment',
+    },
+    relationships: {
+      units: {
+        type: 'taxonomy_term--unit',
+        id: unitMap.get('TRAYS').id,
+      },
+      inventory_asset: {
+        type: 'asset--plant',
+        id: plantAsset.id,
+      },
+    },
+  });
+
+  await farm.quantity.send(traysQuantity);
+
+  return traysQuantity;
+}
+
+export async function createTraySizeQuantity(formData) {
+  const farm = await farmosUtil.getFarmOSInstance();
+  const unitMap = await farmosUtil.getUnitToTermMap();
+
+  const traySizeQuantity = farm.quantity.create({
+    type: 'quantity--standard',
+    attributes: {
+      measure: 'ratio',
+      value: {
+        decimal: parseInt(formData.traySize),
+      },
+      label: 'Tray Size',
+    },
+    relationships: {
+      units: {
+        type: 'taxonomy_term--unit',
+        id: unitMap.get('CELLS/TRAY').id,
+      },
+    },
+  });
+
+  await farm.quantity.send(traySizeQuantity);
+
+  return traySizeQuantity;
+}
+
+export async function createSeedsQuantity(formData) {
+  const farm = await farmosUtil.getFarmOSInstance();
+  const unitMap = await farmosUtil.getUnitToTermMap();
+
+  const seedsQuantity = farm.quantity.create({
+    type: 'quantity--standard',
+    attributes: {
+      measure: 'count',
+      value: {
+        decimal:
+          formData.trays * parseInt(formData.traySize) * formData.seedsPerCell,
+      },
+      label: 'Seeds',
+    },
+    relationships: {
+      units: {
+        type: 'taxonomy_term--unit',
+        id: unitMap.get('SEEDS').id,
+      },
+    },
+  });
+
+  await farm.quantity.send(seedsQuantity);
+
+  return seedsQuantity;
+}
+
+export async function createSeedingLog(
+  formData,
+  plantAsset,
+  traysQuantity,
+  traySizeQuantity,
+  seedsQuantity
+) {
+  const farm = await farmosUtil.getFarmOSInstance();
+  const categoryMap = await farmosUtil.getLogCategoryToTermMap();
+  const greenhouseMap = await farmosUtil.getGreenhouseNameToAssetMap();
+
+  // create the seeding log
+  const seedingLog = farm.log.create({
+    type: 'log--seeding',
+    attributes: {
+      name: plantAsset.attributes.name,
+      timestamp: dayjs(formData.seedingDate).format(),
+      status: 'done',
+      is_movement: true,
+      purchase_date: dayjs(formData.seedingDate).format(),
+    },
+    relationships: {
+      location: [
+        {
+          type: 'asset--structure',
+          id: greenhouseMap.get(formData.locationName).id,
+        },
+      ],
+      asset: [{ type: 'asset--plant', id: plantAsset.id }],
+      category: [
+        {
+          type: 'taxonomy_term--log_category',
+          id: categoryMap.get('seeding_tray').id,
+        },
+      ],
+      quantity: [
+        {
+          type: 'quantity--standard',
+          id: traysQuantity.id,
+        },
+        {
+          type: 'quantity--standard',
+          id: traySizeQuantity.id,
+        },
+        {
+          type: 'quantity--standard',
+          id: seedsQuantity.id,
+        },
+      ],
+    },
+  });
+
+  await farm.log.send(seedingLog);
+
+  return seedingLog;
+}

--- a/modules/farm_fd2/src/entrypoints/tray_seeding/lib.submit.unit.cy.js
+++ b/modules/farm_fd2/src/entrypoints/tray_seeding/lib.submit.unit.cy.js
@@ -1,0 +1,438 @@
+import * as lib from './lib';
+import * as farmosUtil from '@libs/farmosUtil/farmosUtil';
+
+describe('Test the tray seeding submission', () => {
+  /*
+   * Create a form object that has the same format as the data.form
+   * object used in the tray_seeding entry point.  This will be passed
+   * to the lib functions as if it is coming from the tray seeding
+   * entry point as a submission.
+   */
+  let form = {
+    seedingDate: '1950-01-01',
+    cropName: 'BROCCOLI',
+    locationName: 'CHUAU',
+    trays: 25,
+    traySize: '200',
+    seedsPerCell: 3,
+    comment: 'A comment',
+  };
+
+  /*
+   * Variables to hold the map objects that used in the tests. The
+   * maps are actually created in the before() function.
+   */
+  let farm = null;
+  let cropMap = null;
+  let termMap = null;
+  let greenhouseMap = null;
+  let categoryMap = null;
+
+  /*
+   * Variables to hold the records that are used in the tests.  It is only
+   * necessary to have one of each of these types of records, so they are
+   * created in the before() function and then used in multiple tests.
+   */
+  let plantAsset = null;
+  let traysQuant = null;
+  let traySizeQuant = null;
+  let seedsQuant = null;
+  let seedingLog = null;
+
+  before(() => {
+    /*
+     * Create all of the maps that are needed here.
+     * Not all of these are used in every test, but collecting them
+     * here simplifies the test structure.
+     */
+    cy.wrap(farmosUtil.getFarmOSInstance()).then((newFarm) => {
+      farm = newFarm;
+    });
+
+    cy.wrap(farmosUtil.getCropNameToTermMap()).then((map) => {
+      cropMap = map;
+    });
+    cy.wrap(farmosUtil.getUnitToTermMap()).then((map) => {
+      termMap = map;
+    });
+    cy.wrap(farmosUtil.getGreenhouseNameToAssetMap()).then((map) => {
+      greenhouseMap = map;
+    });
+    cy.wrap(farmosUtil.getLogCategoryToTermMap()).then((map) => {
+      categoryMap = map;
+    });
+
+    /*
+     * Create the asset, quantities and log that are needed here.
+     * Not all of these are used in every test, but collecting them
+     * here simplifies the test structure.
+     */
+    cy.wrap(lib.createPlantAsset(form))
+      .as('plantAsset')
+      .then((asset) => {
+        plantAsset = asset;
+      });
+
+    /*
+     * Here we need to ensure that the plantAsset has been created
+     * before we try to create the tray quantities.
+     */
+    cy.get('@plantAsset').then((plantAsset) => {
+      cy.wrap(lib.createTraysQuantity(form, plantAsset))
+        .as('traysQuant')
+        .then((quant) => {
+          traysQuant = quant;
+        });
+    });
+
+    cy.wrap(lib.createTraySizeQuantity(form))
+      .as('traySizeQuant')
+      .then((quant) => {
+        traySizeQuant = quant;
+      });
+
+    cy.wrap(lib.createSeedsQuantity(form))
+      .as('seedsQuant')
+      .then((quant) => {
+        seedsQuant = quant;
+      });
+
+    /*
+     * Use a custom Cypress command to get all of the aliases that
+     * are needed using a a single command.
+     */
+    cy.getAll([
+      '@plantAsset',
+      '@traysQuant',
+      '@traySizeQuant',
+      '@seedsQuant',
+    ]).then(([plantAsset, traysQuant, traySizeQuant, seedsQuant]) => {
+      /*
+       * It is not entirely clear why it is necessary to clear the farmGlobal.
+       * However, without it there is a 422 (Unprocessable Contents) error when
+       * submitting the log to farmOS via farmOS.js. To see the error, comment
+       * out the `farmosUtil.clearFarmGlobal();` line and run the test.
+       *
+       * Note that this does not cause a re-authentication, but it does cause
+       * the creation of a new farmOS object, and a refetching of the schema.
+       * However, there appears to be no difference between the two farmOS
+       * objects as evidenced by the commented out lines below.
+       *
+       * There is a chance that something buried in here or in farmOS.js
+       * is mangling the farmOS object in some way.  But it is not clear what
+       * it is.
+       */
+      farmosUtil.clearFarmGlobal();
+
+      cy.wrap(
+        lib.createSeedingLog(
+          form,
+          plantAsset,
+          traysQuant,
+          traySizeQuant,
+          seedsQuant
+        )
+      )
+        .as(`seedingLog`)
+        .then((log) => {
+          seedingLog = log;
+        });
+    });
+
+    cy.saveLocalStorage();
+    cy.saveSessionStorage();
+  });
+
+  beforeEach(() => {
+    /*
+     * Caching of the farmOS instance and the data for the maps relies
+     * on the session storage and local storage.  Cypress clears these
+     * between every test.  So we save them in the afterEach() hook,
+     * and then restore them in the beforeEach() hook.
+     */
+    cy.restoreLocalStorage();
+    cy.restoreSessionStorage();
+  });
+
+  afterEach(() => {
+    cy.saveLocalStorage();
+    cy.saveSessionStorage();
+  });
+
+  it('Create plant asset', () => {
+    // Fetch the plant asset from farmOS and check it.
+    cy.wrap(
+      farm.asset
+        .fetch({
+          filter: { type: 'asset--plant', id: plantAsset.id },
+        })
+        .then((results) => {
+          return results.data[0]; // only one asset with the plantAsset.id.
+        })
+    ).then((result) => {
+      expect(result.attributes.name).to.equal(
+        form.seedingDate + '_ts_' + form.cropName
+      );
+      expect(result.attributes.status).to.equal('active');
+      expect(result.attributes.notes.value).to.equal(form.comment);
+      expect(result.relationships.plant_type[0].id).to.equal(
+        cropMap.get(form.cropName).id
+      );
+    });
+  });
+
+  it('Error creating plant asset', { retries: 4 }, () => {
+    cy.intercept('POST', '**/api/asset/plant', {
+      statusCode: 401,
+    });
+
+    /*
+     * Here the then/catch must be inside the wrap because wrap
+     * does not have a catch.
+     */
+    cy.wrap(
+      lib
+        .createPlantAsset(form)
+        .then(() => {
+          throw new Error('Creating plant asset should have failed.');
+        })
+        .catch((error) => {
+          expect(error.message).to.equal('Request failed with status code 401');
+        })
+    );
+  });
+
+  it('Create trays quantity', () => {
+    cy.wrap(
+      farm.quantity
+        .fetch({
+          filter: {
+            type: 'quantity--standard',
+            id: traysQuant.id,
+          },
+        })
+        .then((results) => {
+          return results.data[0];
+        })
+    ).then((result) => {
+      expect(result.attributes.label).to.equal('Trays');
+      expect(result.attributes.measure).to.equal('count');
+      expect(result.attributes.value.decimal).to.equal(form.trays.toString());
+      expect(result.attributes.inventory_adjustment).to.equal('increment');
+      expect(result.relationships.units.id).to.equal(termMap.get('TRAYS').id);
+      expect(result.relationships.inventory_asset.id).to.equal(plantAsset.id);
+    });
+  });
+
+  it('Error creating trays quantity', { retries: 4 }, () => {
+    cy.intercept('POST', '**/api/quantity/standard', {
+      statusCode: 401,
+    });
+
+    cy.wrap(
+      lib
+        .createTraysQuantity(form, { id: 999 }) // fake id b.c. quantity is not created.
+        .then(() => {
+          throw new Error('Creating trays quantity should have failed.');
+        })
+        .catch((error) => {
+          expect(error.message).to.equal('Request failed with status code 401');
+        })
+    );
+  });
+
+  it('Create tray size quantity', () => {
+    cy.wrap(
+      farm.quantity
+        .fetch({
+          filter: {
+            type: 'quantity--standard',
+            id: traySizeQuant.id,
+          },
+        })
+        .then((results) => {
+          return results.data[0];
+        })
+    ).then((result) => {
+      expect(result.attributes.label).to.equal('Tray Size');
+      expect(result.attributes.measure).to.equal('ratio');
+      expect(result.attributes.value.decimal).to.equal(form.traySize);
+      expect(result.relationships.units.id).to.equal(
+        termMap.get('CELLS/TRAY').id
+      );
+    });
+  });
+
+  it('Error creating tray size quantity', { retries: 4 }, () => {
+    cy.intercept('POST', '**/api/quantity/standard', {
+      statusCode: 401,
+    });
+
+    cy.wrap(
+      lib
+        .createTraySizeQuantity(form)
+        .then(() => {
+          throw new Error('Creating tray size quantity should have failed.');
+        })
+        .catch((error) => {
+          expect(error.message).to.equal('Request failed with status code 401');
+        })
+    );
+  });
+
+  it('Create seeds quantity', () => {
+    cy.wrap(
+      farm.quantity
+        .fetch({
+          filter: {
+            type: 'quantity--standard',
+            id: seedsQuant.id,
+          },
+        })
+        .then((results) => {
+          return results.data[0];
+        })
+    ).then((result) => {
+      expect(result.attributes.label).to.equal('Seeds');
+      expect(result.attributes.measure).to.equal('count');
+      expect(result.attributes.value.decimal).to.equal(
+        (form.trays * parseInt(form.traySize) * form.seedsPerCell).toString()
+      );
+      expect(result.relationships.units.id).to.equal(termMap.get('SEEDS').id);
+    });
+  });
+
+  it('Error creating seeds quantity', { retries: 4 }, () => {
+    cy.intercept('POST', '**/api/quantity/standard', {
+      statusCode: 401,
+    });
+
+    cy.wrap(
+      lib
+        .createSeedsQuantity(form)
+        .then(() => {
+          throw new Error('Creating seeds quantity should have failed.');
+        })
+        .catch((error) => {
+          expect(error.message).to.equal('Request failed with status code 401');
+        })
+    );
+  });
+
+  it('Create seeding log', () => {
+    cy.wrap(
+      farm.log
+        .fetch({
+          filter: {
+            type: 'log--seeding',
+            id: seedingLog.id,
+          },
+        })
+        .then((results) => {
+          return results.data[0];
+        })
+    ).then((result) => {
+      expect(result.attributes.timestamp).to.contain(form.seedingDate);
+      expect(result.attributes.purchase_date).to.contain(form.seedingDate);
+      expect(result.attributes.name).to.equal(
+        form.seedingDate + '_ts_' + form.cropName
+      );
+      expect(result.attributes.status).to.equal('done');
+      expect(result.attributes.is_movement).to.equal(true);
+      expect(result.relationships.category[0].id).to.equal(
+        categoryMap.get('seeding_tray').id
+      );
+      expect(result.relationships.location[0].id).to.equal(
+        greenhouseMap.get(form.locationName).id
+      );
+      expect(result.relationships.asset[0].id).to.equal(plantAsset.id);
+
+      expect(result.relationships.quantity.length).to.equal(3);
+      expect(result.relationships.quantity[0].id).to.equal(traysQuant.id);
+      expect(result.relationships.quantity[1].id).to.equal(traySizeQuant.id);
+      expect(result.relationships.quantity[2].id).to.equal(seedsQuant.id);
+    });
+  });
+
+  it('Error creating seeding log', { retries: 4 }, () => {
+    cy.intercept('POST', '**/api/log/seeding', {
+      statusCode: 401,
+    });
+
+    cy.wrap(
+      lib
+        .createSeedingLog(
+          form,
+          { id: 123, attributes: { name: 'test' } }, // plant asset
+          { id: 123 }, // trays quantity
+          { id: 123 }, // tray size quantity
+          { id: 123 } // seeds quantity
+        )
+        .then(() => {
+          throw new Error('Creating seeding log should have failed.');
+        })
+        .catch((error) => {
+          expect(error.message).to.equal('Request failed with status code 401');
+        })
+    );
+  });
+
+  it('submitForm creates everything', () => {
+    cy.wrap(lib.submitForm(form)).then((result) => {
+      /*
+       * Here we just need to fetch each of the pieces to ensure that
+       * they have been created. We do that just by checking the type.
+       * The earlier test checked that they were created correctly.
+       */
+      cy.wrap(
+        farm.asset.fetch({
+          filter: { type: 'asset--plant', id: result.plantAsset.id },
+        })
+      ).then((results) => {
+        // Just check the type here to be sure it exists.
+        expect(results.data[0].type).to.equal('asset--plant');
+      });
+
+      cy.wrap(
+        farm.quantity.fetch({
+          filter: { type: 'quantity--standard', id: result.traysQuantity.id },
+        })
+      ).then((results) => {
+        expect(results.data[0].type).to.equal('quantity--standard');
+      });
+
+      cy.wrap(
+        farm.quantity.fetch({
+          filter: {
+            type: 'quantity--standard',
+            id: result.traySizeQuantity.id,
+          },
+        })
+      ).then((results) => {
+        expect(results.data[0].type).to.equal('quantity--standard');
+      });
+
+      cy.wrap(
+        farm.quantity.fetch({
+          filter: {
+            type: 'quantity--standard',
+            id: result.seedsQuantity.id,
+          },
+        })
+      ).then((results) => {
+        expect(results.data[0].type).to.equal('quantity--standard');
+      });
+
+      cy.wrap(
+        farm.log.fetch({
+          filter: {
+            type: 'log--seeding',
+            id: result.seedingLog.id,
+          },
+        })
+      ).then((results) => {
+        expect(results.data[0].type).to.equal('log--seeding');
+      });
+    });
+  });
+});

--- a/modules/farm_fd2/src/entrypoints/tray_seeding/tray_seeding.behavior.e2e.cy.js
+++ b/modules/farm_fd2/src/entrypoints/tray_seeding/tray_seeding.behavior.e2e.cy.js
@@ -1,0 +1,221 @@
+import dayjs from 'dayjs';
+
+describe('Check the behavior of the Tray Seeding page.', () => {
+  beforeEach(() => {
+    cy.restoreLocalStorage();
+    cy.restoreSessionStorage();
+
+    cy.login('admin', 'admin');
+    cy.visit('fd2/tray_seeding/');
+    cy.waitForPage();
+  });
+
+  afterEach(() => {
+    cy.saveLocalStorage();
+    cy.saveSessionStorage();
+  });
+
+  it('Submit shows validity styling', () => {
+    cy.get('[data-cy="seeding-crop-name"]')
+      .find('[data-cy="selector-invalid-feedback"]')
+      .should('not.be.visible');
+    cy.get('[data-cy="submit-button"]').click();
+    cy.get('[data-cy="seeding-crop-name"]')
+      .find('[data-cy="selector-invalid-feedback"]')
+      .should('be.visible');
+  });
+
+  it('Submit invalid disables submit but not reset', () => {
+    cy.get('[data-cy="submit-button"]').should('be.enabled');
+    cy.get('[data-cy="reset-button"]').should('be.enabled');
+    cy.get('[data-cy="submit-button"]').click();
+    cy.get('[data-cy="submit-button"]').should('be.disabled');
+    cy.get('[data-cy="reset-button"]').should('be.enabled');
+  });
+
+  it('Form becomes valid reenables submit', () => {
+    cy.get('[data-cy="submit-button"]').click();
+    cy.get('[data-cy="submit-button"]').should('be.disabled');
+    cy.get('[data-cy="seeding-crop-name"]')
+      .find('[data-cy="selector-input"]')
+      .select('ARUGULA');
+    cy.get('[data-cy="submit-button"]').should('be.disabled');
+    cy.get('[data-cy="seeding-location-name"]')
+      .find('[data-cy="selector-input"]')
+      .select('CHUAU');
+    cy.get('[data-cy="submit-button"]').should('be.disabled');
+    cy.get('[data-cy="seeding-tray-size"]')
+      .find('[data-cy="selector-input"]')
+      .select('50');
+    cy.get('[data-cy="submit-button"]').should('be.enabled');
+  });
+
+  it('Reset clears form to defaults', () => {
+    cy.get('[data-cy="date-input"]').type('1950-01-01');
+    cy.get('[data-cy="seeding-crop-name"]')
+      .find('[data-cy="selector-input"]')
+      .select('ARUGULA');
+    cy.get('[data-cy="seeding-location-name"]')
+      .find('[data-cy="selector-input"]')
+      .select('CHUAU');
+
+    cy.get('[data-cy="seeding-trays"]')
+      .find('[data-cy="numeric-input"]')
+      .clear();
+    cy.get('[data-cy="seeding-trays"]')
+      .find('[data-cy="numeric-input"]')
+      .type('15');
+
+    cy.get('[data-cy="seeding-tray-size"]')
+      .find('[data-cy="selector-input"]')
+      .select('50');
+
+    cy.get('[data-cy="seeding-seeds"]')
+      .find('[data-cy="numeric-input"]')
+      .clear();
+    cy.get('[data-cy="seeding-seeds"]')
+      .find('[data-cy="numeric-input"]')
+      .type('3');
+
+    cy.get('[data-cy="comment-input"]').clear();
+    cy.get('[data-cy="comment-input"]').type('Test comment');
+
+    cy.get('[data-cy="comment-input"]').blur();
+
+    cy.get('[data-cy="reset-button"]').click();
+
+    cy.get('[data-cy="date-input"]').should(
+      'have.value',
+      dayjs().format('YYYY-MM-DD')
+    );
+    cy.get('[data-cy="seeding-crop-name"]')
+      .find('[data-cy="selector-input"]')
+      .should('have.value', null);
+    cy.get('[data-cy="seeding-location-name"]')
+      .find('[data-cy="selector-input"]')
+      .should('have.value', null);
+    cy.get('[data-cy="seeding-trays"]')
+      .find('[data-cy="numeric-input"]')
+      .should('have.value', '1.00');
+    cy.get('[data-cy="seeding-tray-size"]')
+      .find('[data-cy="selector-input"]')
+      .should('have.value', null);
+    cy.get('[data-cy="seeding-seeds"]')
+      .find('[data-cy="numeric-input"]')
+      .should('have.value', '1');
+    cy.get('[data-cy="comment-input"]').should('have.value', '');
+  });
+
+  it('Reset re-enables Submit button', () => {
+    cy.get('[data-cy="submit-button"]').click();
+    cy.get('[data-cy="submit-button"]').should('be.disabled');
+    cy.get('[data-cy="reset-button"]').click();
+    cy.get('[data-cy="submit-button"]').should('be.enabled');
+  });
+
+  it('Trays increment/decrement are 1, 5, 10', () => {
+    cy.get('[data-cy="seeding-trays"]')
+      .find('[data-cy="numeric-increase-sm"]')
+      .click();
+    cy.get('[data-cy="seeding-trays"]')
+      .find('[data-cy="numeric-input"]')
+      .should('have.value', '2.00');
+
+    cy.get('[data-cy="seeding-trays"]')
+      .find('[data-cy="numeric-increase-md"]')
+      .click();
+    cy.get('[data-cy="seeding-trays"]')
+      .find('[data-cy="numeric-input"]')
+      .should('have.value', '7.00');
+
+    cy.get('[data-cy="seeding-trays"]')
+      .find('[data-cy="numeric-increase-lg"]')
+      .click();
+    cy.get('[data-cy="seeding-trays"]')
+      .find('[data-cy="numeric-input"]')
+      .should('have.value', '17.00');
+
+    cy.get('[data-cy="seeding-trays"]')
+      .find('[data-cy="numeric-decrease-sm"]')
+      .click();
+    cy.get('[data-cy="seeding-trays"]')
+      .find('[data-cy="numeric-input"]')
+      .should('have.value', '16.00');
+
+    cy.get('[data-cy="seeding-trays"]')
+      .find('[data-cy="numeric-decrease-md"]')
+      .click();
+    cy.get('[data-cy="seeding-trays"]')
+      .find('[data-cy="numeric-input"]')
+      .should('have.value', '11.00');
+
+    cy.get('[data-cy="seeding-trays"]')
+      .find('[data-cy="numeric-decrease-lg"]')
+      .click();
+    cy.get('[data-cy="seeding-trays"]')
+      .find('[data-cy="numeric-input"]')
+      .should('have.value', '1.00');
+  });
+
+  it('Trays has 0.01 minimum value', () => {
+    cy.get('[data-cy="seeding-trays"]')
+      .find('[data-cy="numeric-decrease-sm"]')
+      .click();
+    cy.get('[data-cy="seeding-trays"]')
+      .find('[data-cy="numeric-input"]')
+      .should('have.value', '0.01');
+  });
+
+  it('Seeds/Cell increment/decrement is 1', () => {
+    cy.get('[data-cy="seeding-seeds"]')
+      .find('[data-cy="numeric-increase-sm"]')
+      .click();
+    cy.get('[data-cy="seeding-seeds"]')
+      .find('[data-cy="numeric-input"]')
+      .should('have.value', '2');
+
+    cy.get('[data-cy="seeding-seeds"]')
+      .find('[data-cy="numeric-decrease-sm"]')
+      .click();
+    cy.get('[data-cy="seeding-seeds"]')
+      .find('[data-cy="numeric-input"]')
+      .should('have.value', '1');
+  });
+
+  it('Seeds/Cell has 1 minimum value', () => {
+    cy.get('[data-cy="seeding-seeds"]')
+      .find('[data-cy="numeric-decrease-sm"]')
+      .click();
+    cy.get('[data-cy="seeding-seeds"]')
+      .find('[data-cy="numeric-input"]')
+      .should('have.value', '1');
+  });
+
+  it('Total seeds is computed correctly', () => {
+    cy.get('[data-cy="seeding-trays"]')
+      .find('[data-cy="numeric-input"]')
+      .clear();
+    cy.get('[data-cy="seeding-trays"]')
+      .find('[data-cy="numeric-input"]')
+      .type('10');
+
+    cy.get('[data-cy="seeding-tray-size"]')
+      .find('[data-cy="selector-input"]')
+      .select('50');
+
+    cy.get('[data-cy="seeding-seeds"]')
+      .find('[data-cy="numeric-input"]')
+      .clear();
+    cy.get('[data-cy="seeding-seeds"]')
+      .find('[data-cy="numeric-input"]')
+      .type('3');
+
+    cy.get('[data-cy="seeding-seeds"]')
+      .find('[data-cy="numeric-input"]')
+      .blur();
+
+    cy.get('[data-cy="seeding-total-seeds"]')
+      .find('[data-cy="text-text"]')
+      .should('have.value', '1,500');
+  });
+});

--- a/modules/farm_fd2/src/entrypoints/tray_seeding/tray_seeding.content.e2e.cy.js
+++ b/modules/farm_fd2/src/entrypoints/tray_seeding/tray_seeding.content.e2e.cy.js
@@ -1,0 +1,196 @@
+import dayjs from 'dayjs';
+
+describe('Check the content of the Tray Seeding page.', () => {
+  beforeEach(() => {
+    /*
+     * Caching of the farmOS instance and the data for the maps relies
+     * on the session storage and local storage.  Cypress clears these
+     * between every test.  So we save them in the afterEach() hook,
+     * and then restore them in the beforeEach() hook.
+     */
+    cy.restoreLocalStorage();
+    cy.restoreSessionStorage();
+
+    cy.login('admin', 'admin');
+    cy.visit('fd2/tray_seeding/');
+    cy.waitForPage();
+  });
+
+  afterEach(() => {
+    cy.saveLocalStorage();
+    cy.saveSessionStorage();
+  });
+
+  it('Check header.', () => {
+    cy.get('[data-cy="seeding-header"]').should('contain.text', 'Tray Seeding');
+  });
+
+  it('All components are visible.', () => {
+    cy.get('[data-cy="seeding-date"]').should('be.visible');
+    cy.get('[data-cy="seeding-crop-name"]').should('be.visible');
+    cy.get('[data-cy="seeding-location-name"]').should('be.visible');
+    cy.get('[data-cy="seeding-trays"]').should('be.visible');
+    cy.get('[data-cy="seeding-tray-size"]').should('be.visible');
+    cy.get('[data-cy="seeding-seeds"]').should('be.visible');
+    cy.get('[data-cy="seeding-total-seeds"]').should('be.visible');
+    cy.get('[data-cy="seeding-comment"]').should('be.visible');
+    cy.get('[data-cy="seeding-submit-reset"]').should('be.visible');
+  });
+
+  it('Check date field.', () => {
+    /*
+     * There is only one 'date-label', 'date-required', and 'date-input' on
+     * the page, so we can cy.get() them directly without first getting their
+     * parent element.  Compare this with the crop field test below.
+     */
+    cy.get('[data-cy="date-label"]').should('have.text', 'Date:');
+    cy.get('[data-cy="date-required"]').should('be.visible');
+    cy.get('[data-cy="date-input"]').should(
+      'have.value',
+      dayjs().format('YYYY-MM-DD')
+    );
+  });
+
+  it('Check crop field.', () => {
+    /*
+     * The crop, location and tray size dropdowns area all made using
+     * the `SelectorBase` component.  Thus, they will all have
+     * `selector-label, selector-required` and `selector-input` elements.
+     * Thus, to get the right one we first have to get the parent element
+     * (e.g. `seeding-crop-name`) and then use find() within it to get
+     * the specific `selector-label`, `selector-required` or `selector-input`
+     * that we want.  See the similar pattern below for the location and
+     * tray size fields.  Note also that the Trays and Seeds/Cell fields
+     * follow a similar pattern because they are built using the `NumericBase`
+     * component.
+     */
+    cy.get('[data-cy="seeding-crop-name"]')
+      .find('[data-cy="selector-label"]')
+      .should('have.text', 'Crop:');
+    cy.get('[data-cy="seeding-crop-name"]')
+      .find('[data-cy="selector-required"]')
+      .should('be.visible');
+    cy.get('[data-cy="seeding-crop-name"]')
+      .find('[data-cy="selector-input"]')
+      .should('have.value', null);
+  });
+
+  it('Check location field.', () => {
+    cy.get('[data-cy="seeding-location-name"]')
+      .find('[data-cy="selector-label"]')
+      .should('have.text', 'Location:');
+    cy.get('[data-cy="seeding-location-name"]')
+      .find('[data-cy="selector-required"]')
+      .should('be.visible');
+    cy.get('[data-cy="seeding-location-name"]')
+      .find('[data-cy="selector-input"]')
+      .should('have.value', null);
+  });
+
+  it('Check that location contains only greenhouses.', () => {
+    cy.get('[data-cy="seeding-location-name"]')
+      .find('[data-cy="selector-input"]')
+      .find('option')
+      .should('have.length', 6);
+    cy.get('[data-cy="seeding-location-name"]')
+      .find('[data-cy="selector-option-1"]')
+      .should('have.value', 'CHUAU');
+    cy.get('[data-cy="seeding-location-name"]')
+      .find('[data-cy="selector-option-5"]')
+      .should('have.value', 'SEEDING BENCH');
+  });
+
+  it('Check trays field.', () => {
+    cy.get('[data-cy="seeding-trays"]')
+      .find('[data-cy="numeric-label"]')
+      .should('have.text', 'Trays:');
+    cy.get('[data-cy="seeding-trays"]')
+      .find('[data-cy="numeric-required"]')
+      .should('be.visible');
+    cy.get('[data-cy="seeding-trays"]')
+      .find('[data-cy="numeric-input"]')
+      .should('have.value', '1.00');
+
+    cy.get('[data-cy="seeding-trays"]')
+      .find('[data-cy="numeric-increase-sm"]')
+      .should('exist');
+    cy.get('[data-cy="seeding-trays"]')
+      .find('[data-cy="numeric-increase-md"]')
+      .should('exist');
+    cy.get('[data-cy="seeding-trays"]')
+      .find('[data-cy="numeric-increase-lg"]')
+      .should('exist');
+    cy.get('[data-cy="seeding-trays"]')
+      .find('[data-cy="numeric-decrease-sm"]')
+      .should('exist');
+    cy.get('[data-cy="seeding-trays"]')
+      .find('[data-cy="numeric-decrease-md"]')
+      .should('exist');
+    cy.get('[data-cy="seeding-trays"]')
+      .find('[data-cy="numeric-decrease-lg"]')
+      .should('exist');
+  });
+
+  it('Check tray size field', () => {
+    cy.get('[data-cy="seeding-tray-size"]')
+      .find('[data-cy="selector-label"]')
+      .should('have.text', 'Tray Size:');
+    cy.get('[data-cy="seeding-tray-size"]')
+      .find('[data-cy="selector-required"]')
+      .should('be.visible');
+    cy.get('[data-cy="seeding-tray-size"]')
+      .find('[data-cy="selector-input"]')
+      .should('have.value', null);
+  });
+
+  it('Check seeds per cell field.', () => {
+    cy.get('[data-cy="seeding-seeds"]')
+      .find('[data-cy="numeric-label"]')
+      .should('have.text', 'Seeds/Cell:');
+    cy.get('[data-cy="seeding-seeds"]')
+      .find('[data-cy="numeric-required"]')
+      .should('be.visible');
+    cy.get('[data-cy="seeding-seeds"]')
+      .find('[data-cy="numeric-input"]')
+      .should('have.value', '1');
+
+    cy.get('[data-cy="seeding-seeds"]')
+      .find('[data-cy="numeric-increase-sm"]')
+      .should('exist');
+    cy.get('[data-cy="seeding-seeds"]')
+      .find('[data-cy="numeric-increase-md"]')
+      .should('not.exist');
+    cy.get('[data-cy="seeding-seeds"]')
+      .find('[data-cy="numeric-increase-lg"]')
+      .should('not.exist');
+    cy.get('[data-cy="seeding-seeds"]')
+      .find('[data-cy="numeric-decrease-sm"]')
+      .should('exist');
+    cy.get('[data-cy="seeding-seeds"]')
+      .find('[data-cy="numeric-decrease-md"]')
+      .should('not.exist');
+    cy.get('[data-cy="seeding-seeds"]')
+      .find('[data-cy="numeric-decrease-lg"]')
+      .should('not.exist');
+  });
+
+  it('Check total seeds.', () => {
+    cy.get('[data-cy="seeding-total-seeds"]')
+      .find('[data-cy="text-label"]')
+      .should('have.text', 'Total Seeds:');
+    cy.get('[data-cy="seeding-total-seeds"]')
+      .find('[data-cy="text-text"]')
+      .should('have.value', '');
+  });
+
+  it('Check comment field.', () => {
+    cy.get('[data-cy="comment-input"]').should('have.value', '');
+  });
+
+  it('Check submit and reset buttons.', () => {
+    cy.get('[data-cy="submit-button"]').should('be.visible');
+    cy.get('[data-cy="submit-button"]').should('be.enabled');
+    cy.get('[data-cy="reset-button"]').should('be.visible');
+    cy.get('[data-cy="reset-button"]').should('be.enabled');
+  });
+});

--- a/modules/farm_fd2/src/entrypoints/tray_seeding/tray_seeding.exists.e2e.cy.js
+++ b/modules/farm_fd2/src/entrypoints/tray_seeding/tray_seeding.exists.e2e.cy.js
@@ -1,9 +1,9 @@
-describe('Check that the main entrypoint in the fd2 module exists.', () => {
+describe('Check that the tray_seeding entry point in farm_fd2 exists.', () => {
   it('Check that the page loaded.', () => {
     // Login if running in live farmOS.
     cy.login('admin', 'admin');
     // Go to the main page.
-    cy.visit('/fd2/main/');
+    cy.visit('fd2/tray_seeding/');
     // Check that the page loads.
     cy.waitForPage();
   });

--- a/modules/farm_fd2/src/entrypoints/tray_seeding/tray_seeding.html
+++ b/modules/farm_fd2/src/entrypoints/tray_seeding/tray_seeding.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1.0"
+    />
+    <title>Tray Seeding</title>
+  </head>
+  <body>
+    <div id="app"></div>
+    <script
+      type="module"
+      src="/tray_seeding/tray_seeding.js"
+    ></script>
+  </body>
+</html>

--- a/modules/farm_fd2/src/entrypoints/tray_seeding/tray_seeding.js
+++ b/modules/farm_fd2/src/entrypoints/tray_seeding/tray_seeding.js
@@ -1,0 +1,13 @@
+// Imports for Bootstrap-Vue components.
+import 'bootstrap/dist/css/bootstrap.css';
+import 'bootstrap-vue-next/dist/bootstrap-vue-next.css';
+
+import { createApp } from 'vue';
+import { createPinia } from 'pinia';
+import App from './App.vue';
+
+const app = createApp(App);
+
+app.use(createPinia());
+
+app.mount('#app');

--- a/modules/farm_fd2/src/entrypoints/tray_seeding/tray_seeding.submit.e2e.cy.js
+++ b/modules/farm_fd2/src/entrypoints/tray_seeding/tray_seeding.submit.e2e.cy.js
@@ -1,0 +1,151 @@
+import * as farmosUtil from '../../../../../library/farmosUtil/farmosUtil';
+
+describe('Check the submission of Tray Seedings.', () => {
+  beforeEach(() => {
+    /*
+     * Caching of the farmOS instance and the data for the maps relies
+     * on the session storage and local storage.  Cypress clears these
+     * between every test.  So we save them in the afterEach() hook,
+     * and then restore them in the beforeEach() hook.
+     */
+    cy.restoreLocalStorage();
+    cy.restoreSessionStorage();
+
+    cy.login('admin', 'admin');
+    cy.visit('fd2/tray_seeding/');
+    cy.waitForPage();
+  });
+
+  afterEach(() => {
+    cy.saveLocalStorage();
+    cy.saveSessionStorage();
+  });
+
+  function submitForm() {
+    cy.get('[data-cy="date-input"]').type('1950-01-01');
+    cy.get('[data-cy="seeding-crop-name"]')
+      .find('[data-cy="selector-input"]')
+      .select('ARUGULA');
+    cy.get('[data-cy="seeding-location-name"]')
+      .find('[data-cy="selector-input"]')
+      .select('CHUAU');
+    cy.get('[data-cy="seeding-trays"]')
+      .find('[data-cy="numeric-input"]')
+      .clear();
+    cy.get('[data-cy="seeding-trays"]')
+      .find('[data-cy="numeric-input"]')
+      .type('15');
+    cy.get('[data-cy="seeding-tray-size"]')
+      .find('[data-cy="selector-input"]')
+      .select('50');
+    cy.get('[data-cy="seeding-seeds"]')
+      .find('[data-cy="numeric-input"]')
+      .clear();
+    cy.get('[data-cy="seeding-seeds"]')
+      .find('[data-cy="numeric-input"]')
+      .type('3');
+    cy.get('[data-cy="comment-input"]').clear();
+    cy.get('[data-cy="comment-input"]').type('Test comment');
+    cy.get('[data-cy="comment-input"]').blur();
+
+    cy.get('[data-cy="submit-button"]').click();
+  }
+
+  it('Submit a Tray Seeding.', () => {
+    submitForm();
+
+    cy.get('.toast').should('be.visible');
+    cy.get('.toast').contains('Submitting tray seeding...');
+
+    let name = '1950-01-01_ts_ARUGULA';
+    cy.get('.toast')
+      .contains('Tray seeding created.')
+      .then(() => {
+        cy.wrap(farmosUtil.getFarmOSInstance()).as('farm');
+      });
+
+    cy.get('@farm').then((farm) => {
+      let logFilter = { type: 'log--seeding', name: name };
+
+      cy.wrap(farm.log.fetch({ filter: logFilter }))
+        .then((results) => {
+          expect(results.fulfilled.length).to.equal(1);
+          expect(results.rejected.length).to.equal(0);
+          return results.data[0];
+        })
+        .then((log) => {
+          expect(log.attributes.name).to.equal(name);
+          expect(log.attributes.timestamp).to.contain('1950-01-01');
+          expect(log.relationships.quantity.length).to.equal(3);
+          return log;
+        })
+        .then(() => {
+          // Check that the "sticky" parts of the form are not reset...
+          cy.get('[data-cy="date-input"]').should('have.value', '1950-01-01');
+          cy.get('[data-cy="seeding-location-name"]')
+            .find('[data-cy="selector-input"]')
+            .should('have.value', 'CHUAU');
+
+          // And that the toast is hidden.
+          cy.get('.toast', { timeout: 7000 }).should('not.exist');
+        });
+
+      /*
+       * Note: Deleting the asset must come after deleting the log,
+       * because the asset is referenced by the log. But Cypress does
+       * not guarantee that when two async functions are invoked with
+       * cy.wrap() calls will execute in the order they are written.
+       * So the cy.get() here ensures that the log is deleted before
+       * the asset is deleted.
+       *
+       * See: https://docs.cypress.io/api/commands/wrap#Promises
+       */
+      let plantFilter = { type: 'asset--plant', name: name };
+
+      cy.wrap(farm.asset.fetch({ filter: plantFilter }))
+        .then((results) => {
+          expect(results.fulfilled.length).to.equal(1);
+          expect(results.rejected.length).to.equal(0);
+          return results.data[0];
+        })
+        .then((log) => {
+          expect(log.attributes.name).to.equal(name);
+          expect(log.attributes.status).to.equal('active');
+          return log;
+        });
+    });
+  });
+
+  it('Test error on submission.', () => {
+    // Generate an error in the creation of the plant asset.
+    cy.intercept('POST', '**/api/asset/plant', {
+      statusCode: 401,
+    });
+
+    submitForm();
+
+    cy.get('.toast').should('be.visible');
+    cy.get('.toast').contains('Error creating tray seeding.');
+    cy.get('.toast', { timeout: 10000 }).should('not.exist');
+
+    // Check that form is still populated...
+    cy.get('[data-cy="date-input"]').should('have.value', '1950-01-01');
+    cy.get('[data-cy="seeding-crop-name"]')
+      .find('[data-cy="selector-input"]')
+      .should('have.value', 'ARUGULA');
+    cy.get('[data-cy="seeding-location-name"]')
+      .find('[data-cy="selector-input"]')
+      .should('have.value', 'CHUAU');
+    cy.get('[data-cy="seeding-trays"]')
+      .find('[data-cy="numeric-input"]')
+      .should('have.value', '15.00');
+    cy.get('[data-cy="seeding-tray-size"]')
+      .find('[data-cy="selector-input"]')
+      .should('have.value', '50');
+    cy.get('[data-cy="seeding-seeds"]')
+      .find('[data-cy="numeric-input"]')
+      .should('have.value', '3');
+    cy.get('[data-cy="comment-input"]').should('have.value', 'Test comment');
+    cy.get('[data-cy="submit-button"]').should('be.enabled');
+  });
+});

--- a/modules/farm_fd2/src/module/farm_fd2.info.yml
+++ b/modules/farm_fd2/src/module/farm_fd2.info.yml
@@ -3,4 +3,10 @@ description: 'FarmData2 supports operations and reporting for diversified vegeta
 package: FarmData2
 type: module
 version: 1.0
-core_version_requirement: '>=9'
+core_version_requirement: '>=10'
+dependencies:
+  - farm
+  - farm_inventory
+  - views
+  - simple_oauth_password_grant
+  - farm_api_default_consumer

--- a/modules/farm_fd2/src/module/farm_fd2.libraries.yml
+++ b/modules/farm_fd2/src/module/farm_fd2.libraries.yml
@@ -9,3 +9,14 @@ main:
       main/main.css: {}
     component:
       shared/index.css: {}
+tray_seeding:
+  js:
+    tray_seeding/tray_seeding.js:
+      preprocess: false
+      minified: true
+      attributes: { type: 'module' }
+  css:
+    theme:
+      tray_seeding/tray_seeding.css: {}
+    component:
+      shared/index.css: {}

--- a/modules/farm_fd2/src/module/farm_fd2.libraries.yml
+++ b/modules/farm_fd2/src/module/farm_fd2.libraries.yml
@@ -20,3 +20,4 @@ tray_seeding:
       tray_seeding/tray_seeding.css: {}
     component:
       shared/index.css: {}
+    

--- a/modules/farm_fd2/src/module/farm_fd2.links.menu.yml
+++ b/modules/farm_fd2/src/module/farm_fd2.links.menu.yml
@@ -4,3 +4,9 @@ farm.fd2_main:
   parent: farm.base
   route_name: farm.fd2_main.content
   weight: 100
+farm.fd2_tray_seeding:
+  title: 'Tray Seeding'
+  description: 'Data entry form for recording a tray seeding.'
+  parent: farm.fd2_main
+  route_name: farm.fd2_tray_seeding.content
+  weight: 100

--- a/modules/farm_fd2/src/module/farm_fd2.routing.yml
+++ b/modules/farm_fd2/src/module/farm_fd2.routing.yml
@@ -5,3 +5,10 @@ farm.fd2_main.content:
     _title: 'FarmData2'
   requirements:
     _permission: 'access content'
+farm.fd2_tray_seeding.content:
+  path: '/fd2/tray_seeding'
+  defaults:
+    _controller: '\Drupal\farm_fd2\Controller\FD2_Controller::content'
+    _title: 'Tray Seeding'
+  requirements:
+    _permission: 'access content'


### PR DESCRIPTION
**Pull Request Description**

This PR adds the Tray Seeding entry point to the farm_fd2 module to collect data about tray seedings and create the appropriate farmOS assets and logs. The assets and logs created are documented in `docs/DataModel.md`.

Closes #10

---

**Licensing Certification**

FarmData2 is a [Free Cultural Work](https://freedomdefined.org/Definition) and all accepted contributions are licensed as described in the LICENSE.md file. This requires that the contributor holds the rights to do so. By submitting this pull request **I certify that I satisfy the terms of the [Developer Certificate of Origin](https://developercertificate.org/)** for its contents.
