### PR TITLE
test(lib): updates tests for log categories created by install

### DIFF
--- a/library/farmosUtil/farmosUtil.logCategories.unit.cy.js
+++ b/library/farmosUtil/farmosUtil.logCategories.unit.cy.js
@@ -16,15 +16,15 @@ describe('Test the log categories utility functions', () => {
       expect(categories).to.not.be.null;
       expect(categories.length).to.equal(12);
 
-      expect(categories[0].attributes.name).to.equal('seeding_cover_crop');
+      expect(categories[0].attributes.name).to.equal('amendment');
       expect(categories[0].attributes.description.value).to.equal(
-        'For logs associated with the seeding of a cover crop.'
+        'For logs where soil amendments are made.'
       );
       expect(categories[0].type).to.equal('taxonomy_term--log_category');
 
-      expect(categories[2].attributes.name).to.equal('seeding_tray');
+      expect(categories[2].attributes.name).to.equal('irrigation');
       expect(categories[2].attributes.description.value).to.equal(
-        'For logs associated with seedings in trays.'
+        'For logs associated with field irrigation.'
       );
       expect(categories[2].type).to.equal('taxonomy_term--log_category');
     });


### PR DESCRIPTION
**Pull Request Description**

Patches the log category tests for the `farmosUtil` library to match the log categories that are added by `farm_fd2.install` rather than the previous ones added in the creation of the sample database.

---

**Licensing Certification**

FarmData2 is a [Free Cultural Work](https://freedomdefined.org/Definition) and all accepted contributions are licensed as described in the LICENSE.md file. This requires that the contributor holds the rights to do so. By submitting this pull request **I certify that I satisfy the terms of the [Developer Certificate of Origin](https://developercertificate.org/)** for its contents.
