### PR TITLE
test(fd2): tests permission based access to tray seeding

### DIFF
--- a/cypress/support/e2e.js
+++ b/cypress/support/e2e.js
@@ -18,3 +18,4 @@ import './commands';
 
 // Alternatively you can use CommonJS syntax:
 // require('./commands')
+import '@cypress/skip-test/support';

--- a/modules/farm_fd2/src/entrypoints/tray_seeding/tray_seeding.exists.e2e.cy.js
+++ b/modules/farm_fd2/src/entrypoints/tray_seeding/tray_seeding.exists.e2e.cy.js
@@ -1,10 +1,30 @@
 describe('Check that the tray_seeding entry point in farm_fd2 exists.', () => {
-  it('Check that the page loaded.', () => {
+  it('Check that admin can access tray seeding form', () => {
     // Login if running in live farmOS.
     cy.login('admin', 'admin');
     // Go to the main page.
     cy.visit('fd2/tray_seeding/');
     // Check that the page loads.
     cy.waitForPage();
+  });
+
+  it('Check that guest cannot access tray seeding form', () => {
+    /*
+     * Skip this test if we are not running from the live farmOS
+     * server.  If we are running on the dev or preview server then
+     * the login does nothing and the test would fail because the page
+     * would be served to the guest.  When running on the live farmOS
+     * the login validates the guest credentials and enforces the permissions
+     * set for the entry point.
+     *
+     * For some reason the test is marked as "pending" when it is skipped
+     * in this way.  None the less, Cypress reports that all tests pass
+     * both on the live server and on the dev server.
+     */
+    cy.skipOn('localhost');
+
+    cy.login('guest', 'farmdata2');
+    cy.visit({ url: 'fd2/tray_seeding/', failOnStatusCode: false });
+    cy.get('.page-title').should('contain.text', 'Access denied');
   });
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
       },
       "devDependencies": {
         "@cspell/dict-vue": "^3.0.0",
+        "@cypress/skip-test": "^2.6.1",
         "@mryhryki/markdown-preview": "^0.5.0",
         "@prettier/plugin-php": "^0.19.6",
         "@rushstack/eslint-patch": "^1.2.0",
@@ -724,6 +725,12 @@
       "engines": {
         "node": ">= 6"
       }
+    },
+    "node_modules/@cypress/skip-test": {
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/@cypress/skip-test/-/skip-test-2.6.1.tgz",
+      "integrity": "sha512-X+ibefBiuOmC5gKG91wRIT0/OqXeETYvu7zXktjZ3yLeO186Y8ia0K7/gQUpAwuUi28DuqMd1+7tBQVtPkzbPA==",
+      "dev": true
     },
     "node_modules/@cypress/xvfb": {
       "version": "1.2.4",

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
   },
   "devDependencies": {
     "@cspell/dict-vue": "^3.0.0",
+    "@cypress/skip-test": "^2.6.1",
     "@mryhryki/markdown-preview": "^0.5.0",
     "@prettier/plugin-php": "^0.19.6",
     "@rushstack/eslint-patch": "^1.2.0",


### PR DESCRIPTION
**Pull Request Description**

Adds a test that checks that the guest user does not have access to the Tray Seeding form when running on the live farmOS server.  The test is skipped when running on the dev or preview servers.

This PR also adds `@cypress/skip-test` as a dev dependency to allow dynamic skipping of tests.

Closes #105 

---

**Licensing Certification**

FarmData2 is a [Free Cultural Work](https://freedomdefined.org/Definition) and all accepted contributions are licensed as described in the LICENSE.md file. This requires that the contributor holds the rights to do so. By submitting this pull request **I certify that I satisfy the terms of the [Developer Certificate of Origin](https://developercertificate.org/)** for its contents.
