### PR TITLE
Added Bash Trap and Cleanup Function to test.bash

### DIFF
--- a/bin/test.bash
+++ b/bin/test.bash
@@ -73,7 +73,7 @@ cleanup() {
     echo "Builder terminated."
   fi
   # Exit the script
-  exit 130
+  exit $EXIT_CODE
 }
 # Trap SIGINT (Ctrl-C) and SIGTERM
 trap cleanup SIGINT SIGTERM
@@ -340,4 +340,4 @@ fi
 echo "Tests complete."
 
 # Runs normal cleanup
-cleanup
+cleanup "$EXIT_CODE"

--- a/bin/test.bash
+++ b/bin/test.bash
@@ -41,6 +41,43 @@ function usage {
   exit 255
 }
 
+# Define cleanup() function. This needs to be defined ASAP to catch SIGINT and SIGTERM at the earliest signs of trouble.
+cleanup() {
+  echo "Cleaning up..."
+
+  # Terminate the dev server if it's running
+  if [ -n "$DEV_GID" ]; then
+    echo "Terminating the dev server..."
+    kill -INT -- -"$DEV_GID"
+    echo "Dev server terminated."
+  fi
+
+  # Terminate the builder if it's running
+  if [ -n "$BUILDER_GID" ]; then
+    echo "Terminating the builder..."
+    kill -INT -- -"$BUILDER_GID"
+    echo "Builder terminated."
+  fi
+
+  # Terminate the preview server if it's running
+  if [ -n "$PREVIEW_GID" ]; then
+    echo "Terminating preview server..."
+    kill -INT -- -"$PREVIEW_GID"
+    echo "Preview server terminated."
+  fi
+
+  # Terminate the live builder if it's running
+  if [ -n "$LIVE_GID" ]; then
+    echo "Terminating the builder..."
+    kill -INT -- -"$LIVE_GID"
+    echo "Builder terminated."
+  fi
+  # Exit the script
+  exit "$EXIT_CODE"
+}
+# Trap SIGINT (Ctrl-C) and SIGTERM
+trap cleanup SIGINT SIGTERM
+
 # Change into the main repo directory.
 SCRIPT_PATH=$(readlink -f "$0")                     # Path to this script.
 SCRIPT_DIR=$(dirname "$SCRIPT_PATH")                # Path to directory containing this script.
@@ -302,29 +339,5 @@ fi
 
 echo "Tests complete."
 
-# If we brought up a server, then take it back down.
-if [ -n "$DEV_PID" ]; then
-  echo "Terminating the dev server..."
-  kill -INT -- -"$DEV_GID"
-  echo "Dev server terminated."
-fi
-
-if [ -n "$BUILDER_GID" ]; then
-  echo "Terminating the builder..."
-  kill -INT -- -"$BUILDER_GID"
-  echo "Builder terminated."
-fi
-
-if [ -n "$PREVIEW_GID" ]; then
-  echo "Terminating preview server..."
-  kill -INT -- -"$PREVIEW_GID"
-  echo "Preview server terminated."
-fi
-
-if [ -n "$LIVE_GID" ]; then
-  echo "Terminating the builder..."
-  kill -INT -- -"$LIVE_GID"
-  echo "Builder terminated."
-fi
-
-exit "$EXIT_CODE"
+# Runs normal cleanup
+cleanup

--- a/bin/test.bash
+++ b/bin/test.bash
@@ -45,6 +45,9 @@ function usage {
 cleanup() {
   echo "Cleaning up..."
 
+  # Set default EXIT_CODE to 130 if not provided
+  EXIT_CODE=${1:-130}
+  
   # Terminate the dev server if it's running
   if [ -n "$DEV_GID" ]; then
     echo "Terminating the dev server..."
@@ -340,4 +343,4 @@ fi
 echo "Tests complete."
 
 # Runs normal cleanup
-cleanup "$EXIT_CODE"
+cleanup $EXIT_CODE

--- a/bin/test.bash
+++ b/bin/test.bash
@@ -73,7 +73,7 @@ cleanup() {
     echo "Builder terminated."
   fi
   # Exit the script
-  exit "$EXIT_CODE"
+  exit 130
 }
 # Trap SIGINT (Ctrl-C) and SIGTERM
 trap cleanup SIGINT SIGTERM


### PR DESCRIPTION
**Pull Request Description**

Fixes `Ctrl+c` failures to close out "zombie" servers after failed tests. 

Closes #141 

**Licensing Certification**

FarmData2 is a [Free Cultural Work](https://freedomdefined.org/Definition) and all accepted contributions are licensed as described in the LICENSE.md file. This requires that the contributor holds the rights to do so. By submitting this pull request **I certify that I satisfy the terms of the [Developer Certificate of Origin](https://developercertificate.org/)** for its contents.
