### PR TITLE
fix(examples): tweaks BedPicker example

### DIFF
--- a/components/BedPicker/BedPicker.vue
+++ b/components/BedPicker/BedPicker.vue
@@ -22,7 +22,7 @@ import * as farmosUtil from '@libs/farmosUtil/farmosUtil.js';
 
 /**
  * The BedPicker component is a UI element that allows the user to select beds from a within a location.
- * The BedPicker component will only be added to the DOM if the location specified
+ * The BedPicker component will only be visible if the location specified
  * by the `location` prop contains at least one bed.
  *
  * ## Usage Example

--- a/modules/farm_fd2_examples/src/entrypoints/bed_picker/App.vue
+++ b/modules/farm_fd2_examples/src/entrypoints/bed_picker/App.vue
@@ -57,10 +57,12 @@
             buttons
             button-variant="outline-primary"
             size="sm"
+            v-model="location"
           >
             <BFormRadio
               id="alf-button"
               data-cy="alf-button"
+              value="ALF"
               v-on:click="location = 'ALF'"
             >
               ALF
@@ -68,6 +70,7 @@
             <BFormRadio
               id="b-button"
               data-cy="b-button"
+              value="B"
               v-on:click="location = 'B'"
             >
               B
@@ -75,6 +78,7 @@
             <BFormRadio
               id="chuau-button"
               data-cy="chuau-button"
+              value="CHUAU"
               v-on:click="location = 'CHUAU'"
             >
               CHUAU
@@ -82,6 +86,7 @@
             <BFormRadio
               id="ghana-button"
               data-cy="ghana-button"
+              value="GHANA"
               v-on:click="location = 'GHANA'"
             >
               GHANA
@@ -89,6 +94,7 @@
             <BFormRadio
               id="jasmine-button"
               data-cy="jasmine-button"
+              value="JASMINE"
               v-on:click="location = 'JASMINE'"
             >
               JASMINE
@@ -122,7 +128,7 @@
     </tbody>
   </table>
 
-  <h5>Component State:</h5>
+  <h5>Component Event Payloads:</h5>
   <table>
     <thead>
       <th>Event</th>


### PR DESCRIPTION
**Pull Request Description**

Updates the `BedPicker` example so that:
- The second table heading matches the others.
- The `ALF` radio button is initially selected to reflect the initial state of the component.

---

**Licensing Certification**

FarmData2 is a [Free Cultural Work](https://freedomdefined.org/Definition) and all accepted contributions are licensed as described in the LICENSE.md file. This requires that the contributor holds the rights to do so. By submitting this pull request **I certify that I satisfy the terms of the [Developer Certificate of Origin](https://developercertificate.org/)** for its contents.
