### PR TITLE
fix(fd2): allows the use of multiple log categories

### DIFF
--- a/bin/runAllTests.bash
+++ b/bin/runAllTests.bash
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+test.bash --comp
+test.bash --unit --lib
+test.bash --unit --fd2
+test.bash --e2e --fd2 --live

--- a/docs/DataModel.md
+++ b/docs/DataModel.md
@@ -2,12 +2,27 @@
 
 ## Log Categories
 
-- Seeding Logs
-  - `seeding_tray`
-  - `seeding_direct`
-  - `seeding_cover_crop`
-- Activity Logs
-  - `activity_soil_disturbance_tillage`
+The following log categories are defined by the [conventions used for storing data related to the PASA Soil Health Benchmark Study](https://our-sci.gitlab.io/software/json_schema_distribution/staging_wiki/docs/Description%20and%20Specification) and one of them should be associated with every log that is created:
+
+```text
+amendment,For logs where soil amendments are made.
+grazing,For logs that record animal grazing events.
+irrigation,For logs associated with field irrigation.
+pest_disease_control,For logs related to pest or disease control.
+seeding,For logs associated with seedings.
+termination,For logs associated with termination of a planting.
+tillage,For logs representing soil disturbances.
+transplanting,For logs representing transplantation of a plant.
+weed_control,For logs related to weed control.
+```
+
+The following log categories are defined specifically by FarmData2 and should be applied to any log that is associated with the type of event described. For example, an activity log representing the `tillage` associated with a direct seeding should also have a `seeding_direct` log category.
+
+```text
+seeding_cover_crop,For logs associated with the seeding of a cover crop.
+seeding_direct,For logs associated with direct seedings.
+seeding_tray,For logs associated with seedings in trays.
+```
 
 ## Units
 

--- a/library/farmosUtil/farmosUtil.js
+++ b/library/farmosUtil/farmosUtil.js
@@ -1597,7 +1597,8 @@ export async function deleteStandardQuantity(quantityId) {
  * @param {string} seedingDate the date of the seeding
  * @param {string} locationName the name of the location where the seeding occurred.
  * This must be the name of a field, bed or greenhouse.
- * @param {string} logCategory the type of seeding log ('seeding_tray', 'seeding_direct' , 'seeding_cover').
+ * @param {Array<string>} logCategories the log categories associated with this log.
+ * Must include `seeding` and one of `seeding_tray` or `seeding_direct` or `seeding_cover_crop`.
  * @param {Object} plantAsset the plant asset created by the seeding.
  * @param {Array<Object>} [quantities=[]] an array of quantity objects
  * (e.g. `quantity--standard`) associated with the seeding.
@@ -1609,12 +1610,12 @@ export async function deleteStandardQuantity(quantityId) {
 export async function createSeedingLog(
   seedingDate,
   locationName,
-  logCategory,
+  logCategories,
   plantAsset,
   quantities = []
 ) {
   let locationID = null;
-  if (logCategory === 'seeding_tray') {
+  if (logCategories.includes('seeding_tray')) {
     const greenhouseMap = await getGreenhouseNameToAssetMap();
     locationID = greenhouseMap.get(locationName).id;
   } else {
@@ -1631,6 +1632,13 @@ export async function createSeedingLog(
   }
 
   const categoryMap = await getLogCategoryToTermMap();
+  let logCategoriesArray = [];
+  for (const cat of logCategories) {
+    logCategoriesArray.push({
+      type: 'taxonomy_term--log_category',
+      id: categoryMap.get(cat).id,
+    });
+  }
 
   const seedingLogData = {
     type: 'log--seeding',
@@ -1649,12 +1657,7 @@ export async function createSeedingLog(
         },
       ],
       asset: [{ type: 'asset--plant', id: plantAsset.id }],
-      category: [
-        {
-          type: 'taxonomy_term--log_category',
-          id: categoryMap.get(logCategory).id,
-        },
-      ],
+      category: logCategoriesArray,
       quantity: quantitiesArray,
     },
   };
@@ -1714,7 +1717,8 @@ export async function deleteSeedingLog(seedingLogId) {
  *
  * @param {string} disturbanceDate the date the disturbance took place.
  * @param {string} locationName the location where the disturbance took place.
- * @param {string} logCategory the log category indicating the type of disturbance (e.g. `disturbance_tillage`).
+ * @param {Array<string>} logCategories the log categories associated with this log.
+ * Must include `tillage`.
  * @param {Object} [plantAsset=null] the plant asset (i.e. `asset--plant`) affected by the disturbance.
  * @param {Array<Object>} [quantities=[]] an array of quantity (e.g. `quantity--standard`) objects associated with the disturbance.
  * @param {Array<Object>} [equipment=[]] an array of equipment asset objects (i.e. `asset--equipment`) that were used to disturb the soil.
@@ -1725,7 +1729,7 @@ export async function deleteSeedingLog(seedingLogId) {
 export async function createSoilDisturbanceActivityLog(
   distrubanceDate,
   locationName,
-  logCategory,
+  logCategories,
   plantAsset = null,
   quantities = [],
   equipment = []
@@ -1751,6 +1755,13 @@ export async function createSoilDisturbanceActivityLog(
   }
 
   const categoryMap = await getLogCategoryToTermMap();
+  let logCategoriesArray = [];
+  for (const cat of logCategories) {
+    logCategoriesArray.push({
+      type: 'taxonomy_term--log_category',
+      id: categoryMap.get(cat).id,
+    });
+  }
 
   const activityLogData = {
     type: 'log--activity',
@@ -1768,12 +1779,7 @@ export async function createSoilDisturbanceActivityLog(
         },
       ],
       asset: [{ type: 'asset--plant', id: plantAsset.id }],
-      category: [
-        {
-          type: 'taxonomy_term--log_category',
-          id: categoryMap.get(logCategory).id,
-        },
-      ],
+      category: logCategoriesArray,
       quantity: quantitiesArray,
       equipment: equipmentArray,
     },

--- a/library/farmosUtil/farmosUtil.logCategories.unit.cy.js
+++ b/library/farmosUtil/farmosUtil.logCategories.unit.cy.js
@@ -14,17 +14,17 @@ describe('Test the log categories utility functions', () => {
   it('Get the log categories', () => {
     cy.wrap(farmosUtil.getLogCategories()).then((categories) => {
       expect(categories).to.not.be.null;
-      expect(categories.length).to.equal(4);
+      expect(categories.length).to.equal(13);
 
-      expect(categories[0].attributes.name).to.equal('seeding_cover_crop');
+      expect(categories[0].attributes.name).to.equal('grazing');
       expect(categories[0].attributes.description.value).to.equal(
-        'For seeding logs representing seedings of cover crops.'
+        'For logs that record animal grazing events.'
       );
       expect(categories[0].type).to.equal('taxonomy_term--log_category');
 
-      expect(categories[2].attributes.name).to.equal('seeding_tray');
+      expect(categories[2].attributes.name).to.equal('termination');
       expect(categories[2].attributes.description.value).to.equal(
-        'For seeding logs representing seedings in trays.'
+        'For logs associated with termination of a planting.'
       );
       expect(categories[2].type).to.equal('taxonomy_term--log_category');
     });
@@ -60,7 +60,7 @@ describe('Test the log categories utility functions', () => {
   it('Get the logCategoryToTerm map', () => {
     cy.wrap(farmosUtil.getLogCategoryToTermMap()).then((categoryMap) => {
       expect(categoryMap).to.not.be.null;
-      expect(categoryMap.size).to.equal(4);
+      expect(categoryMap.size).to.equal(13);
 
       expect(categoryMap.get('seeding_cover_crop')).to.not.be.null;
       expect(categoryMap.get('seeding_cover_crop').type).to.equal(
@@ -77,7 +77,7 @@ describe('Test the log categories utility functions', () => {
   it('Get the logCategoryIdToAsset map', () => {
     cy.wrap(farmosUtil.getLogCategoryIdToTermMap()).then((categoryIdMap) => {
       expect(categoryIdMap).to.not.be.null;
-      expect(categoryIdMap.size).to.equal(4);
+      expect(categoryIdMap.size).to.equal(13);
 
       cy.wrap(farmosUtil.getLogCategoryToTermMap()).then((categoryNameMap) => {
         const coverId = categoryNameMap.get('seeding_cover_crop').id;

--- a/library/farmosUtil/farmosUtil.logCategories.unit.cy.js
+++ b/library/farmosUtil/farmosUtil.logCategories.unit.cy.js
@@ -14,17 +14,17 @@ describe('Test the log categories utility functions', () => {
   it('Get the log categories', () => {
     cy.wrap(farmosUtil.getLogCategories()).then((categories) => {
       expect(categories).to.not.be.null;
-      expect(categories.length).to.equal(13);
+      expect(categories.length).to.equal(12);
 
-      expect(categories[0].attributes.name).to.equal('grazing');
+      expect(categories[0].attributes.name).to.equal('seeding_cover_crop');
       expect(categories[0].attributes.description.value).to.equal(
-        'For logs that record animal grazing events.'
+        'For logs associated with the seeding of a cover crop.'
       );
       expect(categories[0].type).to.equal('taxonomy_term--log_category');
 
-      expect(categories[2].attributes.name).to.equal('termination');
+      expect(categories[2].attributes.name).to.equal('seeding_tray');
       expect(categories[2].attributes.description.value).to.equal(
-        'For logs associated with termination of a planting.'
+        'For logs associated with seedings in trays.'
       );
       expect(categories[2].type).to.equal('taxonomy_term--log_category');
     });
@@ -60,7 +60,7 @@ describe('Test the log categories utility functions', () => {
   it('Get the logCategoryToTerm map', () => {
     cy.wrap(farmosUtil.getLogCategoryToTermMap()).then((categoryMap) => {
       expect(categoryMap).to.not.be.null;
-      expect(categoryMap.size).to.equal(13);
+      expect(categoryMap.size).to.equal(12);
 
       expect(categoryMap.get('seeding_cover_crop')).to.not.be.null;
       expect(categoryMap.get('seeding_cover_crop').type).to.equal(
@@ -77,7 +77,7 @@ describe('Test the log categories utility functions', () => {
   it('Get the logCategoryIdToAsset map', () => {
     cy.wrap(farmosUtil.getLogCategoryIdToTermMap()).then((categoryIdMap) => {
       expect(categoryIdMap).to.not.be.null;
-      expect(categoryIdMap.size).to.equal(13);
+      expect(categoryIdMap.size).to.equal(12);
 
       cy.wrap(farmosUtil.getLogCategoryToTermMap()).then((categoryNameMap) => {
         const coverId = categoryNameMap.get('seeding_cover_crop').id;

--- a/library/farmosUtil/farmosUtil.quantity.unit.cy.js
+++ b/library/farmosUtil/farmosUtil.quantity.unit.cy.js
@@ -99,7 +99,7 @@ describe('Test the quantity functions', () => {
         farmosUtil.createSeedingLog(
           '01/02/1999',
           'CHUAU',
-          'seeding_tray',
+          ['seeding_tray'],
           plantAsset,
           [quantity]
         )

--- a/library/farmosUtil/farmosUtil.seeding.unit.cy.js
+++ b/library/farmosUtil/farmosUtil.seeding.unit.cy.js
@@ -41,7 +41,7 @@ describe('Test the seeding log functions', () => {
         farmosUtil.createSeedingLog(
           '01/02/1999',
           'CHUAU',
-          'seeding_tray',
+          ['seeding', 'seeding_tray'],
           plantAsset,
           [quantity]
         )
@@ -58,9 +58,15 @@ describe('Test the seeding log functions', () => {
 
           expect(result.attributes.status).to.equal('done');
           expect(result.attributes.is_movement).to.equal(true);
+
+          expect(result.relationships.category.length).to.equal(2);
           expect(result.relationships.category[0].id).to.equal(
+            categoryMap.get('seeding').id
+          );
+          expect(result.relationships.category[1].id).to.equal(
             categoryMap.get('seeding_tray').id
           );
+
           expect(result.relationships.location[0].id).to.equal(
             greenhouseMap.get('CHUAU').id
           );
@@ -92,7 +98,7 @@ describe('Test the seeding log functions', () => {
         farmosUtil.createSeedingLog(
           '01/02/1999',
           'A',
-          'seeding_direct',
+          ['seeding', 'seeding_direct'],
           plantAsset,
           [quantity]
         )
@@ -111,9 +117,15 @@ describe('Test the seeding log functions', () => {
 
           expect(result.attributes.status).to.equal('done');
           expect(result.attributes.is_movement).to.equal(true);
+
+          expect(result.relationships.category.length).to.equal(2);
           expect(result.relationships.category[0].id).to.equal(
+            categoryMap.get('seeding').id
+          );
+          expect(result.relationships.category[1].id).to.equal(
             categoryMap.get('seeding_direct').id
           );
+
           expect(result.relationships.location[0].id).to.equal(
             fieldMap.get('A').id
           );
@@ -138,7 +150,12 @@ describe('Test the seeding log functions', () => {
     cy.get('@plantAsset').then((plantAsset) => {
       cy.wrap(
         farmosUtil
-          .createSeedingLog('01/02/1999', 'CHUAU', 'seeding_tray', plantAsset)
+          .createSeedingLog(
+            '01/02/1999',
+            'CHUAU',
+            ['seeding', 'seeding_tray'],
+            plantAsset
+          )
           .then(() => {
             throw new Error('Creating seeding log should have failed.');
           })
@@ -165,7 +182,7 @@ describe('Test the seeding log functions', () => {
         farmosUtil.createSeedingLog(
           '01/02/1999',
           'CHUAU',
-          'seeding_tray',
+          ['seeding', 'seeding_tray'],
           plantAsset,
           [quantity]
         )

--- a/library/farmosUtil/farmosUtil.soil.unit.cy.js
+++ b/library/farmosUtil/farmosUtil.soil.unit.cy.js
@@ -51,7 +51,7 @@ describe('Test the soil disturbance activity log functions', () => {
           farmosUtil.createSoilDisturbanceActivityLog(
             '1999-01-02',
             'A',
-            'activity_soil_disturbance_tillage',
+            ['tillage', 'seeding_direct'],
             plantAsset,
             [depthQuantity, speedQuantity],
             equipmentArray
@@ -78,9 +78,15 @@ describe('Test the soil disturbance activity log functions', () => {
             fieldMap.get('A').id
           );
           expect(result.relationships.asset[0].id).to.equal(plantAsset.id);
+
+          expect(result.relationships.category.length).to.equal(2);
           expect(result.relationships.category[0].id).to.equal(
-            categoryMap.get('activity_soil_disturbance_tillage').id
+            categoryMap.get('tillage').id
           );
+          expect(result.relationships.category[1].id).to.equal(
+            categoryMap.get('seeding_direct').id
+          );
+
           expect(result.relationships.quantity.length).to.equal(2);
           expect(result.relationships.quantity[0].id).to.equal(
             depthQuantity.id
@@ -115,7 +121,7 @@ describe('Test the soil disturbance activity log functions', () => {
           .createSoilDisturbanceActivityLog(
             '1999-01-02',
             'A',
-            'activity_soil_disturbance_tillage',
+            ['tillage'],
             plantAsset
           )
           .then(() => {
@@ -142,7 +148,7 @@ describe('Test the soil disturbance activity log functions', () => {
         farmosUtil.createSoilDisturbanceActivityLog(
           '1999-01-02',
           'A',
-          'activity_soil_disturbance_tillage',
+          ['tillage'],
           plantAsset
         )
       ).as('soilLog');

--- a/modules/farm_fd2/src/entrypoints/direct_seeding/lib.js
+++ b/modules/farm_fd2/src/entrypoints/direct_seeding/lib.js
@@ -67,7 +67,7 @@ export async function submitForm(formData) {
     seedingLog = await farmosUtil.createSeedingLog(
       formData.seedingDate,
       formData.locationName,
-      'seeding_direct',
+      ['seeding', 'seeding_direct'],
       plantAsset,
       [bedFeetQuantity, rowsPerBedQuantity, bedWidthQuantity]
     );
@@ -95,7 +95,7 @@ export async function submitForm(formData) {
       activityLog = await farmosUtil.createSoilDisturbanceActivityLog(
         formData.seedingDate,
         formData.locationName,
-        'activity_soil_disturbance_tillage',
+        ['tillage', 'seeding_direct'],
         plantAsset,
         [depthQuantity, speedQuantity],
         equipmentAssets

--- a/modules/farm_fd2/src/entrypoints/direct_seeding/lib.submit.unit.cy.js
+++ b/modules/farm_fd2/src/entrypoints/direct_seeding/lib.submit.unit.cy.js
@@ -176,11 +176,18 @@ describe('Test the direct seeding lib.', () => {
           result.seedingLog.relationships.asset[0].id
         );
 
+        expect(seedingLog.relationships.category.length).to.equal(2);
         expect(seedingLog.relationships.category[0].type).to.equal(
           'taxonomy_term--log_category'
         );
         expect(seedingLog.relationships.category[0].id).to.equal(
           result.seedingLog.relationships.category[0].id
+        );
+        expect(seedingLog.relationships.category[1].type).to.equal(
+          'taxonomy_term--log_category'
+        );
+        expect(seedingLog.relationships.category[1].id).to.equal(
+          result.seedingLog.relationships.category[1].id
         );
 
         expect(seedingLog.relationships.quantity.length).to.equal(3);
@@ -272,9 +279,15 @@ describe('Test the direct seeding lib.', () => {
       expect(activityLog.relationships.asset[0].id).to.equal(
         result.plantAsset.id
       );
+
+      expect(activityLog.relationships.category.length).to.equal(2);
       expect(activityLog.relationships.category[0].id).to.equal(
-        categoryMap.get('activity_soil_disturbance_tillage').id
+        categoryMap.get('tillage').id
       );
+      expect(activityLog.relationships.category[1].id).to.equal(
+        categoryMap.get('seeding_direct').id
+      );
+
       expect(activityLog.relationships.quantity.length).to.equal(2);
       expect(activityLog.relationships.quantity[0].id).to.equal(
         result.depthQuantity.id

--- a/modules/farm_fd2/src/entrypoints/direct_seeding/lib.submitNoEquipment.unit.cy.js
+++ b/modules/farm_fd2/src/entrypoints/direct_seeding/lib.submitNoEquipment.unit.cy.js
@@ -171,11 +171,18 @@ describe('Test the direct seeding lib.', () => {
           result.seedingLog.relationships.asset[0].id
         );
 
+        expect(seedingLog.relationships.category.length).to.equal(2);
         expect(seedingLog.relationships.category[0].type).to.equal(
           'taxonomy_term--log_category'
         );
         expect(seedingLog.relationships.category[0].id).to.equal(
           result.seedingLog.relationships.category[0].id
+        );
+        expect(seedingLog.relationships.category[1].type).to.equal(
+          'taxonomy_term--log_category'
+        );
+        expect(seedingLog.relationships.category[1].id).to.equal(
+          result.seedingLog.relationships.category[1].id
         );
 
         expect(seedingLog.relationships.quantity.length).to.equal(3);

--- a/modules/farm_fd2/src/entrypoints/tray_seeding/lib.js
+++ b/modules/farm_fd2/src/entrypoints/tray_seeding/lib.js
@@ -60,7 +60,7 @@ export async function submitForm(formData) {
     seedingLog = await farmosUtil.createSeedingLog(
       formData.seedingDate,
       formData.locationName,
-      'seeding_tray',
+      ['seeding', 'seeding_tray'],
       plantAsset,
       [traysQuantity, traySizeQuantity, seedsQuantity]
     );

--- a/modules/farm_fd2/src/entrypoints/tray_seeding/lib.submit.unit.cy.js
+++ b/modules/farm_fd2/src/entrypoints/tray_seeding/lib.submit.unit.cy.js
@@ -185,11 +185,18 @@ describe('Test the tray seeding lib', () => {
           result.seedingLog.relationships.asset[0].id
         );
 
+        expect(seedingLog.relationships.category.length).to.equal(2);
         expect(seedingLog.relationships.category[0].type).to.equal(
           'taxonomy_term--log_category'
         );
         expect(seedingLog.relationships.category[0].id).to.equal(
           result.seedingLog.relationships.category[0].id
+        );
+        expect(seedingLog.relationships.category[1].type).to.equal(
+          'taxonomy_term--log_category'
+        );
+        expect(seedingLog.relationships.category[1].id).to.equal(
+          result.seedingLog.relationships.category[1].id
         );
 
         expect(seedingLog.relationships.quantity.length).to.equal(3);


### PR DESCRIPTION
**Pull Request Description**

This PR makes the use of log categories consistent with the Survey Stack conventions for entering direct seeding data into farmOS but ensuring that logs include their `log_category` as well as any FarmData2 specific log categories.

Closes #146 
Partially addresses #108

---

**Licensing Certification**

FarmData2 is a [Free Cultural Work](https://freedomdefined.org/Definition) and all accepted contributions are licensed as described in the LICENSE.md file. This requires that the contributor holds the rights to do so. By submitting this pull request **I certify that I satisfy the terms of the [Developer Certificate of Origin](https://developercertificate.org/)** for its contents.
