### PR TITLE
fix(dev): moves database file to ~/.fd2/ so it persists in docker volume

### DIFF
--- a/.fd2-cspell.txt
+++ b/.fd2-cspell.txt
@@ -17,6 +17,7 @@ entrypoints
 farmadata
 farmdata
 farmos
+getent
 getopt
 gids
 isready
@@ -28,6 +29,7 @@ localstorage
 mfinelli
 Michal
 mryhryki
+newgrp
 novnc
 PASA
 pgid
@@ -44,6 +46,7 @@ shellcheck
 shfmt
 toplevel
 unplugin
+usermod
 vite
 vuejs
 vuese

--- a/bin/fd2-up.bash
+++ b/bin/fd2-up.bash
@@ -51,7 +51,7 @@ echo "  Full path: $FD2_PATH"
 
 # Create the .fd2 directory if it does not exist.
 # This directory is used for development environment configuration information.
-if [ -d ~/.fd2 ]; then
+if [ ! -d ~/.fd2 ]; then
   echo "Creating the ~/.fd2 configuration directory."
   mkdir ~/.fd2
   echo "  The ~/.fd2 configuration directory created."

--- a/bin/fd2-up.bash
+++ b/bin/fd2-up.bash
@@ -92,7 +92,7 @@ docker rm fd2_farmos &> /dev/null
 docker rm fd2_dev &> /dev/null
 
 echo "Starting containers..."
-safe_cd docker
+safe_cd "$FD2_DIR/docker"
 
 # Note: Any command line args are passed to the docker-compose up command
 docker compose up -d "$@"

--- a/bin/fd2-up.bash
+++ b/bin/fd2-up.bash
@@ -44,7 +44,6 @@ echo -e "${UNDERLINE_BLUE}Starting FarmData2 development environment...${NO_COLO
 # changed by the user.
 FD2_PATH=$(pwd)
 FD2_DIR=$(basename "$FD2_PATH")
-safe_cd docker
 
 echo "Starting development environment from $FD2_DIR."
 echo "  Full path: $FD2_PATH"
@@ -93,6 +92,8 @@ docker rm fd2_farmos &> /dev/null
 docker rm fd2_dev &> /dev/null
 
 echo "Starting containers..."
+safe_cd docker
+
 # Note: Any command line args are passed to the docker-compose up command
 docker compose up -d "$@"
 

--- a/bin/fd2-up.bash
+++ b/bin/fd2-up.bash
@@ -1,7 +1,14 @@
 #!/bin/bash
 
-source ./lib.bash
-source ./colors.bash
+# Get the path to the main repo directory.
+SCRIPT_PATH=$(readlink -f "$0")                     # Path to this script.
+SCRIPT_DIR=$(dirname "$SCRIPT_PATH")                # Path to directory containing this script.
+REPO_ROOT_DIR=$(builtin cd "$SCRIPT_DIR/.." && pwd) # REPO root directory.
+
+source "$SCRIPT_DIR/lib.bash"
+source "$SCRIPT_DIR/colors.bash"
+
+safe_cd "$REPO_ROOT_DIR"
 
 # Ensuring this script is not being run as root.
 RUNNING_AS_ROOT=$(id -un | grep "root")
@@ -30,12 +37,6 @@ if [ -z "$SYS_DOCKER_SOCK" ]; then
   echo "  setting in Docker Desktop -> Settings -> Advanced is enabled."
   exit 255
 fi
-
-# Get the path to the main repo directory.
-SCRIPT_PATH=$(readlink -f "$0")                     # Path to this script.
-SCRIPT_DIR=$(dirname "$SCRIPT_PATH")                # Path to directory containing this script.
-REPO_ROOT_DIR=$(builtin cd "$SCRIPT_DIR/.." && pwd) # REPO root directory.
-safe_cd "$REPO_ROOT_DIR"
 
 echo -e "${UNDERLINE_BLUE}Starting FarmData2 development environment...${NO_COLOR}"
 

--- a/bin/fd2-up.bash
+++ b/bin/fd2-up.bash
@@ -92,7 +92,7 @@ docker rm fd2_farmos &> /dev/null
 docker rm fd2_dev &> /dev/null
 
 echo "Starting containers..."
-safe_cd "$FD2_DIR/docker"
+safe_cd "$FD2_PATH/docker"
 
 # Note: Any command line args are passed to the docker-compose up command
 docker compose up -d "$@"

--- a/bin/fd2-up.bash
+++ b/bin/fd2-up.bash
@@ -49,13 +49,13 @@ safe_cd docker
 echo "Starting development environment from $FD2_DIR."
 echo "  Full path: $FD2_PATH"
 
-# (Re)create the .fd2 directory.
+# Create the .fd2 directory if it does not exist.
 # This directory is used for development environment configuration information.
-# It is recreated on each start.
-echo "Creating the ~/.fd2 configuration directory."
-rm -fr ~/.fd2 2> /dev/null
-mkdir ~/.fd2
-echo "  The ~/.fd2 configuration directory created."
+if [ -d ~/.fd2 ]; then
+  echo "Creating the ~/.fd2 configuration directory."
+  mkdir ~/.fd2
+  echo "  The ~/.fd2 configuration directory created."
+fi
 
 # Determine the host operating system.
 echo "Detecting host Operating System..."

--- a/bin/fd2-up.linux.bash
+++ b/bin/fd2-up.linux.bash
@@ -82,7 +82,7 @@ if [ "$PROFILE" == "linux" ] || [ "$PROFILE" == "wsl" ]; then
       echo "  Found unused GID=$FD2GRP_GID for fd2grp."
     fi
 
-    sudo -S groupadd --gid "$FD2GRP_GID"S fd2grp
+    sudo -S groupadd --gid "$FD2GRP_GID" fd2grp
     error_check
     echo "  fd2grp group created on host with GID=$FD2GRP_GID."
   else

--- a/bin/fd2-up.linux.bash
+++ b/bin/fd2-up.linux.bash
@@ -1,6 +1,5 @@
-# fd2-up-orig.bash...
-
-# test change.
+# Handles all of the permissions issues that arise when mounting
+# directories from the host machine into the container on linux/wsl.
 
 if [ "$PROFILE" == "linux" ] || [ "$PROFILE" == "wsl" ]; then
   echo "Configuring Linux or Windows (WSL) host..."

--- a/bin/fd2-up.linux.bash
+++ b/bin/fd2-up.linux.bash
@@ -106,10 +106,10 @@ if [ "$PROFILE" == "linux" ] || [ "$PROFILE" == "wsl" ]; then
 
   # If the FarmData2 directory is not in the fd2grp then set it.
   # shellcheck disable=SC2010
-  FD2GRP_OWNS_FD2=$(ls -ld "../../$FD2_DIR" | grep " fd2grp ")
+  FD2GRP_OWNS_FD2=$(ls -ld "$FD2_PATH" | grep " fd2grp ")
   if [ -z "$FD2GRP_OWNS_FD2" ]; then
     echo "  Assigning $FD2_DIR to the fd2grp group."
-    sudo chgrp -R fd2grp "../../$FD2_DIR"
+    sudo chgrp -R fd2grp "$FD2_PATH"
     error_check
     echo "  $FD2_DIR assigned to the fd2grp group."
   else
@@ -118,10 +118,10 @@ if [ "$PROFILE" == "linux" ] || [ "$PROFILE" == "wsl" ]; then
 
   # If the fd2grp does not have RW access to FarmData2 change it.
   # shellcheck disable=SC2012
-  FD2GRP_RW_FD2=$(ls -ld "../../$FD2_DIR" | cut -c 5-6 | grep "rw")
+  FD2GRP_RW_FD2=$(ls -ld "$FD2_PATH" | cut -c 5-6 | grep "rw")
   if [ -z "$FD2GRP_RW_FD2" ]; then
     echo "  Granting fd2grp RW access to $FD2_DIR."
-    sudo chmod -R g+rw "../../$FD2_DIR"
+    sudo chmod -R g+rw "$FD2_PATH"
     error_check
     echo "  fd2grp granted RW access to $FD2_DIR."
   else

--- a/bin/fd2-up.macos.bash
+++ b/bin/fd2-up.macos.bash
@@ -1,6 +1,7 @@
 # On MacOS the GID's in the container do not need to
 # match those on the host OS.  So we just use GID's
 # that we know do not exist in the container.
+rm -rf ~/.fd2/gids &> /dev/null
 mkdir ~/.fd2/gids
 echo "3000" > ~/.fd2/gids/fd2grp.gid
 echo "3001" > ~/.fd2/gids/docker.gid

--- a/bin/installDB.bash
+++ b/bin/installDB.bash
@@ -11,9 +11,9 @@ function usage {
   echo "  The default behavior if no flags are provided is to install the"
   echo "  latest release of the sample database."
   echo ""
-  echo "  -c|--current : Reinstall the most recently installed database."
-  echo "    - The file /var/tmp/db.sample.tar.gz will be installed if it exists."
-  echo "    - If /var/tmp/db.sample.tar.gz does not exist then the -p|--prompt behavior will be used."
+  echo "  -c|--current : Reinstall the most recently installed sample database."
+  echo "    - The file ~/.fd2/db.sample.tar.gz will be installed if it exists."
+  echo "    - If ~/.fd2/db.sample.tar.gz does not exist then the default behavior will be used."
   echo "    - No other flags may be specified with -c|--current."
   echo ""
   echo "  -p|--prompt : Prompt for the release and database artifact to install."
@@ -94,7 +94,7 @@ fi
 
 if [ -n "$PROMPT" ]; then
   if [ -n "$DB_RELEASE" ] || [ -n "$DB_ASSET" ] || [ -n "$CURRENT" ]; then
-    echo -e "${ON_RED}ERROR:${NO_COLOR} When -p|--prompt is specified, no other flags maybe included."
+    echo -e "${ON_RED}ERROR:${NO_COLOR} When -p|--prompt is specified, no other flags may be included."
     echo "Use installDB.bash --help for usage information"
     exit 255
   fi
@@ -107,11 +107,10 @@ if [ -n "$CURRENT" ]; then
     exit 255
   fi
 
-  if [ ! -f "/var/tmp/db.sample.tar.gz" ]; then
-    echo "/var/tmp/db.sample.tar.gz does not exist."
-    echo "Defaulting to -p|--prompt behavior."
+  if [ ! -f "$HOME/.fd2/db.sample.tar.gz" ]; then
+    echo "$HOME/.fd2/db.sample.tar.gz does not exist."
+    echo "Defaulting to default behavior."
     unset CURRENT
-    PROMPT=1
   fi
 fi
 
@@ -190,13 +189,13 @@ else
 fi
 
 if [ -n "$CURRENT" ]; then
-  echo -e "${UNDERLINE_GREEN}Installing $DB_ASSET from /var/tmp...${NO_COLOR}"
+  echo -e "${UNDERLINE_GREEN}Installing $DB_ASSET from $HOME/.fd2/...${NO_COLOR}"
 else
   echo -e "${UNDERLINE_GREEN}Installing $DB_ASSET from release $DB_RELEASE...${NO_COLOR}"
 
-  if [ -f "/var/tmp/$DB_ASSET" ]; then
+  if [ -f "$HOME/.fd2/$DB_ASSET" ]; then
     echo "Deleting existing database archives..."
-    rm "/var/tmp/$DB_ASSET"
+    rm "$HOME/.fd2/$DB_ASSET"
     error_check "Unable to delete existing database archives."
     echo "  Deleted."
   fi
@@ -204,7 +203,7 @@ else
   echo "Downloading database \"$DB_ASSET\" from release $DB_RELEASE..."
   gh release download "$DB_RELEASE" \
     --repo FarmData2/FD2-SampleDBs \
-    --dir /var/tmp \
+    --dir "$HOME/.fd2/" \
     --pattern "$DB_ASSET" \
     --clobber
   error_check "Unable to download the database."
@@ -238,7 +237,7 @@ error_check "Unable to delete the current database."
 echo "  Deleted."
 
 echo "Extracting $DB_ASSET..."
-echo "fd2dev" | sudo -Sk -p "" tar -xzf "/var/tmp/$DB_ASSET" > /dev/null
+echo "fd2dev" | sudo -Sk -p "" tar -xzf "$HOME/.fd2/$DB_ASSET" > /dev/null
 error_check "Error extracting the database."
 echo "  Extracted."
 
@@ -269,7 +268,7 @@ error_check "Unable to clear the cache."
 echo "  Drupal cache cleared."
 
 if [ -n "$CURRENT" ]; then
-  echo -e "${UNDERLINE_GREEN}Installed $DB_ASSET from /var/tmp.${NO_COLOR}"
+  echo -e "${UNDERLINE_GREEN}Installed $DB_ASSET from $HOME/.fd2/.${NO_COLOR}"
 else
   echo -e "${UNDERLINE_GREEN}Installed $DB_ASSET from release $DB_RELEASE.${NO_COLOR}"
 fi


### PR DESCRIPTION
**Pull Request Description**

Moves the location to which sample database asset files are downloaded from `/var/tmp` to `~/.fd2/` so that the downloaded file is persisted in the Docker volume for the user's home directory.  This ensures that the `installDB.bash -c` script will be able to install the most recent database after the dev environment is taken down and brought back up.

This PR also:
- Updates the `fd2-up.bash` and `fd2-up-linux.bash` scripts to work with absolute paths so that they can be run from any directory within the repo.
- Updates `fd2-up.bash` so that it does not change to `docker` directory until necessary.

Closes #122

---

**Licensing Certification**

FarmData2 is a [Free Cultural Work](https://freedomdefined.org/Definition) and all accepted contributions are licensed as described in the LICENSE.md file. This requires that the contributor holds the rights to do so. By submitting this pull request **I certify that I satisfy the terms of the [Developer Certificate of Origin](https://developercertificate.org/)** for its contents.
