### PR TITLE
refactor(lib): refactor caching in the farmosUtil.js library

### DIFF
--- a/library/farmosUtil/farmosUtil.caching.unit.cy.js
+++ b/library/farmosUtil/farmosUtil.caching.unit.cy.js
@@ -1,0 +1,111 @@
+import * as farmosUtil from './farmosUtil.js';
+
+describe('Test the caching behavior', () => {
+  /*
+   * Don't save and restore the session and local storage in these
+   * tests.  That way we have more explicit control over the caching.
+   */
+
+  it('fetchWithCaching uses global variable cache', () => {
+    farmosUtil.clearCachedValue('cacheTest');
+    expect(farmosUtil.getFromGlobalVariableCache('cacheTest')).to.be.null;
+    expect(sessionStorage.getItem('cacheTest')).to.be.null;
+
+    const mockFetch = {
+      fetchedValue: async () => {
+        return { data: { one: 'two' } };
+      },
+    };
+    const fetchFunc = cy.spy(mockFetch, 'fetchedValue');
+
+    // Get the first one to ensure the cache is populated.
+    cy.wrap(
+      farmosUtil.fetchWithCaching('cacheTest', mockFetch.fetchedValue)
+    ).as('value');
+
+    cy.get('@value')
+      .then((value) => {
+        expect(fetchFunc).to.be.calledOnce;
+        expect(value.one).to.equal('two');
+
+        const globalVal = farmosUtil.getFromGlobalVariableCache('cacheTest');
+        expect(globalVal.one).to.equal('two');
+
+        const sessionVal = JSON.parse(sessionStorage.getItem('cacheTest'));
+        expect(sessionVal.one).to.equal('two');
+      })
+      .then(() => {
+        // Now clear the session storage to ensure that the value came from the global.
+        sessionStorage.removeItem('cacheTest');
+
+        cy.wrap(
+          farmosUtil.fetchWithCaching('cacheTest', mockFetch.fetchedValue)
+        ).as('value2');
+
+        cy.get('@value2').then((value2) => {
+          // Should still have only been one API call.
+          expect(fetchFunc).to.be.calledOnce;
+          expect(value2.one).to.equal('two');
+
+          const globalVal2 = farmosUtil.getFromGlobalVariableCache('cacheTest');
+          expect(globalVal2.one).to.equal('two');
+
+          // Note: sessionStorage is not recreated when we get the value from the global.
+          const sessionVal2 = sessionStorage.getItem('cacheTest');
+          expect(sessionVal2).to.be.null;
+        });
+      });
+  });
+
+  it('fetchWithCaching uses sessionStorage cache', () => {
+    farmosUtil.clearCachedValue('cacheTest');
+    expect(farmosUtil.getFromGlobalVariableCache('cacheTest')).to.be.null;
+    expect(sessionStorage.getItem('cacheTest')).to.be.null;
+
+    const mockFetch = {
+      fetchedValue: async () => {
+        return { data: { one: 'two' } };
+      },
+    };
+    const fetchFunc = cy.spy(mockFetch, 'fetchedValue');
+
+    // Get the first one to ensure the cache is populated.
+    cy.wrap(
+      farmosUtil.fetchWithCaching('cacheTest', mockFetch.fetchedValue)
+    ).as('value');
+
+    cy.get('@value')
+      .then((value) => {
+        expect(fetchFunc).to.be.calledOnce;
+        expect(value.one).to.equal('two');
+
+        const globalVal = farmosUtil.getFromGlobalVariableCache('cacheTest');
+        expect(globalVal.one).to.equal('two');
+
+        const sessionVal = JSON.parse(sessionStorage.getItem('cacheTest'));
+        expect(sessionVal.one).to.equal('two');
+      })
+      .then(() => {
+        // Clear the global so we test if we get the value from the sessionStorage.
+        farmosUtil.clearFromGlobalVariableCache('cacheTest');
+        expect(farmosUtil.getFromGlobalVariableCache('cacheTest')).to.be.null;
+        expect(sessionStorage.getItem('cacheTest')).not.to.be.null;
+
+        cy.wrap(
+          farmosUtil.fetchWithCaching('cacheTest', mockFetch.fetchedValue)
+        ).as('value2');
+
+        cy.get('@value2').then((value2) => {
+          // Should still have been only one API call.
+          expect(fetchFunc).to.be.calledOnce;
+          expect(value2.one).to.equal('two');
+
+          const globalVal2 = farmosUtil.getFromGlobalVariableCache('cacheTest');
+          expect(globalVal2.one).to.equal('two');
+
+          const sessionVal2 = JSON.parse(sessionStorage.getItem('cacheTest'));
+          expect(sessionVal2.one).to.equal('two');
+        });
+      });
+  });
+});

--- a/library/farmosUtil/farmosUtil.caching.unit.cy.js
+++ b/library/farmosUtil/farmosUtil.caching.unit.cy.js
@@ -13,7 +13,7 @@ describe('Test the caching behavior', () => {
 
     const mockFetch = {
       fetchedValue: async () => {
-        return { data: { one: 'two' } };
+        return { one: 'two' };
       },
     };
     const fetchFunc = cy.spy(mockFetch, 'fetchedValue');
@@ -64,7 +64,7 @@ describe('Test the caching behavior', () => {
 
     const mockFetch = {
       fetchedValue: async () => {
-        return { data: { one: 'two' } };
+        return { one: 'two' };
       },
     };
     const fetchFunc = cy.spy(mockFetch, 'fetchedValue');

--- a/library/farmosUtil/farmosUtil.crops.unit.cy.js
+++ b/library/farmosUtil/farmosUtil.crops.unit.cy.js
@@ -43,67 +43,11 @@ describe('Test the crop utility functions', () => {
     );
   });
 
-  it('Test that getCrops uses global variable cache', { retries: 4 }, () => {
-    farmosUtil.clearCachedCrops();
-    expect(farmosUtil.getGlobalCrops()).to.be.null;
-    expect(sessionStorage.getItem('crops')).to.be.null;
-
-    cy.intercept(
-      'GET',
-      '**/api/taxonomy_term/plant_type?*',
-      cy.spy().as('fetchCrops')
-    );
-
-    // Get the first one to ensure the cache is populated.
-    cy.wrap(farmosUtil.getCrops())
-      .then(() => {
-        // There are three pages of crops.
-        cy.get('@fetchCrops').its('callCount').should('equal', 3);
-        expect(farmosUtil.getGlobalCrops()).not.to.be.null;
-        expect(sessionStorage.getItem('crops')).not.to.be.null;
-      })
-      .then(() => {
-        // Now check that the global is used and sessionStorage cache is repopulated.
-        sessionStorage.removeItem('crops');
-        cy.wrap(farmosUtil.getCrops()).then(() => {
-          // No more api calls were made.
-          cy.get('@fetchCrops').its('callCount').should('equal', 3);
-          expect(farmosUtil.getGlobalCrops()).not.to.be.null;
-          expect(sessionStorage.getItem('crops')).to.be.null;
-        });
-      });
-  });
-
-  it('Test that getCrops uses session storage cache', { retries: 4 }, () => {
-    farmosUtil.clearCachedCrops();
-    expect(farmosUtil.getGlobalCrops()).to.be.null;
-    expect(sessionStorage.getItem('crops')).to.be.null;
-
-    cy.intercept(
-      'GET',
-      '**/api/taxonomy_term/plant_type?*',
-      cy.spy().as('fetchCrops')
-    );
-
-    // Get the first one to ensure the cache is populated.
-    cy.wrap(farmosUtil.getCrops())
-      .then(() => {
-        cy.get('@fetchCrops').its('callCount').should('equal', 3);
-        expect(farmosUtil.getGlobalCrops()).not.to.be.null;
-        expect(sessionStorage.getItem('crops')).not.to.be.null;
-      })
-      .then(() => {
-        farmosUtil.clearGlobalCrops();
-        expect(farmosUtil.getGlobalCrops()).to.be.null;
-        expect(sessionStorage.getItem('crops')).not.to.be.null;
-
-        // Now check that the session storage is used.
-        cy.wrap(farmosUtil.getCrops()).then(() => {
-          cy.get('@fetchCrops').its('callCount').should('equal', 3);
-          expect(farmosUtil.getGlobalCrops()).to.not.be.null;
-          expect(sessionStorage.getItem('crops')).to.not.be.null;
-        });
-      });
+  it('Check that crops are cached', () => {
+    cy.wrap(farmosUtil.getCrops()).then(() => {
+      expect(farmosUtil.getFromGlobalVariableCache('crops')).to.not.be.null;
+      expect(sessionStorage.getItem('crops')).to.not.be.null;
+    });
   });
 
   it('Get the cropNameMap', () => {

--- a/library/farmosUtil/farmosUtil.fieldsAndBeds.unit.cy.js
+++ b/library/farmosUtil/farmosUtil.fieldsAndBeds.unit.cy.js
@@ -24,100 +24,32 @@ describe('Test the land utility functions', () => {
     });
   });
 
-  it(
-    'Test that get fields and beds throws error if fetch fails',
-    { retries: 4 },
-    () => {
-      farmosUtil.clearCachedFieldsAndBeds();
+  it('Check that fields and beds are cached', () => {
+    cy.wrap(farmosUtil.getFieldsAndBeds()).then(() => {
+      expect(farmosUtil.getFromGlobalVariableCache('fields_and_beds')).to.not.be
+        .null;
+      expect(sessionStorage.getItem('fields_and_beds')).to.not.be.null;
+    });
+  });
 
-      cy.intercept('GET', '**/api/asset/land?*', {
-        forceNetworkError: true,
-      });
+  it('Get fields and beds throws error if fetch fails', { retries: 4 }, () => {
+    farmosUtil.clearCachedFieldsAndBeds();
 
-      cy.wrap(
-        farmosUtil
-          .getFieldsAndBeds()
-          .then(() => {
-            throw new Error('Fetching fields and beds should have failed.');
-          })
-          .catch((error) => {
-            expect(error.message).to.equal('Unable to fetch fields and beds.');
-          })
-      );
-    }
-  );
+    cy.intercept('GET', '**/api/asset/land?*', {
+      forceNetworkError: true,
+    });
 
-  it(
-    'Test that getFieldsAndBeds uses global variable cache',
-    { retries: 4 },
-    () => {
-      farmosUtil.clearCachedFieldsAndBeds();
-      expect(farmosUtil.getGlobalFieldsAndBeds()).to.be.null;
-      expect(sessionStorage.getItem('fields_and_beds')).to.be.null;
-
-      cy.intercept(
-        'GET',
-        '**/api/asset/land?*',
-        cy.spy().as('fetchFieldsAndBeds')
-      );
-
-      // Get the first one to ensure the cache is populated.
-      cy.wrap(farmosUtil.getFieldsAndBeds())
+    cy.wrap(
+      farmosUtil
+        .getFieldsAndBeds()
         .then(() => {
-          cy.get('@fetchFieldsAndBeds').its('callCount').should('equal', 2);
-          expect(farmosUtil.getGlobalFieldsAndBeds()).not.to.be.null;
-          expect(sessionStorage.getItem('fields_and_beds')).not.to.be.null;
+          throw new Error('Fetching fields and beds should have failed.');
         })
-        .then(() => {
-          // Now check that the global is used.
-          sessionStorage.removeItem('fields_and_beds');
-          expect(farmosUtil.getGlobalFieldsAndBeds()).not.to.be.null;
-          expect(sessionStorage.getItem('fields_and_beds')).to.be.null;
-
-          cy.wrap(farmosUtil.getFieldsAndBeds()).then(() => {
-            cy.get('@fetchFieldsAndBeds').its('callCount').should('equal', 2);
-            expect(farmosUtil.getGlobalFieldsAndBeds()).to.not.be.null;
-            expect(sessionStorage.getItem('fields_and_beds')).to.be.null;
-          });
-        });
-    }
-  );
-
-  it(
-    'Test that getFieldsAndBeds uses session storage cache',
-    { retries: 4 },
-    () => {
-      farmosUtil.clearCachedFieldsAndBeds();
-      expect(farmosUtil.getGlobalFieldsAndBeds()).to.be.null;
-      expect(sessionStorage.getItem('fields_and_beds')).to.be.null;
-
-      cy.intercept(
-        'GET',
-        '**/api/asset/land?*',
-        cy.spy().as('fetchFieldsAndBeds')
-      );
-
-      // Get the first one to ensure the cache is populated.
-      cy.wrap(farmosUtil.getFieldsAndBeds())
-        .then(() => {
-          // Note fields and beds are fetched by separate API calls.
-          cy.get('@fetchFieldsAndBeds').its('callCount').should('equal', 2);
-          expect(farmosUtil.getGlobalFieldsAndBeds()).not.to.be.null;
-          expect(sessionStorage.getItem('fields_and_beds')).not.to.be.null;
+        .catch((error) => {
+          expect(error.message).to.equal('Unable to fetch fields and beds.');
         })
-        .then(() => {
-          // Now check that the session storage is used.
-          farmosUtil.clearGlobalFieldsAndBeds();
-          expect(farmosUtil.getGlobalFieldsAndBeds()).to.be.null;
-          expect(sessionStorage.getItem('fields_and_beds')).not.to.be.null;
-          cy.wrap(farmosUtil.getFieldsAndBeds()).then(() => {
-            cy.get('@fetchFieldsAndBeds').its('callCount').should('equal', 2);
-            expect(farmosUtil.getGlobalFieldsAndBeds()).to.not.be.null;
-            expect(sessionStorage.getItem('fields_and_beds')).to.not.be.null;
-          });
-        });
-    }
-  );
+    );
+  });
 
   it('Get the FieldOrBedNameToAsset map', () => {
     cy.wrap(farmosUtil.getFieldOrBedNameToAssetMap()).then((landNameMap) => {

--- a/library/farmosUtil/farmosUtil.greenhouses.unit.cy.js
+++ b/library/farmosUtil/farmosUtil.greenhouses.unit.cy.js
@@ -47,74 +47,13 @@ describe('Test the greenhouse utility functions', () => {
     }
   );
 
-  it(
-    'Test that getGreenhouses uses global variable cache',
-    { retries: 4 },
-    () => {
-      farmosUtil.clearCachedGreenhouses();
-      expect(farmosUtil.getGlobalGreenhouses()).to.be.null;
-      expect(sessionStorage.getItem('greenhouses')).to.be.null;
-
-      cy.intercept(
-        'GET',
-        '**/api/asset/structure?*',
-        cy.spy().as('fetchGreenhouses')
-      );
-
-      // Get the first one to ensure the cache is populated.
-      cy.wrap(farmosUtil.getGreenhouses())
-        .then(() => {
-          cy.get('@fetchGreenhouses').its('callCount').should('equal', 1);
-          expect(farmosUtil.getGlobalGreenhouses()).not.to.be.null;
-          expect(sessionStorage.getItem('greenhouses')).not.to.be.null;
-        })
-        .then(() => {
-          // Now check that the global is used.
-          sessionStorage.removeItem('greenhouses');
-          cy.wrap(farmosUtil.getGreenhouses()).then(() => {
-            cy.get('@fetchGreenhouses').its('callCount').should('equal', 1);
-            expect(farmosUtil.getGlobalGreenhouses()).not.to.be.null;
-            expect(sessionStorage.getItem('greenhouses')).to.be.null;
-          });
-        });
-    }
-  );
-
-  it(
-    'Test that getGreenhouses uses session storage cache',
-    { retries: 4 },
-    () => {
-      farmosUtil.clearCachedGreenhouses();
-      expect(farmosUtil.getGlobalGreenhouses()).to.be.null;
-      expect(sessionStorage.getItem('greenhouses')).to.be.null;
-
-      cy.intercept(
-        'GET',
-        '**/api/asset/structure?*',
-        cy.spy().as('fetchGreenhouses')
-      );
-
-      // Get the first one to ensure the cache is populated.
-      cy.wrap(farmosUtil.getGreenhouses())
-        .then(() => {
-          cy.get('@fetchGreenhouses').its('callCount').should('equal', 1);
-          expect(farmosUtil.getGlobalGreenhouses()).not.to.be.null;
-          expect(sessionStorage.getItem('greenhouses')).not.to.be.null;
-        })
-        .then(() => {
-          farmosUtil.clearGlobalGreenhouses();
-          expect(farmosUtil.getGlobalGreenhouses()).to.be.null;
-          expect(sessionStorage.getItem('greenhouses')).not.to.be.null;
-
-          // Now check that the session storage is used.
-          cy.wrap(farmosUtil.getGreenhouses()).then(() => {
-            cy.get('@fetchGreenhouses').its('callCount').should('equal', 1);
-            expect(farmosUtil.getGlobalGreenhouses()).to.not.be.null;
-            expect(sessionStorage.getItem('greenhouses')).to.not.be.null;
-          });
-        });
-    }
-  );
+  it('Check that greenhouses are cached', () => {
+    cy.wrap(farmosUtil.getGreenhouses()).then(() => {
+      expect(farmosUtil.getFromGlobalVariableCache('greenhouses')).to.not.be
+        .null;
+      expect(sessionStorage.getItem('greenhouses')).to.not.be.null;
+    });
+  });
 
   it('Get the GreenhouseNameToAsset map', () => {
     cy.wrap(farmosUtil.getGreenhouseNameToAssetMap()).then((ghNameMap) => {

--- a/library/farmosUtil/farmosUtil.js
+++ b/library/farmosUtil/farmosUtil.js
@@ -470,10 +470,9 @@ export function printObject(farm, recordType) {
  * farmOS API if necessary.  This function should return the result of the
  * API call or throw an Error if the API call fails.
  * @throws {Error} propagates any error thrown by the `fetchFunction`.
- * @returns the value returned by the fetch function, either from the cache
- * or by calling the fetchFunction if the value is not cached..
+ * @returns {Object} the value of the data property in the object returned by the fetch function.
  */
-async function fetchWithCaching(key, fetchFunction) {
+export async function fetchWithCaching(key, fetchFunction) {
   /*
    * If the value to be fetched exits in the global variable cache
    * return it from there.

--- a/library/farmosUtil/farmosUtil.js
+++ b/library/farmosUtil/farmosUtil.js
@@ -565,32 +565,6 @@ export function clearCachedUsers() {
 }
 
 /**
- * @private
- *
- * Get the `global_users` object.  This is used for testing to ensure
- * that the global is set by the appropriate functions.  This function
- * should not be used in front end code. Use the
- * [`getUsers`]{@link #module_farmosUtil.getUsers}
- * function instead.
- */
-export function getGlobalUsers() {
-  return getFromGlobalVariableCache('users');
-}
-
-/**
- * @private
- *
- * Clear the `global_users` object.  This is used for testing to ensure
- * that the global is not set by prior tests. This function
- * should not be used in front end code. Use the
- * [`clearCachedUsers`]{@link #module_farmosUtil.clearCachedUsers}
- * function instead.
- */
-export function clearGlobalUsers() {
-  clearFromGlobalVariableCache('users');
-}
-
-/**
  * Get an array containing all of the active users from the farmOS host.  The users
  * will appear in the array in order by the value of the `attributes.display_name`
  * property.

--- a/library/farmosUtil/farmosUtil.logCategories.unit.cy.js
+++ b/library/farmosUtil/farmosUtil.logCategories.unit.cy.js
@@ -30,6 +30,14 @@ describe('Test the log categories utility functions', () => {
     });
   });
 
+  it('Check that log categories are cached', () => {
+    cy.wrap(farmosUtil.getLogCategories()).then(() => {
+      expect(farmosUtil.getFromGlobalVariableCache('log_categories')).to.not.be
+        .null;
+      expect(sessionStorage.getItem('log_categories')).to.not.be.null;
+    });
+  });
+
   it('Test that get units throws error if fetch fails', { retries: 4 }, () => {
     farmosUtil.clearCachedLogCategories();
 
@@ -48,77 +56,6 @@ describe('Test the log categories utility functions', () => {
         })
     );
   });
-
-  it(
-    'Test that getLogCategories uses global variable cache',
-    { retries: 4 },
-    () => {
-      cy.intercept(
-        'GET',
-        '**/api/taxonomy_term/log_category?',
-        cy.spy().as('fetchLogCategories')
-      );
-
-      farmosUtil.clearCachedLogCategories();
-      expect(farmosUtil.getGlobalLogCategories()).to.be.null;
-      expect(sessionStorage.getItem('log_categories')).to.be.null;
-
-      // Get the first one to ensure the cache is populated.
-      cy.wrap(farmosUtil.getLogCategories())
-        .then(() => {
-          cy.get('@fetchLogCategories').its('callCount').should('equal', 1);
-          expect(farmosUtil.getGlobalLogCategories()).not.to.be.null;
-          expect(sessionStorage.getItem('log_categories')).not.to.be.null;
-        })
-        .then(() => {
-          // Now check that the global is used.
-          sessionStorage.removeItem('log_categories');
-          cy.wrap(farmosUtil.getLogCategories()).then(() => {
-            cy.get('@fetchLogCategories').its('callCount').should('equal', 1);
-            expect(farmosUtil.getGlobalLogCategories()).not.to.be.null;
-            expect(sessionStorage.getItem('log_categories')).to.be.null;
-          });
-        });
-    }
-  );
-
-  it(
-    'Test that getLogCategories uses session storage cache',
-    { retries: 4 },
-    () => {
-      cy.intercept(
-        'GET',
-        '**/api/taxonomy_term/log_category?',
-        cy.spy().as('fetchLogCategories')
-      );
-
-      farmosUtil.clearCachedLogCategories();
-      expect(farmosUtil.getGlobalLogCategories()).to.be.null;
-      expect(sessionStorage.getItem('log_categories')).to.be.null;
-
-      // Get the first one to ensure the cache is populated.
-      cy.wrap(farmosUtil.getLogCategories())
-        .then(() => {
-          cy.get('@fetchLogCategories').should('have.been.calledOnce');
-          expect(farmosUtil.getGlobalLogCategories()).not.to.be.null;
-          expect(sessionStorage.getItem('log_categories')).not.to.be.null;
-        })
-        .then(() => {
-          farmosUtil.clearGlobalLogCategories();
-          expect(farmosUtil.getGlobalLogCategories()).to.be.null;
-          expect(sessionStorage.getItem('log_categories')).not.to.be.null;
-
-          // Now check that the session storage is used.
-          cy.wrap(farmosUtil.getLogCategories()).then(() => {
-            cy.get('@fetchLogCategories').should('have.been.calledOnce');
-            expect(farmosUtil.getGlobalLogCategories()).to.not.be.null;
-            expect(sessionStorage.getItem('log_categories')).to.not.be.null;
-          });
-        });
-
-      cy.get('@fetchLogCategories').should('have.been.calledOnce');
-    }
-  );
 
   it('Get the logCategoryToTerm map', () => {
     cy.wrap(farmosUtil.getLogCategoryToTermMap()).then((categoryMap) => {

--- a/library/farmosUtil/farmosUtil.permissions.unit.cy.js
+++ b/library/farmosUtil/farmosUtil.permissions.unit.cy.js
@@ -44,6 +44,17 @@ describe('Test the permissions checking utility functions', () => {
     });
   });
 
+  it('Check that permissions are cached', () => {
+    farmosUtil.clearCachedFarm();
+    farmosUtil.clearCachedPermissions();
+    // calling getPermissions here will use admin credentials
+    cy.wrap(farmosUtil.getPermissions()).then(() => {
+      expect(farmosUtil.getFromGlobalVariableCache('permissions')).to.not.be
+        .null;
+      expect(sessionStorage.getItem('permissions')).to.not.be.null;
+    });
+  });
+
   it(
     'Test that getPermissions throws error if fetch fails',
     { retries: 4 },
@@ -70,7 +81,7 @@ describe('Test the permissions checking utility functions', () => {
 
   it('Test getPermission function as admin', () => {
     farmosUtil.clearCachedFarm();
-
+    // calling checkPermission here will use admin credentials
     cy.wrap(farmosUtil.checkPermission('create-plant-asset')).should('be.true');
     cy.wrap(farmosUtil.checkPermission('create-structure-asset')).should(
       'be.true'

--- a/library/farmosUtil/farmosUtil.traySizes.unit.cy.js
+++ b/library/farmosUtil/farmosUtil.traySizes.unit.cy.js
@@ -30,6 +30,14 @@ describe('Test the tray sizes utility functions', () => {
     });
   });
 
+  it('Check that tray sizes are cached', () => {
+    cy.wrap(farmosUtil.getTraySizes()).then(() => {
+      expect(farmosUtil.getFromGlobalVariableCache('tray_sizes')).to.not.be
+        .null;
+      expect(sessionStorage.getItem('tray_sizes')).to.not.be.null;
+    });
+  });
+
   it(
     'Test that get tray sizes throws error if fetch fails',
     { retries: 4 },
@@ -50,75 +58,6 @@ describe('Test the tray sizes utility functions', () => {
             expect(error.message).to.equal('Unable to fetch tray sizes.');
           })
       );
-    }
-  );
-
-  it(
-    'Test that getTraySizes uses global variable cache',
-    { retries: 4 },
-    () => {
-      farmosUtil.clearCachedTraySizes();
-      expect(farmosUtil.getGlobalTraySizes()).to.be.null;
-      expect(sessionStorage.getItem('tray_sizes')).to.be.null;
-
-      cy.intercept(
-        'GET',
-        '**/api/taxonomy_term/tray_size?*',
-        cy.spy().as('fetchTraySizes')
-      );
-
-      // Get the first one to ensure the cache is populated.
-      cy.wrap(farmosUtil.getTraySizes())
-        .then(() => {
-          cy.get('@fetchTraySizes').its('callCount').should('equal', 1);
-          expect(farmosUtil.getGlobalTraySizes()).not.to.be.null;
-          expect(sessionStorage.getItem('tray_sizes')).not.to.be.null;
-        })
-        .then(() => {
-          // Now check that the global is used.
-          sessionStorage.removeItem('tray_sizes');
-          cy.wrap(farmosUtil.getTraySizes()).then(() => {
-            cy.get('@fetchTraySizes').its('callCount').should('equal', 1);
-            expect(farmosUtil.getGlobalTraySizes()).not.to.be.null;
-            expect(sessionStorage.getItem('tray_sizes')).to.be.null;
-          });
-        });
-    }
-  );
-
-  it(
-    'Test that getTraySizes uses session storage cache',
-    { retries: 4 },
-    () => {
-      farmosUtil.clearCachedTraySizes();
-      expect(farmosUtil.getGlobalTraySizes()).to.be.null;
-      expect(sessionStorage.getItem('tray_sizes')).to.be.null;
-
-      cy.intercept(
-        'GET',
-        '**/api/taxonomy_term/tray_size?*',
-        cy.spy().as('fetchTraySizes')
-      );
-
-      // Get the first one to ensure the cache is populated.
-      cy.wrap(farmosUtil.getTraySizes())
-        .then(() => {
-          cy.get('@fetchTraySizes').its('callCount').should('equal', 1);
-          expect(farmosUtil.getGlobalTraySizes()).not.to.be.null;
-          expect(sessionStorage.getItem('tray_sizes')).not.to.be.null;
-        })
-        .then(() => {
-          farmosUtil.clearGlobalTraySizes();
-          expect(farmosUtil.getGlobalTraySizes()).to.be.null;
-          expect(sessionStorage.getItem('tray_sizes')).not.to.be.null;
-
-          // Now check that the session storage is used.
-          cy.wrap(farmosUtil.getTraySizes()).then(() => {
-            cy.get('@fetchTraySizes').its('callCount').should('equal', 1);
-            expect(farmosUtil.getGlobalTraySizes()).to.not.be.null;
-            expect(sessionStorage.getItem('tray_sizes')).to.not.be.null;
-          });
-        });
     }
   );
 

--- a/library/farmosUtil/farmosUtil.units.unit.cy.js
+++ b/library/farmosUtil/farmosUtil.units.unit.cy.js
@@ -30,6 +30,13 @@ describe('Test the units utility functions', () => {
     });
   });
 
+  it('Check that units are cached', () => {
+    cy.wrap(farmosUtil.getUnits()).then(() => {
+      expect(farmosUtil.getFromGlobalVariableCache('units')).to.not.be.null;
+      expect(sessionStorage.getItem('units')).to.not.be.null;
+    });
+  });
+
   it('Test that get units throws error if fetch fails', { retries: 4 }, () => {
     farmosUtil.clearCachedUnits();
 
@@ -47,67 +54,6 @@ describe('Test the units utility functions', () => {
           expect(error.message).to.equal('Unable to fetch units.');
         })
     );
-  });
-
-  it('Test that getUnits uses global variable cache', { retries: 4 }, () => {
-    farmosUtil.clearCachedUnits();
-    expect(farmosUtil.getGlobalUnits()).to.be.null;
-    expect(sessionStorage.getItem('units')).to.be.null;
-
-    cy.intercept(
-      'GET',
-      '**/api/taxonomy_term/unit?*',
-      cy.spy().as('fetchUnits')
-    );
-
-    // Get the first one to ensure the cache is populated.
-    cy.wrap(farmosUtil.getUnits())
-      .then(() => {
-        cy.get('@fetchUnits').its('callCount').should('equal', 1);
-        expect(farmosUtil.getGlobalUnits()).not.to.be.null;
-        expect(sessionStorage.getItem('units')).not.to.be.null;
-      })
-      .then(() => {
-        // Now check that the global is used.
-        sessionStorage.removeItem('units');
-        cy.wrap(farmosUtil.getUnits()).then(() => {
-          cy.get('@fetchUnits').its('callCount').should('equal', 1);
-          expect(farmosUtil.getGlobalUnits()).not.to.be.null;
-          expect(sessionStorage.getItem('units')).to.be.null;
-        });
-      });
-  });
-
-  it('Test that getUnits uses session storage cache', { retries: 4 }, () => {
-    farmosUtil.clearCachedUnits();
-    expect(farmosUtil.getGlobalUnits()).to.be.null;
-    expect(sessionStorage.getItem('units')).to.be.null;
-
-    cy.intercept(
-      'GET',
-      '**/api/taxonomy_term/unit?*',
-      cy.spy().as('fetchUnits')
-    );
-
-    // Get the first one to ensure the cache is populated.
-    cy.wrap(farmosUtil.getUnits())
-      .then(() => {
-        cy.get('@fetchUnits').its('callCount').should('equal', 1);
-        expect(farmosUtil.getGlobalUnits()).not.to.be.null;
-        expect(sessionStorage.getItem('units')).not.to.be.null;
-      })
-      .then(() => {
-        farmosUtil.clearGlobalUnits();
-        expect(farmosUtil.getGlobalUnits()).to.be.null;
-        expect(sessionStorage.getItem('units')).not.to.be.null;
-
-        // Now check that the session storage is used.
-        cy.wrap(farmosUtil.getUnits()).then(() => {
-          cy.get('@fetchUnits').its('callCount').should('equal', 1);
-          expect(farmosUtil.getGlobalUnits()).to.not.be.null;
-          expect(sessionStorage.getItem('units')).to.not.be.null;
-        });
-      });
   });
 
   it('Get the unitToTerm map', () => {


### PR DESCRIPTION
**Pull Request Description**

This PR factors the caching functionality in farmosUtil.js out into its own function and then refactors all of the functions that use that caching functionality so that they use the factored out function. This reduces the overall amount of code and test code. Additional tests were added that test just the caching functionality and the corresponding tests for each of the refactored functions was removed.

Closes #92

---

**Licensing Certification**

FarmData2 is a [Free Cultural Work](https://freedomdefined.org/Definition) and all accepted contributions are licensed as described in the LICENSE.md file. This requires that the contributor holds the rights to do so. By submitting this pull request **I certify that I satisfy the terms of the [Developer Certificate of Origin](https://developercertificate.org/)** for its contents.
