### PR TITLE
ci: fixes drupal-releae hook so it copies all changed files

### DIFF
--- a/.githooks/drupal-release
+++ b/.githooks/drupal-release
@@ -55,7 +55,7 @@ echo "    Done."
 echo "    Copying files from farm_fd2/dist/farmdata to clone..."
 git switch --quiet production
 error_check "Failed to switch to production branch."
-cp -Ru modules/farm_fd2/dist/farmdata2/* /var/tmp/farmdata2/
+cp -R modules/farm_fd2/dist/farmdata2/* /var/tmp/farmdata2/
 error_check "Failed to copy files from farm_fd2/dist/farmdata2."
 echo "    Done."
 


### PR DESCRIPTION
**Pull Request Description**

Patches the `drupal-release` git hook so that all changed files are copied into the drupal farmdata2 module repo.  

---

**Licensing Certification**

FarmData2 is a [Free Cultural Work](https://freedomdefined.org/Definition) and all accepted contributions are licensed as described in the LICENSE.md file. This requires that the contributor holds the rights to do so. By submitting this pull request **I certify that I satisfy the terms of the [Developer Certificate of Origin](https://developercertificate.org/)** for its contents.
