### PR TITLE
feat(fd2): adds the seeding parent menu

### DIFF
--- a/modules/farm_fd2/src/entrypoints/seeding/App.vue
+++ b/modules/farm_fd2/src/entrypoints/seeding/App.vue
@@ -1,0 +1,43 @@
+<template>
+  <h1 data-cy="title">FarmData2 Seeding Features</h1>
+  <p>
+    This menu contains the collection of FarmData2 seeding features including:
+  </p>
+
+  <UL>
+    <LI>
+      Tray Seeding Input: A form for recording seedings that are made in trays
+      in a greenhouse.
+    </LI>
+    <LI>
+      Direct Seeding Input: A form for recording seedings that are made directly
+      in the ground.
+    </LI>
+    <LI>Cover Crop Seedings: Seeding of a cover crop in a field. </LI>
+  </UL>
+
+  <div
+    data-cy="page-loaded"
+    v-show="false"
+  >
+    {{ pageDoneLoading }}
+  </div>
+</template>
+
+<script>
+export default {
+  data() {
+    return {
+      createdCount: 0,
+    };
+  },
+  computed: {
+    pageDoneLoading() {
+      return this.createdCount == 1;
+    },
+  },
+  created() {
+    this.createdCount++;
+  },
+};
+</script>

--- a/modules/farm_fd2/src/entrypoints/seeding/index.html
+++ b/modules/farm_fd2/src/entrypoints/seeding/index.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1.0"
+    />
+    <title>Seeding</title>
+  </head>
+  <body>
+    <div id="app"></div>
+    <script
+      type="module"
+      src="/seeding/seeding.js"
+    ></script>
+  </body>
+</html>

--- a/modules/farm_fd2/src/entrypoints/seeding/seeding.exists.e2e.cy.js
+++ b/modules/farm_fd2/src/entrypoints/seeding/seeding.exists.e2e.cy.js
@@ -1,0 +1,10 @@
+describe('Check that the seeding entry point in farm_fd2 exists.', () => {
+  it('Check that the page loaded.', () => {
+    // Login if running in live farmOS.
+    cy.login('admin', 'admin');
+    // Go to the main page.
+    cy.visit('fd2/seeding/');
+    // Check that the page loads.
+    cy.waitForPage();
+  });
+});

--- a/modules/farm_fd2/src/entrypoints/seeding/seeding.html
+++ b/modules/farm_fd2/src/entrypoints/seeding/seeding.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1.0"
+    />
+    <title>Seeding</title>
+  </head>
+  <body>
+    <div id="app"></div>
+    <script
+      type="module"
+      src="/seeding/seeding.js"
+    ></script>
+  </body>
+</html>

--- a/modules/farm_fd2/src/entrypoints/seeding/seeding.js
+++ b/modules/farm_fd2/src/entrypoints/seeding/seeding.js
@@ -1,0 +1,13 @@
+// Imports for Bootstrap-Vue components.
+import 'bootstrap/dist/css/bootstrap.css';
+import 'bootstrap-vue-next/dist/bootstrap-vue-next.css';
+
+import { createApp } from 'vue';
+import { createPinia } from 'pinia';
+import App from './App.vue';
+
+const app = createApp(App);
+
+app.use(createPinia());
+
+app.mount('#app');

--- a/modules/farm_fd2/src/module/farm_fd2.libraries.yml
+++ b/modules/farm_fd2/src/module/farm_fd2.libraries.yml
@@ -20,4 +20,15 @@ tray_seeding:
       tray_seeding/tray_seeding.css: {}
     component:
       shared/index.css: {}
-    
+
+seeding:
+  js:
+    seeding/seeding.js:
+      preprocess: false
+      minified: true
+      attributes: { type: 'module' }
+  css:
+    theme:
+      seeding/seeding.css: {}
+    component:
+      shared/index.css: {}

--- a/modules/farm_fd2/src/module/farm_fd2.links.menu.yml
+++ b/modules/farm_fd2/src/module/farm_fd2.links.menu.yml
@@ -4,9 +4,15 @@ farm.fd2_main:
   parent: farm.base
   route_name: farm.fd2_main.content
   weight: 100
+farm.fd2_seeding:
+  title: 'Seeding'
+  description: 'FarmData2 features for seedings.'
+  parent: farm.fd2_main
+  route_name: farm.fd2_seeding.content
+  weight: 100
 farm.fd2_tray_seeding:
   title: 'Tray Seeding'
   description: 'Data entry form for recording a tray seeding.'
-  parent: farm.fd2_main
+  parent: farm.fd2_seeding
   route_name: farm.fd2_tray_seeding.content
   weight: 100

--- a/modules/farm_fd2/src/module/farm_fd2.routing.yml
+++ b/modules/farm_fd2/src/module/farm_fd2.routing.yml
@@ -13,6 +13,13 @@ farm.fd2_main.content:
     _title: 'FarmData2'
   requirements:
     _permission: 'access content'
+farm.fd2_seeding.content:
+  path: '/fd2/seeding'
+  defaults:
+    _controller: '\Drupal\farm_fd2\Controller\FD2_Controller::content'
+    _title: 'Seeding'
+  requirements:
+    _permission: 'access content'
 farm.fd2_tray_seeding.content:
   path: '/fd2/tray_seeding'
   defaults:


### PR DESCRIPTION
**Pull Request Description**

This PR adds the "Seeding" parent menu to the "FarmData2" menu.  It moves the "Tray Seeding" input form to this parent menu and will provide a parent for the additional seeding related features (direct seeding, cover crop seeding, seeding reports, etc...)

Related to #129 

---

**Licensing Certification**

FarmData2 is a [Free Cultural Work](https://freedomdefined.org/Definition) and all accepted contributions are licensed as described in the LICENSE.md file. This requires that the contributor holds the rights to do so. By submitting this pull request **I certify that I satisfy the terms of the [Developer Certificate of Origin](https://developercertificate.org/)** for its contents.
