### PR TITLE
refactor: move asset, quantity, log creation into `farmosUtil.js`

### DIFF
--- a/docs/DataModel.md
+++ b/docs/DataModel.md
@@ -19,9 +19,10 @@ The general convention for naming logs and assets is:
     - `ds` - direct seeding
     - `cs` - cover crop seeding
     - `xp` - transplanting
-    - `ha` - harvesting
+    - `ha` - harvest
     - `sd` - soil disturbance
     - `sa` - soil amendment
+  - `<description>` is typically one word that describes the operation. For example, for a tray seeding the `<description>` is the name of the crop that was seeded.
 
 ### Assets
 

--- a/library/farmosUtil/farmosUtil.plant.unit.cy.js
+++ b/library/farmosUtil/farmosUtil.plant.unit.cy.js
@@ -32,16 +32,6 @@ describe('Test the plant asset functions', () => {
       });
   });
 
-  it('Delete a plant asset', () => {
-    cy.wrap(
-      farmosUtil.createPlantAsset('testPlant', 'ARUGULA', 'testComment')
-    ).then((plantAsset) => {
-      cy.wrap(farmosUtil.deletePlantAsset(plantAsset.id)).then((result) => {
-        expect(result.status).to.equal(204);
-      });
-    });
-  });
-
   it('Error creating plant asset', { retries: 4 }, () => {
     cy.intercept('POST', '**/api/asset/plant', {
       statusCode: 401,
@@ -52,6 +42,33 @@ describe('Test the plant asset functions', () => {
         .createPlantAsset('testPlant', 'ARUGULA', 'testComment')
         .then(() => {
           throw new Error('Creating plant asset should have failed.');
+        })
+        .catch((error) => {
+          expect(error.message).to.equal('Request failed with status code 401');
+        })
+    );
+  });
+
+  it('Delete a plant asset', () => {
+    cy.wrap(
+      farmosUtil.createPlantAsset('testPlant', 'ARUGULA', 'testComment')
+    ).then((plantAsset) => {
+      cy.wrap(farmosUtil.deletePlantAsset(plantAsset.id)).then((result) => {
+        expect(result.status).to.equal(204);
+      });
+    });
+  });
+
+  it('Error deleting plant asset', { retries: 4 }, () => {
+    cy.intercept('DELETE', '**/api/asset/plant/*', {
+      statusCode: 401,
+    });
+
+    cy.wrap(
+      farmosUtil
+        .deletePlantAsset('1234')
+        .then(() => {
+          throw new Error('Deleting plant asset should have failed.');
         })
         .catch((error) => {
           expect(error.message).to.equal('Request failed with status code 401');

--- a/library/farmosUtil/farmosUtil.plant.unit.cy.js
+++ b/library/farmosUtil/farmosUtil.plant.unit.cy.js
@@ -1,0 +1,61 @@
+import * as farmosUtil from './farmosUtil';
+
+describe('Test the plant asset functions', () => {
+  let cropMap = null;
+
+  beforeEach(() => {
+    cy.restoreLocalStorage();
+    cy.restoreSessionStorage();
+
+    cy.wrap(farmosUtil.getCropNameToTermMap()).then((map) => {
+      cropMap = map;
+    });
+  });
+
+  afterEach(() => {
+    cy.saveLocalStorage();
+    cy.saveSessionStorage();
+  });
+
+  it('Create a plant asset', () => {
+    cy.wrap(farmosUtil.createPlantAsset('testPlant', 'ARUGULA', 'testComment'))
+      .then((plantAsset) => {
+        cy.wrap(farmosUtil.getPlantAsset(plantAsset.id));
+      })
+      .then((result) => {
+        expect(result.attributes.name).to.equal('testPlant');
+        expect(result.attributes.status).to.equal('active');
+        expect(result.attributes.notes.value).to.equal('testComment');
+        expect(result.relationships.plant_type[0].id).to.equal(
+          cropMap.get('ARUGULA').id
+        );
+      });
+  });
+
+  it('Delete a plant asset', () => {
+    cy.wrap(
+      farmosUtil.createPlantAsset('testPlant', 'ARUGULA', 'testComment')
+    ).then((plantAsset) => {
+      cy.wrap(farmosUtil.deletePlantAsset(plantAsset.id)).then((result) => {
+        expect(result.status).to.equal(204);
+      });
+    });
+  });
+
+  it('Error creating plant asset', { retries: 4 }, () => {
+    cy.intercept('POST', '**/api/asset/plant', {
+      statusCode: 401,
+    });
+
+    cy.wrap(
+      farmosUtil
+        .createPlantAsset('testPlant', 'ARUGULA', 'testComment')
+        .then(() => {
+          throw new Error('Creating plant asset should have failed.');
+        })
+        .catch((error) => {
+          expect(error.message).to.equal('Request failed with status code 401');
+        })
+    );
+  });
+});

--- a/library/farmosUtil/farmosUtil.quantity.unit.cy.js
+++ b/library/farmosUtil/farmosUtil.quantity.unit.cy.js
@@ -1,0 +1,142 @@
+import * as farmosUtil from './farmosUtil';
+
+describe('Test the quantity functions', () => {
+  let unitMap = null;
+
+  beforeEach(() => {
+    cy.restoreLocalStorage();
+    cy.restoreSessionStorage();
+
+    cy.wrap(farmosUtil.getUnitToTermMap()).then((map) => {
+      unitMap = map;
+    });
+  });
+
+  afterEach(() => {
+    cy.saveLocalStorage();
+    cy.saveSessionStorage();
+  });
+
+  it('Create a quantity without an inventory adjustment', () => {
+    cy.wrap(farmosUtil.createStandardQuantity('count', 7, 'testLabel', 'TRAYS'))
+      .then((quantity) => {
+        cy.wrap(farmosUtil.getStandardQuantity(quantity.id));
+      })
+      .then((result) => {
+        expect(result.attributes.measure).to.equal('count');
+        expect(result.attributes.label).to.equal('testLabel');
+        expect(result.attributes.value.decimal).to.equal('7');
+        expect(result.relationships.units.id).to.equal(unitMap.get('TRAYS').id);
+        expect(result.attributes.inventory_adjustment).to.equal(null);
+        expect(result.relationships.inventory_asset).to.equal(null);
+      });
+  });
+
+  it('Error creating quantity', { retries: 4 }, () => {
+    cy.intercept('POST', '**/api/quantity/standard', {
+      statusCode: 401,
+    });
+
+    cy.wrap(
+      farmosUtil
+        .createStandardQuantity('count', 7, 'testLabel', 'TRAYS')
+        .then(() => {
+          throw new Error('Creating quantity should have failed.');
+        })
+        .catch((error) => {
+          expect(error.message).to.equal('Request failed with status code 401');
+        })
+    );
+  });
+
+  it('Delete a quantity', () => {
+    cy.wrap(
+      farmosUtil.createStandardQuantity('count', 7, 'testLabel', 'TRAYS')
+    ).then((quantity) => {
+      cy.wrap(farmosUtil.deleteStandardQuantity(quantity.id)).then((result) => {
+        expect(result.status).to.equal(204);
+      });
+    });
+  });
+
+  it('Error deleting quantity', { retries: 4 }, () => {
+    cy.intercept('DELETE', '**/api/quantity/standard/*', {
+      statusCode: 401,
+    });
+
+    cy.wrap(
+      farmosUtil
+        .deleteStandardQuantity('1234')
+        .then(() => {
+          throw new Error('Deleting standard quantity should have failed.');
+        })
+        .catch((error) => {
+          expect(error.message).to.equal('Request failed with status code 401');
+        })
+    );
+  });
+
+  // THIS FAILS
+  // THE QUANTITY NEEDS TO BE ATTACHED TO A LOG TO MAKE THE INVENTORY REGISTER.
+  it('Create a quantity with an inventory adjustment', () => {
+    cy.wrap(
+      farmosUtil.createPlantAsset('testPlant', 'ARUGULA', 'testComment')
+    ).as('plantAsset');
+
+    cy.get('@plantAsset').then((plantAsset) => {
+      cy.wrap(
+        farmosUtil.createStandardQuantity(
+          'count',
+          7,
+          'testLabel',
+          'TRAYS',
+          plantAsset,
+          'increment'
+        )
+      ).as('quantity');
+    });
+
+    cy.getAll(['@plantAsset', '@quantity']).then(([plantAsset, quantity]) => {
+      cy.wrap(
+        farmosUtil.createSeedingLog(
+          '01/02/1999',
+          'CHUAU',
+          'seeding_tray',
+          plantAsset,
+          [quantity]
+        )
+      ).as('seedingLog');
+    });
+
+    cy.getAll(['@plantAsset', '@quantity', '@seedingLog']).then(
+      ([plantAsset, quantity]) => {
+        cy.wrap(farmosUtil.getStandardQuantity(quantity.id)).then((result) => {
+          expect(result.attributes.measure).to.equal('count');
+          expect(result.attributes.label).to.equal('testLabel');
+          expect(result.attributes.value.decimal).to.equal('7');
+          expect(result.relationships.units.id).to.equal(
+            unitMap.get('TRAYS').id
+          );
+          expect(result.attributes.inventory_adjustment).to.equal('increment');
+          expect(result.relationships.inventory_asset.id).to.equal(
+            plantAsset.id
+          );
+        });
+
+        cy.wrap(farmosUtil.getPlantAsset(plantAsset.id)).then(
+          (plantWithInventory) => {
+            expect(plantWithInventory.attributes.inventory[0].measure).to.equal(
+              'count'
+            );
+            expect(plantWithInventory.attributes.inventory[0].value).to.equal(
+              '7'
+            );
+            expect(plantWithInventory.attributes.inventory[0].units).to.equal(
+              'TRAYS'
+            );
+          }
+        );
+      }
+    );
+  });
+});

--- a/library/farmosUtil/farmosUtil.seeding.unit.cy.js
+++ b/library/farmosUtil/farmosUtil.seeding.unit.cy.js
@@ -1,0 +1,200 @@
+import * as farmosUtil from './farmosUtil';
+
+describe('Test the seeding log functions', () => {
+  let greenhouseMap = null;
+  let categoryMap = null;
+  let fieldMap = null;
+
+  beforeEach(() => {
+    cy.restoreLocalStorage();
+    cy.restoreSessionStorage();
+
+    cy.wrap(farmosUtil.getLogCategoryToTermMap()).then((map) => {
+      categoryMap = map;
+    });
+
+    cy.wrap(farmosUtil.getGreenhouseNameToAssetMap()).then((map) => {
+      greenhouseMap = map;
+    });
+
+    cy.wrap(farmosUtil.getFieldOrBedNameToAssetMap()).then((map) => {
+      fieldMap = map;
+    });
+  });
+
+  afterEach(() => {
+    cy.saveLocalStorage();
+    cy.saveSessionStorage();
+  });
+
+  it('Create a tray seeding log', () => {
+    cy.wrap(
+      farmosUtil.createPlantAsset('testPlant', 'ARUGULA', 'testComment')
+    ).as('plantAsset');
+
+    cy.wrap(
+      farmosUtil.createStandardQuantity('count', 7, 'testLabel', 'TRAYS')
+    ).as('quantity');
+
+    cy.getAll(['@plantAsset', '@quantity']).then(([plantAsset, quantity]) => {
+      cy.wrap(
+        farmosUtil.createSeedingLog(
+          '01/02/1999',
+          'CHUAU',
+          'seeding_tray',
+          plantAsset,
+          [quantity]
+        )
+      ).as('seedingLog');
+    });
+
+    cy.getAll(['@plantAsset', '@quantity', '@seedingLog']).then(
+      ([plantAsset, quantity, seedingLog]) => {
+        console.log(seedingLog);
+
+        cy.wrap(farmosUtil.getSeedingLog(seedingLog.id)).then((result) => {
+          expect(result.attributes.timestamp).to.contain('1999-01-02');
+          expect(result.attributes.purchase_date).to.contain('1999-01-02');
+
+          expect(result.attributes.name).to.equal(plantAsset.attributes.name);
+
+          expect(result.attributes.status).to.equal('done');
+          expect(result.attributes.is_movement).to.equal(true);
+          expect(result.relationships.category[0].id).to.equal(
+            categoryMap.get('seeding_tray').id
+          );
+          expect(result.relationships.location[0].id).to.equal(
+            greenhouseMap.get('CHUAU').id
+          );
+          expect(result.relationships.asset[0].id).to.equal(plantAsset.id);
+
+          expect(result.relationships.quantity.length).to.equal(1);
+          expect(result.relationships.quantity[0].id).to.equal(quantity.id);
+        });
+      }
+    );
+  });
+
+  it('Create a direct seeding log', () => {
+    /*
+     * Test this also because it fetches location id from the
+     * fields and beds map instead of the greenhouses map.
+     */
+
+    cy.wrap(
+      farmosUtil.createPlantAsset('testPlant', 'ARUGULA', 'testComment')
+    ).as('plantAsset');
+
+    cy.wrap(
+      farmosUtil.createStandardQuantity('count', 7, 'testLabel', 'TRAYS')
+    ).as('quantity');
+
+    cy.getAll(['@plantAsset', '@quantity']).then(([plantAsset, quantity]) => {
+      cy.wrap(
+        farmosUtil.createSeedingLog(
+          '01/02/1999',
+          'A',
+          'seeding_direct',
+          plantAsset,
+          [quantity]
+        )
+      ).as('seedingLog');
+    });
+
+    cy.getAll(['@plantAsset', '@quantity', '@seedingLog']).then(
+      ([plantAsset, quantity, seedingLog]) => {
+        console.log(seedingLog);
+
+        cy.wrap(farmosUtil.getSeedingLog(seedingLog.id)).then((result) => {
+          expect(result.attributes.timestamp).to.contain('1999-01-02');
+          expect(result.attributes.purchase_date).to.contain('1999-01-02');
+
+          expect(result.attributes.name).to.equal(plantAsset.attributes.name);
+
+          expect(result.attributes.status).to.equal('done');
+          expect(result.attributes.is_movement).to.equal(true);
+          expect(result.relationships.category[0].id).to.equal(
+            categoryMap.get('seeding_direct').id
+          );
+          expect(result.relationships.location[0].id).to.equal(
+            fieldMap.get('A').id
+          );
+          expect(result.relationships.asset[0].id).to.equal(plantAsset.id);
+
+          expect(result.relationships.quantity.length).to.equal(1);
+          expect(result.relationships.quantity[0].id).to.equal(quantity.id);
+        });
+      }
+    );
+  });
+
+  it('Error creating seeding log', { retries: 4 }, () => {
+    cy.intercept('POST', '**/api/log/seeding', {
+      statusCode: 401,
+    });
+
+    cy.wrap(
+      farmosUtil.createPlantAsset('testPlant', 'ARUGULA', 'testComment')
+    ).as('plantAsset');
+
+    cy.get('@plantAsset').then((plantAsset) => {
+      cy.wrap(
+        farmosUtil
+          .createSeedingLog('01/02/1999', 'CHUAU', 'seeding_tray', plantAsset)
+          .then(() => {
+            throw new Error('Creating seeding log should have failed.');
+          })
+          .catch((error) => {
+            expect(error.message).to.equal(
+              'Request failed with status code 401'
+            );
+          })
+      );
+    });
+  });
+
+  it('Delete a seeding log', () => {
+    cy.wrap(
+      farmosUtil.createPlantAsset('testPlant', 'ARUGULA', 'testComment')
+    ).as('plantAsset');
+
+    cy.wrap(
+      farmosUtil.createStandardQuantity('count', 7, 'testLabel', 'TRAYS')
+    ).as('quantity');
+
+    cy.getAll(['@plantAsset', '@quantity']).then(([plantAsset, quantity]) => {
+      cy.wrap(
+        farmosUtil.createSeedingLog(
+          '01/02/1999',
+          'CHUAU',
+          'seeding_tray',
+          plantAsset,
+          [quantity]
+        )
+      ).as('seedingLog');
+    });
+
+    cy.get('@seedingLog').then((seedingLog) => {
+      cy.wrap(farmosUtil.deleteSeedingLog(seedingLog.id)).then((result) => {
+        expect(result.status).to.equal(204);
+      });
+    });
+  });
+
+  it('Error deleting seeding log', { retries: 4 }, () => {
+    cy.intercept('DELETE', '**/api/log/seeding/*', {
+      statusCode: 401,
+    });
+
+    cy.wrap(
+      farmosUtil
+        .deleteSeedingLog('1234')
+        .then(() => {
+          throw new Error('Deleting seeding log should have failed.');
+        })
+        .catch((error) => {
+          expect(error.message).to.equal('Request failed with status code 401');
+        })
+    );
+  });
+});

--- a/modules/farm_fd2/src/entrypoints/tray_seeding/lib.js
+++ b/modules/farm_fd2/src/entrypoints/tray_seeding/lib.js
@@ -26,7 +26,13 @@ export async function submitForm(formData) {
   let seedingLog = null;
 
   try {
-    plantAsset = await createPlantAsset(formData);
+    const assetName = formData.seedingDate + '_ts_' + formData.cropName;
+    plantAsset = await farmosUtil.createPlantAsset(
+      assetName,
+      formData.cropName,
+      formData.comment
+    );
+
     traysQuantity = await createTraysQuantity(formData, plantAsset);
     traySizeQuantity = await createTraySizeQuantity(formData);
     seedsQuantity = await createSeedsQuantity(formData);
@@ -108,18 +114,7 @@ export async function submitForm(formData) {
     }
 
     if (plantAsset) {
-      try {
-        await farmosUtil
-          .getFarmOSInstance()
-          .asset.delete('plant', plantAsset.id);
-      } catch (error) {
-        console.log('TraySeeding: \n');
-        console.log('  Unable to delete plant asset with:');
-        console.log('    name: ' + plantAsset.name);
-        console.log('      id: ' + plantAsset.id);
-        console.log(error.message);
-        console.dir(error);
-      }
+      await farmosUtil.deletePlantAsset(plantAsset.id);
     }
 
     throw Error('Error creating tray seeding.', error);

--- a/modules/farm_fd2/src/entrypoints/tray_seeding/lib.js
+++ b/modules/farm_fd2/src/entrypoints/tray_seeding/lib.js
@@ -1,5 +1,4 @@
 import * as farmosUtil from '@libs/farmosUtil/farmosUtil';
-import dayjs from 'dayjs';
 
 /**
  * Create the farmOS records (asset, quantities and log) to represent
@@ -33,15 +32,35 @@ export async function submitForm(formData) {
       formData.comment
     );
 
-    traysQuantity = await createTraysQuantity(formData, plantAsset);
-    traySizeQuantity = await createTraySizeQuantity(formData);
-    seedsQuantity = await createSeedsQuantity(formData);
-    seedingLog = await createSeedingLog(
-      formData,
+    traysQuantity = await farmosUtil.createStandardQuantity(
+      'count',
+      formData.trays,
+      'Trays',
+      'TRAYS',
       plantAsset,
-      traysQuantity,
-      traySizeQuantity,
-      seedsQuantity
+      'increment'
+    );
+
+    traySizeQuantity = await farmosUtil.createStandardQuantity(
+      'ratio',
+      formData.traySize,
+      'Tray Size',
+      'CELLS/TRAY'
+    );
+
+    seedsQuantity = await farmosUtil.createStandardQuantity(
+      'count',
+      formData.seedsPerCell * formData.trays * formData.traySize,
+      'Seeds',
+      'SEEDS'
+    );
+
+    seedingLog = await farmosUtil.createSeedingLog(
+      formData.seedingDate,
+      formData.locationName,
+      'seeding_tray',
+      plantAsset,
+      [traysQuantity, traySizeQuantity, seedsQuantity]
     );
 
     return {
@@ -57,60 +76,19 @@ export async function submitForm(formData) {
 
     // Handle errors here by deleting any records that were created.
     if (seedingLog) {
-      try {
-        await farmosUtil
-          .getFarmOSInstance()
-          .log.delete('seeding', seedingLog.id);
-      } catch (error) {
-        console.log('TraySeeding: \n');
-        console.log('  Unable to delete seeding log with:');
-        console.log('    name: ' + seedingLog.name);
-        console.log('      id: ' + seedingLog.id);
-        console.log(error.message);
-        console.dir(error);
-      }
+      await farmosUtil.deleteSeedingLog(seedingLog.id);
     }
 
     if (seedsQuantity) {
-      try {
-        await farmosUtil
-          .getFarmOSInstance()
-          .quantity.delete('standard', seedsQuantity.id);
-      } catch (error) {
-        console.log('TraySeeding: \n');
-        console.log('  Unable to delete Seeds quantity with:');
-        console.log('    id: ' + traysQuantity.id);
-        console.log(error.message);
-        console.dir(error);
-      }
+      await farmosUtil.deleteStandardQuantity(seedsQuantity.id);
     }
 
     if (traySizeQuantity) {
-      try {
-        await farmosUtil
-          .getFarmOSInstance()
-          .quantity.delete('standard', traySizeQuantity.id);
-      } catch (error) {
-        console.log('TraySeeding: \n');
-        console.log('  Unable to delete Tray Size quantity with:');
-        console.log('    id: ' + traysQuantity.id);
-        console.log(error.message);
-        console.dir(error);
-      }
+      await farmosUtil.deleteStandardQuantity(traySizeQuantity.id);
     }
 
     if (traysQuantity) {
-      try {
-        await farmosUtil
-          .getFarmOSInstance()
-          .quantity.delete('standard', traysQuantity.id);
-      } catch (error) {
-        console.log('TraySeeding: \n');
-        console.log('  Unable to delete Trays quantity with:');
-        console.log('    id: ' + traysQuantity.id);
-        console.log(error.message);
-        console.dir(error);
-      }
+      await farmosUtil.deleteStandardQuantity(traysQuantity.id);
     }
 
     if (plantAsset) {
@@ -119,180 +97,4 @@ export async function submitForm(formData) {
 
     throw Error('Error creating tray seeding.', error);
   }
-}
-
-/*
- * The functions below are not expected to be called directly from the
- * entry point. They are exported so that they can be unit tested.
- */
-
-export async function createPlantAsset(formData) {
-  const farm = await farmosUtil.getFarmOSInstance();
-  const cropMap = await farmosUtil.getCropNameToTermMap();
-
-  const assetName = formData.seedingDate + '_ts_' + formData.cropName;
-
-  // create an asset--plant
-  const plantAsset = farm.asset.create({
-    type: 'asset--plant',
-    attributes: {
-      name: assetName,
-      status: 'active',
-      notes: { value: formData.comment },
-    },
-    relationships: {
-      plant_type: [
-        {
-          type: 'taxonomy_term--plant_type',
-          id: cropMap.get(formData.cropName).id,
-        },
-      ],
-    },
-  });
-
-  await farm.asset.send(plantAsset);
-
-  return plantAsset;
-}
-
-export async function createTraysQuantity(formData, plantAsset) {
-  const farm = await farmosUtil.getFarmOSInstance();
-  const unitMap = await farmosUtil.getUnitToTermMap();
-
-  // create the necessary quantities
-  const traysQuantity = farm.quantity.create({
-    type: 'quantity--standard',
-    attributes: {
-      measure: 'count',
-      value: {
-        decimal: formData.trays,
-      },
-      label: 'Trays',
-      inventory_adjustment: 'increment',
-    },
-    relationships: {
-      units: {
-        type: 'taxonomy_term--unit',
-        id: unitMap.get('TRAYS').id,
-      },
-      inventory_asset: {
-        type: 'asset--plant',
-        id: plantAsset.id,
-      },
-    },
-  });
-
-  await farm.quantity.send(traysQuantity);
-
-  return traysQuantity;
-}
-
-export async function createTraySizeQuantity(formData) {
-  const farm = await farmosUtil.getFarmOSInstance();
-  const unitMap = await farmosUtil.getUnitToTermMap();
-
-  const traySizeQuantity = farm.quantity.create({
-    type: 'quantity--standard',
-    attributes: {
-      measure: 'ratio',
-      value: {
-        decimal: parseInt(formData.traySize),
-      },
-      label: 'Tray Size',
-    },
-    relationships: {
-      units: {
-        type: 'taxonomy_term--unit',
-        id: unitMap.get('CELLS/TRAY').id,
-      },
-    },
-  });
-
-  await farm.quantity.send(traySizeQuantity);
-
-  return traySizeQuantity;
-}
-
-export async function createSeedsQuantity(formData) {
-  const farm = await farmosUtil.getFarmOSInstance();
-  const unitMap = await farmosUtil.getUnitToTermMap();
-
-  const seedsQuantity = farm.quantity.create({
-    type: 'quantity--standard',
-    attributes: {
-      measure: 'count',
-      value: {
-        decimal:
-          formData.trays * parseInt(formData.traySize) * formData.seedsPerCell,
-      },
-      label: 'Seeds',
-    },
-    relationships: {
-      units: {
-        type: 'taxonomy_term--unit',
-        id: unitMap.get('SEEDS').id,
-      },
-    },
-  });
-
-  await farm.quantity.send(seedsQuantity);
-
-  return seedsQuantity;
-}
-
-export async function createSeedingLog(
-  formData,
-  plantAsset,
-  traysQuantity,
-  traySizeQuantity,
-  seedsQuantity
-) {
-  const farm = await farmosUtil.getFarmOSInstance();
-  const categoryMap = await farmosUtil.getLogCategoryToTermMap();
-  const greenhouseMap = await farmosUtil.getGreenhouseNameToAssetMap();
-
-  // create the seeding log
-  const seedingLog = farm.log.create({
-    type: 'log--seeding',
-    attributes: {
-      name: plantAsset.attributes.name,
-      timestamp: dayjs(formData.seedingDate).format(),
-      status: 'done',
-      is_movement: true,
-      purchase_date: dayjs(formData.seedingDate).format(),
-    },
-    relationships: {
-      location: [
-        {
-          type: 'asset--structure',
-          id: greenhouseMap.get(formData.locationName).id,
-        },
-      ],
-      asset: [{ type: 'asset--plant', id: plantAsset.id }],
-      category: [
-        {
-          type: 'taxonomy_term--log_category',
-          id: categoryMap.get('seeding_tray').id,
-        },
-      ],
-      quantity: [
-        {
-          type: 'quantity--standard',
-          id: traysQuantity.id,
-        },
-        {
-          type: 'quantity--standard',
-          id: traySizeQuantity.id,
-        },
-        {
-          type: 'quantity--standard',
-          id: seedsQuantity.id,
-        },
-      ],
-    },
-  });
-
-  await farm.log.send(seedingLog);
-
-  return seedingLog;
 }

--- a/modules/farm_fd2/src/entrypoints/tray_seeding/lib.submit.unit.cy.js
+++ b/modules/farm_fd2/src/entrypoints/tray_seeding/lib.submit.unit.cy.js
@@ -9,7 +9,7 @@ describe('Test the tray seeding submission', () => {
    * entry point as a submission.
    */
   let form = {
-    seedingDate: '1950-01-01',
+    seedingDate: '1950-01-02',
     cropName: 'BROCCOLI',
     locationName: 'CHUAU',
     trays: 25,
@@ -18,140 +18,15 @@ describe('Test the tray seeding submission', () => {
     comment: 'A comment',
   };
 
-  /*
-   * Variables to hold the map objects that used in the tests. The
-   * maps are actually created in the before() function.
-   */
-  let farm = null;
-  let cropMap = null;
-  let termMap = null;
   let greenhouseMap = null;
-  let categoryMap = null;
 
-  /*
-   * Variables to hold the records that are used in the tests.  It is only
-   * necessary to have one of each of these types of records, so they are
-   * created in the before() function and then used in multiple tests.
-   */
-  let plantAsset = null;
-  let traysQuant = null;
-  let traySizeQuant = null;
-  let seedsQuant = null;
-  let seedingLog = null;
+  beforeEach(() => {
+    cy.restoreLocalStorage();
+    cy.restoreSessionStorage();
 
-  before(() => {
-    /*
-     * Create all of the maps that are needed here.
-     * Not all of these are used in every test, but collecting them
-     * here simplifies the test structure.
-     */
-    cy.wrap(farmosUtil.getFarmOSInstance()).then((newFarm) => {
-      farm = newFarm;
-    });
-
-    cy.wrap(farmosUtil.getCropNameToTermMap()).then((map) => {
-      cropMap = map;
-    });
-    cy.wrap(farmosUtil.getUnitToTermMap()).then((map) => {
-      termMap = map;
-    });
     cy.wrap(farmosUtil.getGreenhouseNameToAssetMap()).then((map) => {
       greenhouseMap = map;
     });
-    cy.wrap(farmosUtil.getLogCategoryToTermMap()).then((map) => {
-      categoryMap = map;
-    });
-
-    /*
-     * Create the asset, quantities and log that are needed here.
-     * Not all of these are used in every test, but collecting them
-     * here simplifies the test structure.
-     */
-    cy.wrap(lib.createPlantAsset(form))
-      .as('plantAsset')
-      .then((asset) => {
-        plantAsset = asset;
-      });
-
-    /*
-     * Here we need to ensure that the plantAsset has been created
-     * before we try to create the tray quantities.
-     */
-    cy.get('@plantAsset').then((plantAsset) => {
-      cy.wrap(lib.createTraysQuantity(form, plantAsset))
-        .as('traysQuant')
-        .then((quant) => {
-          traysQuant = quant;
-        });
-    });
-
-    cy.wrap(lib.createTraySizeQuantity(form))
-      .as('traySizeQuant')
-      .then((quant) => {
-        traySizeQuant = quant;
-      });
-
-    cy.wrap(lib.createSeedsQuantity(form))
-      .as('seedsQuant')
-      .then((quant) => {
-        seedsQuant = quant;
-      });
-
-    /*
-     * Use a custom Cypress command to get all of the aliases that
-     * are needed using a a single command.
-     */
-    cy.getAll([
-      '@plantAsset',
-      '@traysQuant',
-      '@traySizeQuant',
-      '@seedsQuant',
-    ]).then(([plantAsset, traysQuant, traySizeQuant, seedsQuant]) => {
-      /*
-       * It is not entirely clear why it is necessary to clear the farmGlobal.
-       * However, without it there is a 422 (Unprocessable Contents) error when
-       * submitting the log to farmOS via farmOS.js. To see the error, comment
-       * out the `farmosUtil.clearFarmGlobal();` line and run the test.
-       *
-       * Note that this does not cause a re-authentication, but it does cause
-       * the creation of a new farmOS object, and a refetching of the schema.
-       * However, there appears to be no difference between the two farmOS
-       * objects as evidenced by the commented out lines below.
-       *
-       * There is a chance that something buried in here or in farmOS.js
-       * is mangling the farmOS object in some way.  But it is not clear what
-       * it is.
-       */
-      farmosUtil.clearFarmGlobal();
-
-      cy.wrap(
-        lib.createSeedingLog(
-          form,
-          plantAsset,
-          traysQuant,
-          traySizeQuant,
-          seedsQuant
-        )
-      )
-        .as(`seedingLog`)
-        .then((log) => {
-          seedingLog = log;
-        });
-    });
-
-    cy.saveLocalStorage();
-    cy.saveSessionStorage();
-  });
-
-  beforeEach(() => {
-    /*
-     * Caching of the farmOS instance and the data for the maps relies
-     * on the session storage and local storage.  Cypress clears these
-     * between every test.  So we save them in the afterEach() hook,
-     * and then restore them in the beforeEach() hook.
-     */
-    cy.restoreLocalStorage();
-    cy.restoreSessionStorage();
   });
 
   afterEach(() => {
@@ -159,280 +34,176 @@ describe('Test the tray seeding submission', () => {
     cy.saveSessionStorage();
   });
 
-  it('Create plant asset', () => {
-    // Fetch the plant asset from farmOS and check it.
-    cy.wrap(
-      farm.asset
-        .fetch({
-          filter: { type: 'asset--plant', id: plantAsset.id },
-        })
-        .then((results) => {
-          return results.data[0]; // only one asset with the plantAsset.id.
-        })
-    ).then((result) => {
-      expect(result.attributes.name).to.equal(
-        form.seedingDate + '_ts_' + form.cropName
-      );
-      expect(result.attributes.status).to.equal('active');
-      expect(result.attributes.notes.value).to.equal(form.comment);
-      expect(result.relationships.plant_type[0].id).to.equal(
-        cropMap.get(form.cropName).id
-      );
-    });
-  });
-
-  it('Error creating plant asset', { retries: 4 }, () => {
-    cy.intercept('POST', '**/api/asset/plant', {
-      statusCode: 401,
-    });
-
-    /*
-     * Here the then/catch must be inside the wrap because wrap
-     * does not have a catch.
-     */
-    cy.wrap(
-      lib
-        .createPlantAsset(form)
-        .then(() => {
-          throw new Error('Creating plant asset should have failed.');
-        })
-        .catch((error) => {
-          expect(error.message).to.equal('Request failed with status code 401');
-        })
-    );
-  });
-
-  it('Create trays quantity', () => {
-    cy.wrap(
-      farm.quantity
-        .fetch({
-          filter: {
-            type: 'quantity--standard',
-            id: traysQuant.id,
-          },
-        })
-        .then((results) => {
-          return results.data[0];
-        })
-    ).then((result) => {
-      expect(result.attributes.label).to.equal('Trays');
-      expect(result.attributes.measure).to.equal('count');
-      expect(result.attributes.value.decimal).to.equal(form.trays.toString());
-      expect(result.attributes.inventory_adjustment).to.equal('increment');
-      expect(result.relationships.units.id).to.equal(termMap.get('TRAYS').id);
-      expect(result.relationships.inventory_asset.id).to.equal(plantAsset.id);
-    });
-  });
-
-  it('Error creating trays quantity', { retries: 4 }, () => {
-    cy.intercept('POST', '**/api/quantity/standard', {
-      statusCode: 401,
-    });
-
-    cy.wrap(
-      lib
-        .createTraysQuantity(form, { id: 999 }) // fake id b.c. quantity is not created.
-        .then(() => {
-          throw new Error('Creating trays quantity should have failed.');
-        })
-        .catch((error) => {
-          expect(error.message).to.equal('Request failed with status code 401');
-        })
-    );
-  });
-
-  it('Create tray size quantity', () => {
-    cy.wrap(
-      farm.quantity
-        .fetch({
-          filter: {
-            type: 'quantity--standard',
-            id: traySizeQuant.id,
-          },
-        })
-        .then((results) => {
-          return results.data[0];
-        })
-    ).then((result) => {
-      expect(result.attributes.label).to.equal('Tray Size');
-      expect(result.attributes.measure).to.equal('ratio');
-      expect(result.attributes.value.decimal).to.equal(form.traySize);
-      expect(result.relationships.units.id).to.equal(
-        termMap.get('CELLS/TRAY').id
-      );
-    });
-  });
-
-  it('Error creating tray size quantity', { retries: 4 }, () => {
-    cy.intercept('POST', '**/api/quantity/standard', {
-      statusCode: 401,
-    });
-
-    cy.wrap(
-      lib
-        .createTraySizeQuantity(form)
-        .then(() => {
-          throw new Error('Creating tray size quantity should have failed.');
-        })
-        .catch((error) => {
-          expect(error.message).to.equal('Request failed with status code 401');
-        })
-    );
-  });
-
-  it('Create seeds quantity', () => {
-    cy.wrap(
-      farm.quantity
-        .fetch({
-          filter: {
-            type: 'quantity--standard',
-            id: seedsQuant.id,
-          },
-        })
-        .then((results) => {
-          return results.data[0];
-        })
-    ).then((result) => {
-      expect(result.attributes.label).to.equal('Seeds');
-      expect(result.attributes.measure).to.equal('count');
-      expect(result.attributes.value.decimal).to.equal(
-        (form.trays * parseInt(form.traySize) * form.seedsPerCell).toString()
-      );
-      expect(result.relationships.units.id).to.equal(termMap.get('SEEDS').id);
-    });
-  });
-
-  it('Error creating seeds quantity', { retries: 4 }, () => {
-    cy.intercept('POST', '**/api/quantity/standard', {
-      statusCode: 401,
-    });
-
-    cy.wrap(
-      lib
-        .createSeedsQuantity(form)
-        .then(() => {
-          throw new Error('Creating seeds quantity should have failed.');
-        })
-        .catch((error) => {
-          expect(error.message).to.equal('Request failed with status code 401');
-        })
-    );
-  });
-
-  it('Create seeding log', () => {
-    cy.wrap(
-      farm.log
-        .fetch({
-          filter: {
-            type: 'log--seeding',
-            id: seedingLog.id,
-          },
-        })
-        .then((results) => {
-          return results.data[0];
-        })
-    ).then((result) => {
-      expect(result.attributes.timestamp).to.contain(form.seedingDate);
-      expect(result.attributes.purchase_date).to.contain(form.seedingDate);
-      expect(result.attributes.name).to.equal(
-        form.seedingDate + '_ts_' + form.cropName
-      );
-      expect(result.attributes.status).to.equal('done');
-      expect(result.attributes.is_movement).to.equal(true);
-      expect(result.relationships.category[0].id).to.equal(
-        categoryMap.get('seeding_tray').id
-      );
-      expect(result.relationships.location[0].id).to.equal(
-        greenhouseMap.get(form.locationName).id
-      );
-      expect(result.relationships.asset[0].id).to.equal(plantAsset.id);
-
-      expect(result.relationships.quantity.length).to.equal(3);
-      expect(result.relationships.quantity[0].id).to.equal(traysQuant.id);
-      expect(result.relationships.quantity[1].id).to.equal(traySizeQuant.id);
-      expect(result.relationships.quantity[2].id).to.equal(seedsQuant.id);
-    });
-  });
-
-  it('Error creating seeding log', { retries: 4 }, () => {
-    cy.intercept('POST', '**/api/log/seeding', {
-      statusCode: 401,
-    });
-
-    cy.wrap(
-      lib
-        .createSeedingLog(
-          form,
-          { id: 123, attributes: { name: 'test' } }, // plant asset
-          { id: 123 }, // trays quantity
-          { id: 123 }, // tray size quantity
-          { id: 123 } // seeds quantity
-        )
-        .then(() => {
-          throw new Error('Creating seeding log should have failed.');
-        })
-        .catch((error) => {
-          expect(error.message).to.equal('Request failed with status code 401');
-        })
-    );
-  });
-
   it('submitForm creates everything', () => {
-    cy.wrap(lib.submitForm(form)).then((result) => {
-      /*
-       * Here we just need to fetch each of the pieces to ensure that
-       * they have been created. We do that just by checking the type.
-       * The earlier test checked that they were created correctly.
-       */
-      cy.wrap(
-        farm.asset.fetch({
-          filter: { type: 'asset--plant', id: result.plantAsset.id },
-        })
-      ).then((results) => {
-        // Just check the type here to be sure it exists.
-        expect(results.data[0].type).to.equal('asset--plant');
-      });
+    // Submitting the form creates the planting asset, quantities, and seeding log.
+    cy.wrap(lib.submitForm(form), { timeout: 10000 }).then((result) => {
+      // Get each of the farmOS records that were created and check them...
 
-      cy.wrap(
-        farm.quantity.fetch({
-          filter: { type: 'quantity--standard', id: result.traysQuantity.id },
-        })
-      ).then((results) => {
-        expect(results.data[0].type).to.equal('quantity--standard');
-      });
+      // Check the plant asset.
+      cy.wrap(farmosUtil.getPlantAsset(result.plantAsset.id)).then(
+        (plantAsset) => {
+          expect(plantAsset.type).to.equal('asset--plant');
+          expect(plantAsset.attributes.name).to.equal(
+            plantAsset.attributes.name
+          );
+          expect(plantAsset.attributes.status).to.equal('active');
+          expect(plantAsset.attributes.notes.value).to.equal(form.comment);
 
-      cy.wrap(
-        farm.quantity.fetch({
-          filter: {
-            type: 'quantity--standard',
-            id: result.traySizeQuantity.id,
-          },
-        })
-      ).then((results) => {
-        expect(results.data[0].type).to.equal('quantity--standard');
-      });
+          /*
+           * Note: result.plantAsset is the object that was sent to the server.
+           * plantAsset is the object that was retrieved from the server.
+           * So we can usually check them against each other and avoid the step of using
+           * maps to translate from name to id for things like locations and crops.
+           * The exception is when farmOS computes information that is added to the
+           * record.  For example, the location of the planting asset is set by farmOS
+           * based upon the location specified in the seeding log.
+           */
+          expect(plantAsset.relationships.plant_type[0].type).to.equal(
+            'taxonomy_term--plant_type'
+          );
+          expect(plantAsset.relationships.plant_type[0].id).to.equal(
+            result.plantAsset.relationships.plant_type[0].id
+          );
 
-      cy.wrap(
-        farm.quantity.fetch({
-          filter: {
-            type: 'quantity--standard',
-            id: result.seedsQuantity.id,
-          },
-        })
-      ).then((results) => {
-        expect(results.data[0].type).to.equal('quantity--standard');
-      });
+          expect(plantAsset.relationships.location[0].type).to.equal(
+            'asset--structure'
+          );
+          expect(plantAsset.relationships.location[0].id).to.equal(
+            greenhouseMap.get(form.locationName).id
+          );
+        }
+      );
 
-      cy.wrap(
-        farm.log.fetch({
-          filter: {
-            type: 'log--seeding',
-            id: result.seedingLog.id,
-          },
-        })
-      ).then((results) => {
-        expect(results.data[0].type).to.equal('log--seeding');
-      });
+      // Check the trays quantity.
+      cy.wrap(farmosUtil.getStandardQuantity(result.traysQuantity.id)).then(
+        (traysQuantity) => {
+          expect(traysQuantity.type).to.equal('quantity--standard');
+          expect(traysQuantity.attributes.measure).to.equal('count');
+          expect(traysQuantity.attributes.value.decimal).to.equal(
+            form.trays.toString()
+          );
+          expect(traysQuantity.attributes.label).to.equal('Trays');
+
+          expect(traysQuantity.attributes.inventory_adjustment).to.equal(
+            'increment'
+          );
+
+          expect(traysQuantity.relationships.units.type).to.equal(
+            'taxonomy_term--unit'
+          );
+          expect(traysQuantity.relationships.units.id).to.equal(
+            result.traysQuantity.relationships.units.id
+          );
+
+          expect(traysQuantity.relationships.inventory_asset.type).to.equal(
+            'asset--plant'
+          );
+          expect(traysQuantity.relationships.inventory_asset.id).to.equal(
+            result.traysQuantity.relationships.inventory_asset.id
+          );
+        }
+      );
+
+      // Check the tray size quantity.
+      cy.wrap(farmosUtil.getStandardQuantity(result.traySizeQuantity.id)).then(
+        (traySizeQuantity) => {
+          expect(traySizeQuantity.type).to.equal('quantity--standard');
+          expect(traySizeQuantity.attributes.measure).to.equal('ratio');
+          expect(traySizeQuantity.attributes.value.decimal).to.equal(
+            form.traySize.toString()
+          );
+          expect(traySizeQuantity.attributes.label).to.equal('Tray Size');
+
+          expect(traySizeQuantity.attributes.inventory_adjustment).to.be.null;
+
+          expect(traySizeQuantity.relationships.units.type).to.equal(
+            'taxonomy_term--unit'
+          );
+          expect(traySizeQuantity.relationships.units.id).to.equal(
+            result.traySizeQuantity.relationships.units.id
+          );
+
+          expect(traySizeQuantity.relationships.inventory_asset).to.be.null;
+        }
+      );
+
+      // Check the seeds quantity.
+      cy.wrap(farmosUtil.getStandardQuantity(result.seedsQuantity.id)).then(
+        (seedsQuantity) => {
+          expect(seedsQuantity.type).to.equal('quantity--standard');
+          expect(seedsQuantity.attributes.measure).to.equal('count');
+          expect(seedsQuantity.attributes.value.decimal).to.equal(
+            (form.seedsPerCell * form.trays * form.traySize).toString()
+          );
+          expect(seedsQuantity.attributes.label).to.equal('Seeds');
+
+          expect(seedsQuantity.attributes.inventory_adjustment).to.be.null;
+
+          expect(seedsQuantity.relationships.units.type).to.equal(
+            'taxonomy_term--unit'
+          );
+          expect(seedsQuantity.relationships.units.id).to.equal(
+            result.seedsQuantity.relationships.units.id
+          );
+
+          expect(seedsQuantity.relationships.inventory_asset).to.be.null;
+        }
+      );
+
+      // Check the seeding log.
+      cy.wrap(farmosUtil.getSeedingLog(result.seedingLog.id)).then(
+        (seedingLog) => {
+          expect(seedingLog.type).to.equal('log--seeding');
+          expect(seedingLog.attributes.name).to.equal(
+            seedingLog.attributes.name
+          );
+          expect(seedingLog.attributes.timestamp).to.contain('1950-01-02');
+          expect(seedingLog.attributes.status).to.equal('done');
+          expect(seedingLog.attributes.is_movement).to.be.true;
+          expect(seedingLog.attributes.purchase_date).to.contain('1950-01-02');
+
+          expect(seedingLog.relationships.location[0].type).to.equal(
+            'asset--structure'
+          );
+          expect(seedingLog.relationships.location[0].id).to.equal(
+            result.seedingLog.relationships.location[0].id
+          );
+
+          expect(seedingLog.relationships.asset[0].type).to.equal(
+            'asset--plant'
+          );
+          expect(seedingLog.relationships.asset[0].id).to.equal(
+            result.seedingLog.relationships.asset[0].id
+          );
+
+          expect(seedingLog.relationships.category[0].type).to.equal(
+            'taxonomy_term--log_category'
+          );
+          expect(seedingLog.relationships.category[0].id).to.equal(
+            result.seedingLog.relationships.category[0].id
+          );
+
+          expect(seedingLog.relationships.quantity.length).to.equal(3);
+          expect(seedingLog.relationships.quantity[0].type).to.equal(
+            'quantity--standard'
+          );
+          expect(seedingLog.relationships.quantity[0].id).to.equal(
+            result.seedingLog.relationships.quantity[0].id
+          );
+          expect(seedingLog.relationships.quantity[1].type).to.equal(
+            'quantity--standard'
+          );
+          expect(seedingLog.relationships.quantity[1].id).to.equal(
+            result.seedingLog.relationships.quantity[1].id
+          );
+          expect(seedingLog.relationships.quantity[2].type).to.equal(
+            'quantity--standard'
+          );
+          expect(seedingLog.relationships.quantity[2].id).to.equal(
+            result.seedingLog.relationships.quantity[2].id
+          );
+        }
+      );
     });
   });
 });

--- a/modules/farm_fd2/src/entrypoints/tray_seeding/tray_seeding.submit.e2e.cy.js
+++ b/modules/farm_fd2/src/entrypoints/tray_seeding/tray_seeding.submit.e2e.cy.js
@@ -90,16 +90,6 @@ describe('Check the submission of Tray Seedings.', () => {
           cy.get('.toast', { timeout: 7000 }).should('not.exist');
         });
 
-      /*
-       * Note: Deleting the asset must come after deleting the log,
-       * because the asset is referenced by the log. But Cypress does
-       * not guarantee that when two async functions are invoked with
-       * cy.wrap() calls will execute in the order they are written.
-       * So the cy.get() here ensures that the log is deleted before
-       * the asset is deleted.
-       *
-       * See: https://docs.cypress.io/api/commands/wrap#Promises
-       */
       let plantFilter = { type: 'asset--plant', name: name };
 
       cy.wrap(farm.asset.fetch({ filter: plantFilter }))


### PR DESCRIPTION
**Pull Request Description**

This PR:
- Adds functions to the `farmosUtil.js` library that are able to create, fetch and delete `asset--plant`, `quantity--standard` and `log--seeding`
- Adds tests for the functions added to `farmosUtil.js`
- Refactors `lib.js` in the Tray Seeding entry point to use these generic functions.
- Refactors the unit tests for the Tray Seeding `lib.js`

Overall this greatly simplifies the creation of new entry points as they will not have to repeat the code for creating these types of assets, quantities and logs.  As additional entry points are added the `farmosUtil.js` library will need to expand to include functions for any new types of assets, quantities, logs, etc. that are needed.

---

**Licensing Certification**

FarmData2 is a [Free Cultural Work](https://freedomdefined.org/Definition) and all accepted contributions are licensed as described in the LICENSE.md file. This requires that the contributor holds the rights to do so. By submitting this pull request **I certify that I satisfy the terms of the [Developer Certificate of Origin](https://developercertificate.org/)** for its contents.
