### PR TITLE
fix(fd2): creates log categories on module install

### DIFF
--- a/modules/farm_fd2/src/module/farm_fd2.install
+++ b/modules/farm_fd2/src/module/farm_fd2.install
@@ -1,0 +1,45 @@
+<?php
+use Drupal\taxonomy\Entity\Term;
+
+/**
+ * Add some FarmData2 specific terms to the log_category vocabulary.
+ */
+function farm_fd2_install() {
+  $vocab = 'log_category';
+
+  $items = [
+    ['name' => 'seeding_cover_crop', 'description' => 'For logs associated with the seeding of a cover crop.' ],
+    ['name' => 'seeding_direct', 'description' => 'For logs associated with direct seedings.' ],
+    ['name' => 'seeding_tray', 'description' => 'For logs associated with seedings in trays.' ],
+    
+    ['name' => 'amendment', 'description' => 'For logs where soil amendments are made.' ],
+    ['name' => 'grazing', 'description' => 'For logs that record animal grazing events' ],
+    ['name' => 'irrigation', 'description' => 'For logs associated with field irrigation.' ],
+    ['name' => 'pest_disease_control', 'description' => 'For logs related to pest or disease control.' ],
+    ['name' => 'seeding', 'description' => 'For logs associated with seedings.' ],
+    ['name' => 'termination', 'description' => 'For logs associated with termination of a planting.' ],
+    ['name' => 'tillage', 'description' => 'For logs representing soil disturbances.' ],
+    ['name' => 'transplanting', 'description' => 'For logs representing transplantation of a plant.' ],
+    ['name' => 'weed_control', 'description' => 'For logs related to weed control.' ],
+  ];
+
+  foreach ($items as $item) {
+
+    $terms = \Drupal::entityTypeManager()
+            ->getStorage('taxonomy_term')
+            ->loadByProperties([
+                    'vid' => $vocab,
+                    'name' =>$item['name'],
+                ]);
+
+    if(empty($terms)) {
+      $term = Term::create(array(
+        'parent' => array(),
+        'name' => $item['name'],
+        'description' => $item['description'],
+        'vid' => $vocab,
+      ))->save();
+    }
+  }
+}
+?>

--- a/modules/farm_fd2/vite.config.js
+++ b/modules/farm_fd2/vite.config.js
@@ -24,6 +24,10 @@ let viteConfig = {
           dest: '.',
         },
         {
+          src: '../module/*.install',
+          dest: '.',
+        },
+        {
           src: '../module/Controller',
           dest: 'src/',
         },


### PR DESCRIPTION
**Pull Request Description**

This PR adds the `farm_fd2.install` file to the `farm_fd2` module.  This file is executed by drupal when the module is installed and it creates the log categories that are used by FarmData2 (if they do not already exist).

Additional code can be added to `farm_fd2.install` to create additional log categories or terms in other taxonomies (e.g. `units`).

Closes #139

---

**Licensing Certification**

FarmData2 is a [Free Cultural Work](https://freedomdefined.org/Definition) and all accepted contributions are licensed as described in the LICENSE.md file. This requires that the contributor holds the rights to do so. By submitting this pull request **I certify that I satisfy the terms of the [Developer Certificate of Origin](https://developercertificate.org/)** for its contents.
