### PR TITLE
feat(examples): adds a BedPicker example

### DIFF
--- a/components/BedPicker/BedPicker.content.comp.cy.js
+++ b/components/BedPicker/BedPicker.content.comp.cy.js
@@ -24,7 +24,7 @@ describe('Test the default BedPicker content', () => {
     cy.get('@readySpy')
       .should('have.been.calledOnce')
       .then(() => {
-        cy.get('[data-cy="bed-picker"]').should('exist');
+        cy.get('[data-cy="bed-picker"]').should('be.visible');
         cy.get('[data-cy="picker-label"]').should('have.text', 'Beds:');
         cy.get('[data-cy="picker-options"]')
           .children()
@@ -55,7 +55,7 @@ describe('Test the default BedPicker content', () => {
     cy.get('@readySpy')
       .should('have.been.calledOnce')
       .then(() => {
-        cy.get('[data-cy="bed-picker"]').should('exist');
+        cy.get('[data-cy="bed-picker"]').should('be.visible');
         cy.get('[data-cy="picker-options"]')
           .children()
           .should('have.length', 4);
@@ -141,6 +141,24 @@ describe('Test the default BedPicker content', () => {
           .find('input')
           .eq(3)
           .should('not.be.checked');
+      });
+  });
+
+  it('Check hidden if no beds in location', () => {
+    const readySpy = cy.spy().as('readySpy');
+
+    cy.mount(BedPicker, {
+      props: {
+        onReady: readySpy,
+        location: 'B',
+        required: true,
+      },
+    });
+
+    cy.get('@readySpy')
+      .should('have.been.calledOnce')
+      .then(() => {
+        cy.get('[data-cy="bed-picker"]').should('not.be.visible');
       });
   });
 });

--- a/components/BedPicker/BedPicker.vue
+++ b/components/BedPicker/BedPicker.vue
@@ -1,7 +1,7 @@
 <template>
   <div>
     <PickerBase
-      v-if="bedList.length > 0"
+      v-show="bedList.length > 0"
       id="bed-picker"
       data-cy="bed-picker"
       invalidFeedbackText="At least one bed is required"
@@ -54,7 +54,6 @@ export default {
     /**
      * The name of the location for which the `BedPicker` should show beds.
      * The `BedPicker` will fetch any beds associated with this location.
-     * This prop is watched and changes will be reflected in the component.
      */
     location: {
       type: String,
@@ -62,7 +61,6 @@ export default {
     },
     /**
      * The beds that are currently picked.
-     * This prop is watched and changes will be reflected in the component.
      */
     picked: {
       type: Array,
@@ -77,7 +75,6 @@ export default {
     },
     /**
      * Whether validity styling should appear on input elements.
-     * This prop is watched and changes will be reflected in the component.
      */
     showValidityStyling: {
       type: Boolean,

--- a/components/BedPicker/BedPicker.vue
+++ b/components/BedPicker/BedPicker.vue
@@ -21,7 +21,7 @@ import PickerBase from '@comps/PickerBase/PickerBase.vue';
 import * as farmosUtil from '@libs/farmosUtil/farmosUtil.js';
 
 /**
- * The BedPicker component is a UI element that allows the user to select a bed from a within a location.
+ * The BedPicker component is a UI element that allows the user to select beds from a within a location.
  * The BedPicker component will only be added to the DOM if the location specified
  * by the `location` prop contains at least one bed.
  *

--- a/components/PickerBase/PickerBase.vue
+++ b/components/PickerBase/PickerBase.vue
@@ -1,62 +1,64 @@
 <template>
-  <BFormGroup
-    id="picker-group"
-    data-cy="picker-group"
-    label-for="picker-options"
-    label-cols="auto"
-    label-align="end"
-  >
-    <template v-slot:label>
-      <div class="d-grid d-md-flex">
-        <div>
-          <span
-            id="picker-label"
-            data-cy="picker-label"
-            >{{ label }}:</span
-          >
-          <sup
-            id="picker-required"
-            data-cy="picker-required"
-            class="text-danger"
-            v-if="required"
-            >*</sup
+  <div>
+    <BFormGroup
+      id="picker-group"
+      data-cy="picker-group"
+      label-for="picker-options"
+      label-cols="auto"
+      label-align="end"
+    >
+      <template v-slot:label>
+        <div class="d-grid d-md-flex">
+          <div>
+            <span
+              id="picker-label"
+              data-cy="picker-label"
+              >{{ label }}:</span
+            >
+            <sup
+              id="picker-required"
+              data-cy="picker-required"
+              class="text-danger"
+              v-if="required"
+              >*</sup
+            >
+          </div>
+          <BButton
+            v-if="showAllButton"
+            id="picker-all-button"
+            data-cy="picker-all-button"
+            size="sm"
+            variant="primary"
+            v-on:click="pickAll()"
+            >All</BButton
           >
         </div>
-        <BButton
-          v-if="showAllButton"
-          id="picker-all-button"
-          data-cy="picker-all-button"
-          size="sm"
-          variant="primary"
-          v-on:click="pickAll()"
-          >All</BButton
-        >
-      </div>
-    </template>
+      </template>
 
-    <BInputGroup
-      id="picker-input"
-      data-cy="picker-input"
-    >
-      <BFormCheckboxGroup
-        data-cy="picker-options"
-        id="picker-options"
-        name="picker-options"
-        v-model="checked"
-        v-bind:options="options"
-        v-bind:state="validationStyling"
-        v-on:change="updatePicked($event)"
-      />
-
-      <BFormInvalidFeedback
-        id="picker-invalid-feedback"
-        data-cy="picker-invalid-feedback"
-        v-bind:state="validationStyling"
+      <BInputGroup
+        id="picker-input"
+        data-cy="picker-input"
       >
-        {{ invalidFeedbackText }}
-      </BFormInvalidFeedback>
-    </BInputGroup>
-  </BFormGroup>
+        <BFormCheckboxGroup
+          data-cy="picker-options"
+          id="picker-options"
+          name="picker-options"
+          v-model="checked"
+          v-bind:options="options"
+          v-bind:state="validationStyling"
+          v-on:change="updatePicked($event)"
+        />
+
+        <BFormInvalidFeedback
+          id="picker-invalid-feedback"
+          data-cy="picker-invalid-feedback"
+          v-bind:state="validationStyling"
+        >
+          {{ invalidFeedbackText }}
+        </BFormInvalidFeedback>
+      </BInputGroup>
+    </BFormGroup>
+  </div>
 </template>
 
 <script>
@@ -218,8 +220,9 @@ export default {
           this.checked = this.checked.filter((option) =>
             this.options.includes(option)
           );
+
+          this.updatePicked();
         }
-        this.updatePicked();
       },
       deep: true,
     },

--- a/modules/farm_fd2_examples/src/entrypoints/bed_picker/App.vue
+++ b/modules/farm_fd2_examples/src/entrypoints/bed_picker/App.vue
@@ -21,87 +21,130 @@
   />
   <hr />
 
-  <strong>Component Props:</strong>
-  <ul>
-    <li>
-      <BFormCheckbox
-        id="required-checkbox"
-        data-cy="required-checkbox"
-        switch
-        v-model="required"
-      >
-        required
-      </BFormCheckbox>
-    </li>
-    <li>
-      <BFormCheckbox
-        id="styling-checkbox"
-        data-cy="styling-checkbox"
-        switch
-        v-model="validity.showStyling"
-      >
-        showValidityStyling
-      </BFormCheckbox>
-    </li>
-    <li>
-      <BButtonGroup>
-        <BButton
-          id="alf-button"
-          data-cy="alf-button"
-          variant="outline-primary"
-          size="sm"
-          v-on:click="location = 'ALF'"
-        >
-          ALF
-        </BButton>
-        <BButton
-          id="chuau-button"
-          data-cy="chuau-button"
-          variant="outline-primary"
-          size="sm"
-          v-on:click="location = 'CHUAU'"
-        >
-          CHUAU
-        </BButton>
-        <BButton
-          id="ghana-button"
-          data-cy="ghana-button"
-          variant="outline-primary"
-          size="sm"
-          v-on:click="location = 'GHANA'"
-        >
-          GHANA
-        </BButton>
-      </BButtonGroup>
-      location
-    </li>
-    <li>
-      <BButton
-        id="picked-button"
-        data-cy="picked-button"
-        variant="outline-primary"
-        size="sm"
-        v-on:click="
-          bed = location + '-1';
-          index = form.beds.indexOf(bed);
-          if (index > -1) {
-            form.beds.splice(index, 1);
-          } else {
-            form.beds.push(bed);
-          }
-        "
-      >
-        Toggle first bed
-      </BButton>
-      picked
-    </li>
-  </ul>
+  <h5>Component Props:</h5>
+  <table>
+    <thead>
+      <th>Prop</th>
+      <th>Control</th>
+    </thead>
+    <tbody>
+      <tr>
+        <td>required</td>
+        <td>
+          <BFormCheckbox
+            id="required-checkbox"
+            data-cy="required-checkbox"
+            switch
+            v-model="required"
+          />
+        </td>
+      </tr>
+      <tr>
+        <td>showValidityStyling</td>
+        <td>
+          <BFormCheckbox
+            id="styling-checkbox"
+            data-cy="styling-checkbox"
+            switch
+            v-model="validity.showStyling"
+          />
+        </td>
+      </tr>
+      <tr>
+        <td>location</td>
+        <td>
+          <BButtonGroup>
+            <BButton
+              id="alf-button"
+              data-cy="alf-button"
+              variant="outline-primary"
+              size="sm"
+              v-on:click="location = 'ALF'"
+            >
+              ALF
+            </BButton>
+            <BButton
+              id="b-button"
+              data-cy="b-button"
+              variant="outline-primary"
+              size="sm"
+              v-on:click="location = 'B'"
+            >
+              B
+            </BButton>
+            <BButton
+              id="chuau-button"
+              data-cy="chuau-button"
+              variant="outline-primary"
+              size="sm"
+              v-on:click="location = 'CHUAU'"
+            >
+              CHUAU
+            </BButton>
+            <BButton
+              id="ghana-button"
+              data-cy="ghana-button"
+              variant="outline-primary"
+              size="sm"
+              v-on:click="location = 'GHANA'"
+            >
+              GHANA
+            </BButton>
+            <BButton
+              id="jasmine-button"
+              data-cy="jasmine-button"
+              variant="outline-primary"
+              size="sm"
+              v-on:click="location = 'JASMINE'"
+            >
+              JASMINE
+            </BButton>
+          </BButtonGroup>
+        </td>
+      </tr>
+      <tr>
+        <td>picked</td>
+        <td>
+          <BButton
+            id="picked-button"
+            data-cy="picked-button"
+            variant="outline-primary"
+            size="sm"
+            v-bind:disabled="!['ALF', 'CHUAU', 'GHANA'].includes(location)"
+            v-on:click="
+              bed = location + '-1';
+              index = form.beds.indexOf(bed);
+              if (index > -1) {
+                form.beds.splice(index, 1);
+              } else {
+                form.beds.push(bed);
+              }
+            "
+          >
+            Toggle first bed
+          </BButton>
+        </td>
+      </tr>
+    </tbody>
+  </table>
 
-  <strong>Component State:</strong>
-  <ul>
-    <li>beds: {{ form.beds }}</li>
-    <li>valid: {{ validity.beds }}</li>
-  </ul>
+  <h5>Component State:</h5>
+  <table>
+    <thead>
+      <th>Event</th>
+      <th>Payload</th>
+    </thead>
+    <tbody>
+      <tr>
+        <td>picked</td>
+        <td>{{ form.beds }}</td>
+      </tr>
+      <tr>
+        <td>valid</td>
+        <td>{{ validity.beds }}</td>
+      </tr>
+    </tbody>
+  </table>
 
   <div
     data-cy="page-loaded"
@@ -152,3 +195,7 @@ export default {
   },
 };
 </script>
+
+<style scoped>
+@import url('@css/fd2-examples.css');
+</style>

--- a/modules/farm_fd2_examples/src/entrypoints/bed_picker/App.vue
+++ b/modules/farm_fd2_examples/src/entrypoints/bed_picker/App.vue
@@ -53,53 +53,47 @@
       <tr>
         <td>location</td>
         <td>
-          <BButtonGroup>
-            <BButton
+          <BFormRadioGroup
+            buttons
+            button-variant="outline-primary"
+            size="sm"
+          >
+            <BFormRadio
               id="alf-button"
               data-cy="alf-button"
-              variant="outline-primary"
-              size="sm"
               v-on:click="location = 'ALF'"
             >
               ALF
-            </BButton>
-            <BButton
+            </BFormRadio>
+            <BFormRadio
               id="b-button"
               data-cy="b-button"
-              variant="outline-primary"
-              size="sm"
               v-on:click="location = 'B'"
             >
               B
-            </BButton>
-            <BButton
+            </BFormRadio>
+            <BFormRadio
               id="chuau-button"
               data-cy="chuau-button"
-              variant="outline-primary"
-              size="sm"
               v-on:click="location = 'CHUAU'"
             >
               CHUAU
-            </BButton>
-            <BButton
+            </BFormRadio>
+            <BFormRadio
               id="ghana-button"
               data-cy="ghana-button"
-              variant="outline-primary"
-              size="sm"
               v-on:click="location = 'GHANA'"
             >
               GHANA
-            </BButton>
-            <BButton
+            </BFormRadio>
+            <BFormRadio
               id="jasmine-button"
               data-cy="jasmine-button"
-              variant="outline-primary"
-              size="sm"
               v-on:click="location = 'JASMINE'"
             >
               JASMINE
-            </BButton>
-          </BButtonGroup>
+            </BFormRadio>
+          </BFormRadioGroup>
         </td>
       </tr>
       <tr>

--- a/modules/farm_fd2_examples/src/entrypoints/bed_picker/App.vue
+++ b/modules/farm_fd2_examples/src/entrypoints/bed_picker/App.vue
@@ -1,0 +1,154 @@
+<template>
+  <p>
+    The BedPicker component allows the user to select beds from a within a
+    location.
+  </p>
+
+  <hr />
+  <BedPicker
+    id="location-bed-picker"
+    data-cy="location-bed-picker"
+    v-bind:location="location"
+    v-model:picked="form.beds"
+    v-bind:required="required"
+    v-bind:showValidityStyling="validity.showStyling"
+    v-on:valid="
+      (valid) => {
+        validity.beds = valid;
+      }
+    "
+    v-on:ready="createdCount++"
+  />
+  <hr />
+
+  <strong>Component Props:</strong>
+  <ul>
+    <li>
+      <BFormCheckbox
+        id="required-checkbox"
+        data-cy="required-checkbox"
+        switch
+        v-model="required"
+      >
+        required
+      </BFormCheckbox>
+    </li>
+    <li>
+      <BFormCheckbox
+        id="styling-checkbox"
+        data-cy="styling-checkbox"
+        switch
+        v-model="validity.showStyling"
+      >
+        showValidityStyling
+      </BFormCheckbox>
+    </li>
+    <li>
+      <BButtonGroup>
+        <BButton
+          id="alf-button"
+          data-cy="alf-button"
+          variant="outline-primary"
+          size="sm"
+          v-on:click="location = 'ALF'"
+        >
+          ALF
+        </BButton>
+        <BButton
+          id="chuau-button"
+          data-cy="chuau-button"
+          variant="outline-primary"
+          size="sm"
+          v-on:click="location = 'CHUAU'"
+        >
+          CHUAU
+        </BButton>
+        <BButton
+          id="ghana-button"
+          data-cy="ghana-button"
+          variant="outline-primary"
+          size="sm"
+          v-on:click="location = 'GHANA'"
+        >
+          GHANA
+        </BButton>
+      </BButtonGroup>
+      location
+    </li>
+    <li>
+      <BButton
+        id="picked-button"
+        data-cy="picked-button"
+        variant="outline-primary"
+        size="sm"
+        v-on:click="
+          bed = location + '-1';
+          index = form.beds.indexOf(bed);
+          if (index > -1) {
+            form.beds.splice(index, 1);
+          } else {
+            form.beds.push(bed);
+          }
+        "
+      >
+        Toggle first bed
+      </BButton>
+      picked
+    </li>
+  </ul>
+
+  <strong>Component State:</strong>
+  <ul>
+    <li>beds: {{ form.beds }}</li>
+    <li>valid: {{ validity.beds }}</li>
+  </ul>
+
+  <div
+    data-cy="page-loaded"
+    v-show="false"
+  >
+    {{ pageDoneLoading }}
+  </div>
+</template>
+
+<script>
+import BedPicker from '@comps/BedPicker/BedPicker.vue';
+
+export default {
+  components: {
+    BedPicker,
+  },
+  data() {
+    return {
+      required: true,
+      location: 'ALF',
+      form: {
+        beds: [],
+      },
+      validity: {
+        showStyling: false,
+        beds: true,
+      },
+      createdCount: 0,
+    };
+  },
+  computed: {
+    pageDoneLoading() {
+      return this.createdCount == 2;
+    },
+  },
+  methods: {
+    toggle(bed) {
+      const index = this.form.beds.indexOf(bed);
+      if (index > -1) {
+        this.form.beds.splice(index, 1);
+      } else {
+        this.form.beds.push(bed);
+      }
+    },
+  },
+  created() {
+    this.createdCount++;
+  },
+};
+</script>

--- a/modules/farm_fd2_examples/src/entrypoints/bed_picker/bed_picker.exists.e2e.cy.js
+++ b/modules/farm_fd2_examples/src/entrypoints/bed_picker/bed_picker.exists.e2e.cy.js
@@ -1,0 +1,10 @@
+describe('Check that the bed_picker entry point in farm_fd2_examples exists.', () => {
+  it('Check that the page loaded.', () => {
+    // Login if running in live farmOS.
+    cy.login('admin', 'admin');
+    // Go to the main page.
+    cy.visit('fd2_examples/bed_picker/');
+    // Check that the page loads.
+    cy.waitForPage();
+  });
+});

--- a/modules/farm_fd2_examples/src/entrypoints/bed_picker/bed_picker.html
+++ b/modules/farm_fd2_examples/src/entrypoints/bed_picker/bed_picker.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1.0"
+    />
+    <title>BedPicker Example</title>
+  </head>
+  <body>
+    <div id="app"></div>
+    <script
+      type="module"
+      src="/bed_picker/bed_picker.js"
+    ></script>
+  </body>
+</html>

--- a/modules/farm_fd2_examples/src/entrypoints/bed_picker/bed_picker.js
+++ b/modules/farm_fd2_examples/src/entrypoints/bed_picker/bed_picker.js
@@ -1,0 +1,13 @@
+// Imports for Bootstrap-Vue components.
+import 'bootstrap/dist/css/bootstrap.css';
+import 'bootstrap-vue-next/dist/bootstrap-vue-next.css';
+
+import { createApp } from 'vue';
+import { createPinia } from 'pinia';
+import App from './App.vue';
+
+const app = createApp(App);
+
+app.use(createPinia());
+
+app.mount('#app');

--- a/modules/farm_fd2_examples/src/entrypoints/bed_picker/index.html
+++ b/modules/farm_fd2_examples/src/entrypoints/bed_picker/index.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1.0"
+    />
+    <title>BedPicker Example</title>
+  </head>
+  <body>
+    <div id="app"></div>
+    <script
+      type="module"
+      src="/bed_picker/bed_picker.js"
+    ></script>
+  </body>
+</html>

--- a/modules/farm_fd2_examples/src/module/farm_fd2_examples.libraries.yml
+++ b/modules/farm_fd2_examples/src/module/farm_fd2_examples.libraries.yml
@@ -31,3 +31,15 @@ date_selector:
       date_selector/date_selector.css: {}
     component:
       shared/index.css: {}
+
+bed_picker:
+  js:
+    bed_picker/bed_picker.js:
+      preprocess: false
+      minified: true
+      attributes: { type: 'module' }
+  css:
+    theme:
+      bed_picker/bed_picker.css: {}
+    component:
+      shared/index.css: {}

--- a/modules/farm_fd2_examples/src/module/farm_fd2_examples.links.menu.yml
+++ b/modules/farm_fd2_examples/src/module/farm_fd2_examples.links.menu.yml
@@ -16,3 +16,9 @@ farm.fd2_examples_date_selector:
   parent: farm.fd2_examples_component_examples
   route_name: farm.fd2_examples_date_selector.content
   weight: 100
+farm.fd2_examples_bed_picker:
+  title: 'BedPicker'
+  description: 'Example for use of the BedPicker component.'
+  parent: farm.fd2_examples_component_examples
+  route_name: farm.fd2_examples_bed_picker.content
+  weight: 100

--- a/modules/farm_fd2_examples/src/module/farm_fd2_examples.routing.yml
+++ b/modules/farm_fd2_examples/src/module/farm_fd2_examples.routing.yml
@@ -19,3 +19,10 @@ farm.fd2_examples_date_selector.content:
     _title: 'DateSelector Example'
   requirements:
     _permission: 'access content'
+farm.fd2_examples_bed_picker.content:
+  path: '/fd2_examples/bed_picker'
+  defaults:
+    _controller: '\Drupal\farm_fd2_examples\Controller\FD2_Controller::content'
+    _title: 'BedPicker Example'
+  requirements:
+    _permission: 'access content'


### PR DESCRIPTION
**Pull Request Description**

Closes #175 

Also:
- Fixes a bug in BedPicker where going to a location with no beds did not clear picked beds.  Fixed by using `v-show` instead of `v-if` for the `PickerBase` and adding a `<div>` around `PickerBase` `<template>` content.
- Adds test for `BedPicker` visibility when there are no beds.

---

**Licensing Certification**

FarmData2 is a [Free Cultural Work](https://freedomdefined.org/Definition) and all accepted contributions are licensed as described in the LICENSE.md file. This requires that the contributor holds the rights to do so. By submitting this pull request **I certify that I satisfy the terms of the [Developer Certificate of Origin](https://developercertificate.org/)** for its contents.
