### PR TITLE
fix(examples): adds control for date prop to DateSelector example

### DIFF
--- a/modules/farm_fd2_examples/src/entrypoints/date_selector/App.vue
+++ b/modules/farm_fd2_examples/src/entrypoints/date_selector/App.vue
@@ -18,30 +18,46 @@
   <hr />
 
   <strong>Component Props:</strong>
-  <UL>
+  <ul>
     <li>
       <BFormCheckbox
         id="required-checkbox"
         data-cy="required-checkbox"
+        switch
         v-model="required"
-        >required</BFormCheckbox
       >
+        required
+      </BFormCheckbox>
     </li>
-    <LI>
+    <li>
       <BFormCheckbox
         id="styling-checkbox"
         data-cy="styling-checkbox"
+        switch
         v-model="validity.showStyling"
-        >showValidityStyling</BFormCheckbox
-      ></LI
-    >
-  </UL>
+      >
+        showValidityStyling
+      </BFormCheckbox>
+    </li>
+    <li>
+      <BButton
+        id="set-date-button"
+        data-cy="set-date-button"
+        variant="outline-primary"
+        size="sm"
+        v-on:click="nextDay"
+      >
+        Next
+      </BButton>
+      date
+    </li>
+  </ul>
 
   <strong>Component State:</strong>
-  <UL>
+  <ul>
     <li>date: {{ form.date }}</li>
-    <LI>valid: {{ validity.date }}</LI>
-  </UL>
+    <li>valid: {{ validity.date }}</li>
+  </ul>
 
   <div
     data-cy="page-loaded"
@@ -53,11 +69,13 @@
 
 <script>
 import DateSelector from '@comps/DateSelector/DateSelector.vue';
+import { BButton } from 'bootstrap-vue-next';
 import dayjs from 'dayjs';
 
 export default {
   components: {
     DateSelector,
+    BButton,
   },
   data() {
     return {
@@ -71,6 +89,11 @@ export default {
       },
       createdCount: 0,
     };
+  },
+  methods: {
+    nextDay() {
+      this.form.date = dayjs(this.form.date).add(1, 'day').format('YYYY-MM-DD');
+    },
   },
   computed: {
     pageDoneLoading() {


### PR DESCRIPTION
**Pull Request Description**

Adds control for changing the `date` `prop` to the `DateSelector` example.

---

**Licensing Certification**

FarmData2 is a [Free Cultural Work](https://freedomdefined.org/Definition) and all accepted contributions are licensed as described in the LICENSE.md file. This requires that the contributor holds the rights to do so. By submitting this pull request **I certify that I satisfy the terms of the [Developer Certificate of Origin](https://developercertificate.org/)** for its contents.
