### PR TITLE
fix(examples): links the BedPicker example in jsDoc and examples page

### DIFF
--- a/components/BedPicker/BedPicker.vue
+++ b/components/BedPicker/BedPicker.vue
@@ -25,18 +25,24 @@ import * as farmosUtil from '@libs/farmosUtil/farmosUtil.js';
  * The BedPicker component will only be visible if the location specified
  * by the `location` prop contains at least one bed.
  *
+ * ## Live Example
+ *
+ * <a href="http://farmos/fd2_examples/bed_picker">The BedPicker Example</a>
+ *
+ * Source: <a href="../../modules/farm_fd2_examples/src/entrypoints/bed_picker/App.vue">App.vue</a>
+ *
  * ## Usage Example
  *
  * ```html
  * <BedPicker
  *   id="location-bed-picker"
  *   data-cy="location-bed-picker"
- *   v-bind:location="selectedLocation"
- *   v-bind:picked="checkedBeds"
- *   v-bind:required="requireBedSelection"
- *   v-on:update:picked="handleUpdateBeds($event)"
- *   v-bind:showValidityStyling="showValidityStyling"
- *   v-on:valid="handleBedsValid($event)"
+ *   v-bind:location="location"
+ *   v-model:picked="form.beds"
+ *   v-bind:required="required"
+ *   v-bind:showValidityStyling="validity.showStyling"
+ *   v-on:valid="(valid) => { validity.beds = valid; }"
+ *   v-on:ready="createdCount++"
  * />
  * ```
  *

--- a/modules/farm_fd2_examples/src/entrypoints/component_examples/App.vue
+++ b/modules/farm_fd2_examples/src/entrypoints/component_examples/App.vue
@@ -2,6 +2,9 @@
   <p>A set of examples illustrating the use of the FarmData2 components.</p>
   <ul>
     <li>
+      <a href="bed_picker">BedPicker</a>: A component for picking multiple beds.
+    </li>
+    <li>
       <a href="date_selector">DateSelector</a>: Component for selecting a date.
     </li>
     <li>


### PR DESCRIPTION
**Pull Request Description**

- Adds a link to the Components example page for the `BedPicker`
- Updates the `BedPicker` jsDoc to
  - Link to the live example and source code
  - revise the static example code in the jsDoc

---

**Licensing Certification**

FarmData2 is a [Free Cultural Work](https://freedomdefined.org/Definition) and all accepted contributions are licensed as described in the LICENSE.md file. This requires that the contributor holds the rights to do so. By submitting this pull request **I certify that I satisfy the terms of the [Developer Certificate of Origin](https://developercertificate.org/)** for its contents.
