### PR TITLE
Fix validity styling

### DIFF
--- a/components/DateSelector/DateSelector.events.comp.cy.js
+++ b/components/DateSelector/DateSelector.events.comp.cy.js
@@ -11,7 +11,17 @@ describe('Test the  DateSelector component events', () => {
     cy.saveSessionStorage();
   });
 
-  it('Emits "valid" on creation', () => {
+  /**
+   * Does 4 checks on validity computation
+   *
+   * required   empty     test
+   * false      false     1. valid event: Not required, not empty
+   * false      true      2. valid event: Not required, empty
+   * true       false     3. valid event: Required, not empty
+   * true       true      4. valid event: Required, empty
+   */
+
+  it('1. valid event: Not required, not empty', () => {
     const readySpy = cy.spy().as('readySpy');
     const validSpy = cy.spy().as('validSpy');
 
@@ -19,6 +29,8 @@ describe('Test the  DateSelector component events', () => {
       props: {
         onReady: readySpy,
         onValid: validSpy,
+        required: false,
+        date: '1999-01-01',
       },
     });
 
@@ -27,6 +39,69 @@ describe('Test the  DateSelector component events', () => {
       .then(() => {
         cy.get('@validSpy').should('have.been.calledOnce');
         cy.get('@validSpy').should('have.been.calledWith', true);
+      });
+  });
+
+  it('2. valid event: Not required, empty', () => {
+    const readySpy = cy.spy().as('readySpy');
+    const validSpy = cy.spy().as('validSpy');
+
+    cy.mount(DateSelector, {
+      props: {
+        onReady: readySpy,
+        onValid: validSpy,
+        required: false,
+        date: null,
+      },
+    });
+
+    cy.get('@readySpy')
+      .should('have.been.calledOnce')
+      .then(() => {
+        cy.get('@validSpy').should('have.been.calledOnce');
+        cy.get('@validSpy').should('have.been.calledWith', true);
+      });
+  });
+
+  it('3. valid event: Required, Not empty', () => {
+    const readySpy = cy.spy().as('readySpy');
+    const validSpy = cy.spy().as('validSpy');
+
+    cy.mount(DateSelector, {
+      props: {
+        onReady: readySpy,
+        onValid: validSpy,
+        required: true,
+        date: '1999-01-02',
+      },
+    });
+
+    cy.get('@readySpy')
+      .should('have.been.calledOnce')
+      .then(() => {
+        cy.get('@validSpy').should('have.been.calledOnce');
+        cy.get('@validSpy').should('have.been.calledWith', true);
+      });
+  });
+
+  it('4. valid event: Required, empty', () => {
+    const readySpy = cy.spy().as('readySpy');
+    const validSpy = cy.spy().as('validSpy');
+
+    cy.mount(DateSelector, {
+      props: {
+        onReady: readySpy,
+        onValid: validSpy,
+        required: true,
+        date: null,
+      },
+    });
+
+    cy.get('@readySpy')
+      .should('have.been.calledOnce')
+      .then(() => {
+        cy.get('@validSpy').should('have.been.calledOnce');
+        cy.get('@validSpy').should('have.been.calledWith', false);
       });
   });
 

--- a/components/DateSelector/DateSelector.styling.comp.cy.js
+++ b/components/DateSelector/DateSelector.styling.comp.cy.js
@@ -12,16 +12,104 @@ describe('Test the DateSelector styling', () => {
   });
 
   /*
-   * There are 4 possibilities for styling...
+   * There are 8 possibilities for styling...
    *
-   * showValidityStyling    isValid   Tested by Test
-   * false                  false     1. Not showing, not valid
-   * false                  true      2. Not showing, valid
-   * true                   false     3. Showing, not valid
-   * true                   true      4. Showing, valid
+   * required   showValidityStyling    isValid   Tested by Test
+   * false      false                  false     1. Not Required, Not showing, not valid
+   * false      false                  true      2. Not Required, Not showing, valid
+   * false      true                   false     3. Not Required, Showing, not valid
+   * false      true                   true      4. Not Required, Showing, valid
+   * true       false                  false     5. Required, Not showing, not valid
+   * true       false                  true      6. Required, Not showing, valid
+   * true       true                   false     7. Required, Showing, not valid
+   * true       true                   true      8. Required, Showing, valid
    */
 
-  it('1. Not showing, not valid', () => {
+  it('1. Not Required, Not showing, not valid', () => {
+    const readySpy = cy.spy().as('readySpy');
+
+    cy.mount(DateSelector, {
+      props: {
+        required: false,
+        date: null,
+        showValidityStyling: false,
+        onReady: readySpy,
+      },
+    });
+
+    cy.get('@readySpy')
+      .should('have.been.calledOnce')
+      .then(() => {
+        cy.get('[data-cy="date-input"]').should('not.have.class', 'is-valid');
+        cy.get('[data-cy="date-input"]').should('not.have.class', 'is-invalid');
+        cy.get('[data-cy="date-invalid-feedback"]').should('not.be.visible');
+      });
+  });
+
+  it('2. Not Required, Not showing, valid', () => {
+    const readySpy = cy.spy().as('readySpy');
+
+    cy.mount(DateSelector, {
+      props: {
+        required: false,
+        date: '1999-01-02',
+        showValidityStyling: false,
+        onReady: readySpy,
+      },
+    });
+
+    cy.get('@readySpy')
+      .should('have.been.calledOnce')
+      .then(() => {
+        cy.get('[data-cy="date-input"]').should('not.have.class', 'is-valid');
+        cy.get('[data-cy="date-input"]').should('not.have.class', 'is-invalid');
+        cy.get('[data-cy="date-invalid-feedback"]').should('not.be.visible');
+      });
+  });
+
+  it('3. Not Required, Showing, not valid', () => {
+    const readySpy = cy.spy().as('readySpy');
+
+    cy.mount(DateSelector, {
+      props: {
+        required: false,
+        date: '',
+        showValidityStyling: true,
+        onReady: readySpy,
+      },
+    });
+
+    cy.get('@readySpy')
+      .should('have.been.calledOnce')
+      .then(() => {
+        cy.get('[data-cy="date-input"]').should('not.have.class', 'is-valid');
+        cy.get('[data-cy="date-input"]').should('not.have.class', 'is-invalid');
+        cy.get('[data-cy="date-invalid-feedback"]').should('not.be.visible');
+      });
+  });
+
+  it('4. Not Required, Showing, valid', () => {
+    const readySpy = cy.spy().as('readySpy');
+
+    cy.mount(DateSelector, {
+      props: {
+        required: false,
+        date: '1999-01-02',
+        showValidityStyling: true,
+        onReady: readySpy,
+      },
+    });
+
+    cy.get('@readySpy')
+      .should('have.been.calledOnce')
+      .then(() => {
+        cy.get('[data-cy="date-input"]').should('have.class', 'is-valid');
+        cy.get('[data-cy="date-input"]').should('not.have.class', 'is-invalid');
+        cy.get('[data-cy="date-invalid-feedback"]').should('not.be.visible');
+      });
+  });
+
+  it('5. Required, Not showing, not valid', () => {
     const readySpy = cy.spy().as('readySpy');
 
     cy.mount(DateSelector, {
@@ -42,7 +130,7 @@ describe('Test the DateSelector styling', () => {
       });
   });
 
-  it('2. Not showing, valid', () => {
+  it('6. Required, Not showing, valid', () => {
     const readySpy = cy.spy().as('readySpy');
 
     cy.mount(DateSelector, {
@@ -63,13 +151,13 @@ describe('Test the DateSelector styling', () => {
       });
   });
 
-  it('3. Showing, not valid', () => {
+  it('7. Required, Showing, not valid', () => {
     const readySpy = cy.spy().as('readySpy');
 
     cy.mount(DateSelector, {
       props: {
         required: true,
-        date: null,
+        date: '',
         showValidityStyling: true,
         onReady: readySpy,
       },
@@ -84,7 +172,7 @@ describe('Test the DateSelector styling', () => {
       });
   });
 
-  it('4. Showing, valid', () => {
+  it('8. Required, Showing, valid', () => {
     const readySpy = cy.spy().as('readySpy');
 
     cy.mount(DateSelector, {

--- a/components/DateSelector/DateSelector.styling.comp.cy.js
+++ b/components/DateSelector/DateSelector.styling.comp.cy.js
@@ -14,25 +14,46 @@ describe('Test the DateSelector styling', () => {
   /*
    * There are 8 possibilities for styling...
    *
-   * required   showValidityStyling    isValid   Tested by Test
-   * false      false                  false     1. Not Required, Not showing, not valid
-   * false      false                  true      2. Not Required, Not showing, valid
-   * false      true                   false     3. Not Required, Showing, not valid
-   * false      true                   true      4. Not Required, Showing, valid
-   * true       false                  false     5. Required, Not showing, not valid
-   * true       false                  true      6. Required, Not showing, valid
-   * true       true                   false     7. Required, Showing, not valid
-   * true       true                   true      8. Required, Showing, valid
+   * required   showValidityStyling    empty     Tested by Test
+   * false      false                  false     1. Not Required, Not showing, not empty
+   * false      false                  true      2. Not Required, Not showing, empty
+   * false      true                   false     3. Not Required, Showing, not empty
+   * false      true                   true      4. Not Required, Showing, empty
+   * true       false                  false     5. Required, Not showing, not empty
+   * true       false                  true      6. Required, Not showing, empty
+   * true       true                   false     7. Required, Showing, not empty
+   * true       true                   true      8. Required, Showing, empty
    */
 
-  it('1. Not Required, Not showing, not valid', () => {
+  it('1. Not Required, Not showing, not empty', () => {
     const readySpy = cy.spy().as('readySpy');
 
     cy.mount(DateSelector, {
       props: {
         required: false,
+        showValidityStyling: false,
+        date: '1999-01-02',
+        onReady: readySpy,
+      },
+    });
+
+    cy.get('@readySpy')
+      .should('have.been.calledOnce')
+      .then(() => {
+        cy.get('[data-cy="date-input"]').should('not.have.class', 'is-valid');
+        cy.get('[data-cy="date-input"]').should('not.have.class', 'is-invalid');
+        cy.get('[data-cy="date-invalid-feedback"]').should('not.be.visible');
+      });
+  });
+
+  it('2. Not Required, Not showing, empty', () => {
+    const readySpy = cy.spy().as('readySpy');
+
+    cy.mount(DateSelector, {
+      props: {
+        required: false,
+        showValidityStyling: false,
         date: null,
-        showValidityStyling: false,
         onReady: readySpy,
       },
     });
@@ -46,56 +67,14 @@ describe('Test the DateSelector styling', () => {
       });
   });
 
-  it('2. Not Required, Not showing, valid', () => {
+  it('3. Not Required, Showing, not empty', () => {
     const readySpy = cy.spy().as('readySpy');
 
     cy.mount(DateSelector, {
       props: {
         required: false,
-        date: '1999-01-02',
-        showValidityStyling: false,
-        onReady: readySpy,
-      },
-    });
-
-    cy.get('@readySpy')
-      .should('have.been.calledOnce')
-      .then(() => {
-        cy.get('[data-cy="date-input"]').should('not.have.class', 'is-valid');
-        cy.get('[data-cy="date-input"]').should('not.have.class', 'is-invalid');
-        cy.get('[data-cy="date-invalid-feedback"]').should('not.be.visible');
-      });
-  });
-
-  it('3. Not Required, Showing, not valid', () => {
-    const readySpy = cy.spy().as('readySpy');
-
-    cy.mount(DateSelector, {
-      props: {
-        required: false,
-        date: '',
         showValidityStyling: true,
-        onReady: readySpy,
-      },
-    });
-
-    cy.get('@readySpy')
-      .should('have.been.calledOnce')
-      .then(() => {
-        cy.get('[data-cy="date-input"]').should('not.have.class', 'is-valid');
-        cy.get('[data-cy="date-input"]').should('not.have.class', 'is-invalid');
-        cy.get('[data-cy="date-invalid-feedback"]').should('not.be.visible');
-      });
-  });
-
-  it('4. Not Required, Showing, valid', () => {
-    const readySpy = cy.spy().as('readySpy');
-
-    cy.mount(DateSelector, {
-      props: {
-        required: false,
         date: '1999-01-02',
-        showValidityStyling: true,
         onReady: readySpy,
       },
     });
@@ -109,56 +88,98 @@ describe('Test the DateSelector styling', () => {
       });
   });
 
-  it('5. Required, Not showing, not valid', () => {
+  it('4. Not Required, Showing, empty', () => {
     const readySpy = cy.spy().as('readySpy');
 
     cy.mount(DateSelector, {
       props: {
-        required: true,
-        date: null,
-        showValidityStyling: false,
-        onReady: readySpy,
-      },
-    });
-
-    cy.get('@readySpy')
-      .should('have.been.calledOnce')
-      .then(() => {
-        cy.get('[data-cy="date-input"]').should('not.have.class', 'is-valid');
-        cy.get('[data-cy="date-input"]').should('not.have.class', 'is-invalid');
-        cy.get('[data-cy="date-invalid-feedback"]').should('not.be.visible');
-      });
-  });
-
-  it('6. Required, Not showing, valid', () => {
-    const readySpy = cy.spy().as('readySpy');
-
-    cy.mount(DateSelector, {
-      props: {
-        required: true,
-        date: '1999-01-02',
-        showValidityStyling: false,
-        onReady: readySpy,
-      },
-    });
-
-    cy.get('@readySpy')
-      .should('have.been.calledOnce')
-      .then(() => {
-        cy.get('[data-cy="date-input"]').should('not.have.class', 'is-valid');
-        cy.get('[data-cy="date-input"]').should('not.have.class', 'is-invalid');
-        cy.get('[data-cy="date-invalid-feedback"]').should('not.be.visible');
-      });
-  });
-
-  it('7. Required, Showing, not valid', () => {
-    const readySpy = cy.spy().as('readySpy');
-
-    cy.mount(DateSelector, {
-      props: {
-        required: true,
-        date: '',
+        required: false,
         showValidityStyling: true,
+        date: '',
+        onReady: readySpy,
+      },
+    });
+
+    cy.get('@readySpy')
+      .should('have.been.calledOnce')
+      .then(() => {
+        cy.get('[data-cy="date-input"]').should('not.have.class', 'is-valid');
+        cy.get('[data-cy="date-input"]').should('not.have.class', 'is-invalid');
+        cy.get('[data-cy="date-invalid-feedback"]').should('not.be.visible');
+      });
+  });
+
+  it('5. Required, Not showing, not empty', () => {
+    const readySpy = cy.spy().as('readySpy');
+
+    cy.mount(DateSelector, {
+      props: {
+        required: true,
+        showValidityStyling: false,
+        date: '1999-01-02',
+        onReady: readySpy,
+      },
+    });
+
+    cy.get('@readySpy')
+      .should('have.been.calledOnce')
+      .then(() => {
+        cy.get('[data-cy="date-input"]').should('not.have.class', 'is-valid');
+        cy.get('[data-cy="date-input"]').should('not.have.class', 'is-invalid');
+        cy.get('[data-cy="date-invalid-feedback"]').should('not.be.visible');
+      });
+  });
+
+  it('6. Required, Not showing, empty', () => {
+    const readySpy = cy.spy().as('readySpy');
+
+    cy.mount(DateSelector, {
+      props: {
+        required: true,
+        showValidityStyling: false,
+        date: '',
+        onReady: readySpy,
+      },
+    });
+
+    cy.get('@readySpy')
+      .should('have.been.calledOnce')
+      .then(() => {
+        cy.get('[data-cy="date-input"]').should('not.have.class', 'is-valid');
+        cy.get('[data-cy="date-input"]').should('not.have.class', 'is-invalid');
+        cy.get('[data-cy="date-invalid-feedback"]').should('not.be.visible');
+      });
+  });
+
+  it('7. Required, Showing, not empty', () => {
+    const readySpy = cy.spy().as('readySpy');
+
+    cy.mount(DateSelector, {
+      props: {
+        required: true,
+        showValidityStyling: true,
+        date: '1999-01-02',
+        onReady: readySpy,
+      },
+    });
+
+    cy.get('@readySpy')
+      .should('have.been.calledOnce')
+      .then(() => {
+        cy.get('[data-cy="date-input"]').should('have.class', 'is-valid');
+        cy.get('[data-cy="date-input"]').should('not.have.class', 'is-invalid');
+        cy.get('[data-cy="date-invalid-feedback"]').should('not.be.visible');
+      });
+  });
+
+  it('8. Required, Showing, empty', () => {
+    const readySpy = cy.spy().as('readySpy');
+
+    cy.mount(DateSelector, {
+      props: {
+        required: true,
+        showValidityStyling: true,
+        date: '',
         onReady: readySpy,
       },
     });
@@ -169,27 +190,6 @@ describe('Test the DateSelector styling', () => {
         cy.get('[data-cy="date-input"]').should('not.have.class', 'is-valid');
         cy.get('[data-cy="date-input"]').should('have.class', 'is-invalid');
         cy.get('[data-cy="date-invalid-feedback"]').should('be.visible');
-      });
-  });
-
-  it('8. Required, Showing, valid', () => {
-    const readySpy = cy.spy().as('readySpy');
-
-    cy.mount(DateSelector, {
-      props: {
-        required: true,
-        date: '1999-01-02',
-        showValidityStyling: true,
-        onReady: readySpy,
-      },
-    });
-
-    cy.get('@readySpy')
-      .should('have.been.calledOnce')
-      .then(() => {
-        cy.get('[data-cy="date-input"]').should('have.class', 'is-valid');
-        cy.get('[data-cy="date-input"]').should('not.have.class', 'is-invalid');
-        cy.get('[data-cy="date-invalid-feedback"]').should('not.be.visible');
       });
   });
 });

--- a/components/DateSelector/DateSelector.vue
+++ b/components/DateSelector/DateSelector.vue
@@ -105,19 +105,29 @@ export default {
     };
   },
   computed: {
+    isEmpty() {
+      return (
+        this.chosenDate == '' ||
+        this.chosenDate == 'Invalid Date' ||
+        this.chosenDate === null
+      );
+    },
     isValid() {
       const validDate = dayjs(this.chosenDate).isValid();
-      return validDate;
+      if (this.required) {
+        return validDate;
+      } else {
+        if (this.isEmpty) {
+          return true;
+        } else {
+          return validDate;
+        }
+      }
     },
     // Controls component styling (i.e. when green check or red X and invalid feedback) should be displayed.
     validityStyling() {
       if (this.showValidityStyling) {
-        if (
-          !this.required &&
-          (this.chosenDate == '' ||
-            this.chosenDate == 'Invalid Date' ||
-            this.chosenDate === null)
-        ) {
+        if (!this.required && this.isEmpty) {
           return null;
         } else {
           return this.isValid;

--- a/components/DateSelector/DateSelector.vue
+++ b/components/DateSelector/DateSelector.vue
@@ -107,16 +107,21 @@ export default {
   computed: {
     isValid() {
       const validDate = dayjs(this.chosenDate).isValid();
-      if (!this.required) {
-        return validDate;
-      } else {
-        return validDate && this.chosenDate !== '';
-      }
+      return validDate;
     },
     // Controls component styling (i.e. when green check or red X and invalid feedback) should be displayed.
     validityStyling() {
       if (this.showValidityStyling) {
-        return this.isValid;
+        if (
+          !this.required &&
+          (this.chosenDate == '' ||
+            this.chosenDate == 'Invalid Date' ||
+            this.chosenDate === null)
+        ) {
+          return null;
+        } else {
+          return this.isValid;
+        }
       } else {
         return null;
       }

--- a/components/NumericInput/NumericInput.events.comp.cy.js
+++ b/components/NumericInput/NumericInput.events.comp.cy.js
@@ -11,15 +11,51 @@ describe('Test the NumericInput component events', () => {
     cy.saveSessionStorage();
   });
 
-  it('Emits "valid" true when component has been created', () => {
+  /**
+   * Does 6 checks on validity computation
+   *
+   * required   empty     valid     test
+   * false      false     false     1a. valid event: Not required, not empty, not valid
+   * false      false     true      1b. valid event: Not required, not empty, valid
+   * false      true                2.  valid event: Not required, empty
+   * true       false     false     3a. valid event: Required, not empty not valid
+   * true       false     true      3b. valid event: Required, not empty valid
+   * true       true                4.  valid event: Required, empty
+   */
+
+  it('1a. valid event: Not required, not empty, not valid', () => {
     const readySpy = cy.spy().as('readySpy');
     const validSpy = cy.spy().as('validSpy');
 
     cy.mount(NumericInput, {
       props: {
+        required: false,
+        value: 'abc',
         label: 'Test',
         invalidFeedbackText: 'Test feedback text',
+        onReady: readySpy,
+        onValid: validSpy,
+      },
+    });
+
+    cy.get('@readySpy')
+      .should('have.been.calledOnce')
+      .then(() => {
+        cy.get('@validSpy').should('have.been.calledOnce');
+        cy.get('@validSpy').should('have.been.calledWith', false);
+      });
+  });
+
+  it('1b. valid event: Not required, not empty, valid', () => {
+    const readySpy = cy.spy().as('readySpy');
+    const validSpy = cy.spy().as('validSpy');
+
+    cy.mount(NumericInput, {
+      props: {
+        required: false,
         value: 7,
+        label: 'Test',
+        invalidFeedbackText: 'Test feedback text',
         onReady: readySpy,
         onValid: validSpy,
       },
@@ -33,15 +69,85 @@ describe('Test the NumericInput component events', () => {
       });
   });
 
-  it('Emits "valid" false when component has been created', () => {
+  it('2.  valid event: Not required, empty', () => {
     const readySpy = cy.spy().as('readySpy');
     const validSpy = cy.spy().as('validSpy');
 
     cy.mount(NumericInput, {
       props: {
+        required: false,
+        value: '',
         label: 'Test',
         invalidFeedbackText: 'Test feedback text',
+        onReady: readySpy,
+        onValid: validSpy,
+      },
+    });
+
+    cy.get('@readySpy')
+      .should('have.been.calledOnce')
+      .then(() => {
+        cy.get('@validSpy').should('have.been.calledOnce');
+        cy.get('@validSpy').should('have.been.calledWith', true);
+      });
+  });
+
+  it('3a. valid event: Required, not empty not valid', () => {
+    const readySpy = cy.spy().as('readySpy');
+    const validSpy = cy.spy().as('validSpy');
+
+    cy.mount(NumericInput, {
+      props: {
+        required: true,
         value: 'abc',
+        label: 'Test',
+        invalidFeedbackText: 'Test feedback text',
+        onReady: readySpy,
+        onValid: validSpy,
+      },
+    });
+
+    cy.get('@readySpy')
+      .should('have.been.calledOnce')
+      .then(() => {
+        cy.get('@validSpy').should('have.been.calledOnce');
+        cy.get('@validSpy').should('have.been.calledWith', false);
+      });
+  });
+
+  it('3b. valid event: Required, not empty valid', () => {
+    const readySpy = cy.spy().as('readySpy');
+    const validSpy = cy.spy().as('validSpy');
+
+    cy.mount(NumericInput, {
+      props: {
+        required: true,
+        value: 7,
+        label: 'Test',
+        invalidFeedbackText: 'Test feedback text',
+        onReady: readySpy,
+        onValid: validSpy,
+      },
+    });
+
+    cy.get('@readySpy')
+      .should('have.been.calledOnce')
+      .then(() => {
+        cy.get('@validSpy').should('have.been.calledOnce');
+        cy.get('@validSpy').should('have.been.calledWith', true);
+      });
+  });
+
+  it('4.  valid event: Required, empty', () => {
+    const readySpy = cy.spy().as('readySpy');
+    const validSpy = cy.spy().as('validSpy');
+
+    cy.mount(NumericInput, {
+      props: {
+        required: true,
+        value: '',
+        label: 'Test',
+        invalidFeedbackText: 'Test feedback text',
         onReady: readySpy,
         onValid: validSpy,
       },

--- a/components/PickerBase/PickerBase.events.comp.cy.js
+++ b/components/PickerBase/PickerBase.events.comp.cy.js
@@ -11,7 +11,16 @@ describe('Test the PickerBase component events', () => {
     cy.saveSessionStorage();
   });
 
-  it('Emits "valid" true on creation if not required.', () => {
+  /**
+   * Does 4 checks on validity computation
+   *
+   * required   empty     test
+   * false      false     1. valid event: Not required, not empty
+   * false      true      2. valid event: Not required, empty
+   * true       false     3. valid event: Required, not empty
+   * true       true      4. valid event: Required, empty
+   */
+  it('1. valid event: Not required, not empty', () => {
     const readySpy = cy.spy().as('readySpy');
     const validSpy = cy.spy().as('validSpy');
 
@@ -20,7 +29,9 @@ describe('Test the PickerBase component events', () => {
         onReady: readySpy,
         onValid: validSpy,
         label: 'Picker',
+        required: false,
         options: ['Option 1', 'Option 2', 'Option 3', 'Option 4'],
+        picked: ['Option 1'],
         invalidFeedbackText: 'Invalid feedback text.',
       },
     });
@@ -33,7 +44,55 @@ describe('Test the PickerBase component events', () => {
       });
   });
 
-  it('Emits "valid" false on creation if required.', () => {
+  it('2. valid event: Not required, empty', () => {
+    const readySpy = cy.spy().as('readySpy');
+    const validSpy = cy.spy().as('validSpy');
+
+    cy.mount(PickerBase, {
+      props: {
+        onReady: readySpy,
+        onValid: validSpy,
+        label: 'Picker',
+        requried: false,
+        options: ['Option 1', 'Option 2', 'Option 3', 'Option 4'],
+        picked: ['Option 1'],
+        invalidFeedbackText: 'Invalid feedback text.',
+      },
+    });
+
+    cy.get('@readySpy')
+      .should('have.been.calledOnce')
+      .then(() => {
+        cy.get('@validSpy').should('have.been.calledOnce');
+        cy.get('@validSpy').should('have.been.calledWith', true);
+      });
+  });
+
+  it('3. valid event: Required, not empty', () => {
+    const readySpy = cy.spy().as('readySpy');
+    const validSpy = cy.spy().as('validSpy');
+
+    cy.mount(PickerBase, {
+      props: {
+        onReady: readySpy,
+        onValid: validSpy,
+        required: true,
+        label: 'Picker',
+        options: ['Option 1', 'Option 2', 'Option 3', 'Option 4'],
+        picked: ['Option 1'],
+        invalidFeedbackText: 'Invalid feedback text.',
+      },
+    });
+
+    cy.get('@readySpy')
+      .should('have.been.calledOnce')
+      .then(() => {
+        cy.get('@validSpy').should('have.been.calledOnce');
+        cy.get('@validSpy').should('have.been.calledWith', true);
+      });
+  });
+
+  it('4. valid event: Required, empty', () => {
     const readySpy = cy.spy().as('readySpy');
     const validSpy = cy.spy().as('validSpy');
 

--- a/components/PickerBase/PickerBase.events.comp.cy.js
+++ b/components/PickerBase/PickerBase.events.comp.cy.js
@@ -11,7 +11,7 @@ describe('Test the PickerBase component events', () => {
     cy.saveSessionStorage();
   });
 
-  it('Emits "valid" true on creation if not required.', () => {
+  it('Emits "valid" false on creation if not required.', () => {
     const readySpy = cy.spy().as('readySpy');
     const validSpy = cy.spy().as('validSpy');
 

--- a/components/PickerBase/PickerBase.events.comp.cy.js
+++ b/components/PickerBase/PickerBase.events.comp.cy.js
@@ -11,7 +11,7 @@ describe('Test the PickerBase component events', () => {
     cy.saveSessionStorage();
   });
 
-  it('Emits "valid" false on creation if not required.', () => {
+  it('Emits "valid" true on creation if not required.', () => {
     const readySpy = cy.spy().as('readySpy');
     const validSpy = cy.spy().as('validSpy');
 

--- a/components/PickerBase/PickerBase.styling.comp.cy.js
+++ b/components/PickerBase/PickerBase.styling.comp.cy.js
@@ -12,16 +12,138 @@ describe('Test the PickerBase component styling', () => {
   });
 
   /*
-   * There are 4 possibilities for styling...
+   * There are 8 possibilities for styling...
    *
-   * showValidityStyling    isValid   Tested by Test
-   * false                  false     1. Not showing, not valid
-   * false                  true      2. Not showing, valid
-   * true                   false     3. Showing, not valid
-   * true                   true      4. Showing, valid
+   * required   showValidityStyling    isValid   Tested by Test
+   * false      false                  false     5. Not required, Not showing, not valid
+   * false      false                  true      6. Not required, Not showing, valid
+   * false      true                   false     7. Not required, Showing, not valid
+   * false      true                   true      8. Not required, Showing, valid
+   * true       false                  false     5. Not required, Not showing, not valid
+   * true       false                  true      6. Not required, Not showing, valid
+   * true       true                   false     7. Not required, Showing, not valid
+   * true       true                   true      8. Not required, Showing, valid
    */
 
-  it.only('1. Not showing, not valid', () => {
+  it('1. Not required, Not showing, not valid', () => {
+    const readySpy = cy.spy().as('readySpy');
+
+    cy.mount(PickerBase, {
+      props: {
+        required: false,
+        showValidityStyling: false,
+        label: 'Picker',
+        options: ['Option 1', 'Option 2', 'Option 3', 'Option 4'],
+        invalidFeedbackText: 'Invalid feedback text.',
+        onReady: readySpy,
+      },
+    });
+
+    cy.get('@readySpy')
+      .should('have.been.calledOnce')
+      .then(() => {
+        cy.get('[data-cy="picker-options"]')
+          .find('input')
+          .eq(0)
+          .should('not.have.class', 'is-valid');
+        cy.get('[data-cy="picker-options"]')
+          .find('input')
+          .eq(0)
+          .should('not.have.class', 'is-invalid');
+        cy.get('[data-cy="picker-invalid-feedback"]').should('not.be.visible');
+      });
+  });
+
+  it('2. Not required, Not showing, valid', () => {
+    const readySpy = cy.spy().as('readySpy');
+
+    cy.mount(PickerBase, {
+      props: {
+        required: false,
+        showValidityStyling: false,
+        label: 'Picker',
+        options: ['Option 1', 'Option 2', 'Option 3', 'Option 4'],
+        picked: ['Option 1'],
+        invalidFeedbackText: 'Invalid feedback text.',
+        onReady: readySpy,
+      },
+    });
+
+    cy.get('@readySpy')
+      .should('have.been.calledOnce')
+      .then(() => {
+        cy.get('[data-cy="picker-options"]')
+          .find('input')
+          .eq(0)
+          .should('not.have.class', 'is-valid');
+        cy.get('[data-cy="picker-options"]')
+          .find('input')
+          .eq(0)
+          .should('not.have.class', 'is-invalid');
+        cy.get('[data-cy="picker-invalid-feedback"]').should('not.be.visible');
+      });
+  });
+
+  it('3. Not required, Showing, not valid', () => {
+    const readySpy = cy.spy().as('readySpy');
+
+    cy.mount(PickerBase, {
+      props: {
+        required: false,
+        showValidityStyling: true,
+        label: 'Picker',
+        options: ['Option 1', 'Option 2', 'Option 3', 'Option 4'],
+        invalidFeedbackText: 'Invalid feedback text.',
+        onReady: readySpy,
+      },
+    });
+
+    cy.get('@readySpy')
+      .should('have.been.calledOnce')
+      .then(() => {
+        cy.get('[data-cy="picker-options"]')
+          .find('input')
+          .eq(0)
+          .should('not.have.class', 'is-valid');
+        cy.get('[data-cy="picker-options"]')
+          .find('input')
+          .eq(0)
+          .should('not.have.class', 'is-invalid');
+        cy.get('[data-cy="picker-invalid-feedback"]').should('not.be.visible');
+      });
+  });
+
+  it('4. Not required, Showing, valid', () => {
+    const readySpy = cy.spy().as('readySpy');
+
+    cy.mount(PickerBase, {
+      props: {
+        required: false,
+        showValidityStyling: true,
+        label: 'Picker',
+        options: ['Option 1', 'Option 2', 'Option 3', 'Option 4'],
+        picked: ['Option 1'],
+        invalidFeedbackText: 'Invalid feedback text.',
+        onReady: readySpy,
+      },
+    });
+
+    cy.get('@readySpy')
+      .should('have.been.calledOnce')
+      .then(() => {
+        cy.get('[data-cy="picker-options"]')
+          .find('input')
+          .eq(0)
+          .should('have.class', 'is-valid');
+        cy.get('[data-cy="picker-options"]')
+          .find('input')
+          .eq(0)
+          .should('not.have.class', 'is-invalid');
+        cy.get('[data-cy="picker-invalid-feedback"]').should('not.be.visible');
+      });
+  });
+
+  it('5. Required, Not showing, not valid', () => {
     const readySpy = cy.spy().as('readySpy');
 
     cy.mount(PickerBase, {
@@ -38,11 +160,6 @@ describe('Test the PickerBase component styling', () => {
     cy.get('@readySpy')
       .should('have.been.calledOnce')
       .then(() => {
-        /*
-         * Just check the first option here.  The content test checked
-         * that styling was applied to all options.  So if it is applied
-         * to one it will be applied to the others.
-         */
         cy.get('[data-cy="picker-options"]')
           .find('input')
           .eq(0)
@@ -55,7 +172,7 @@ describe('Test the PickerBase component styling', () => {
       });
   });
 
-  it.only('2. Not showing, valid', () => {
+  it('6. Required, Not showing, valid', () => {
     const readySpy = cy.spy().as('readySpy');
 
     cy.mount(PickerBase, {
@@ -85,7 +202,7 @@ describe('Test the PickerBase component styling', () => {
       });
   });
 
-  it.only('3. Showing, not valid', () => {
+  it('7. Required, Showing, not valid', () => {
     const readySpy = cy.spy().as('readySpy');
 
     cy.mount(PickerBase, {
@@ -114,7 +231,7 @@ describe('Test the PickerBase component styling', () => {
       });
   });
 
-  it.only('4. Showing, valid', () => {
+  it('8. Required, Showing, valid', () => {
     const readySpy = cy.spy().as('readySpy');
 
     cy.mount(PickerBase, {

--- a/components/PickerBase/PickerBase.styling.comp.cy.js
+++ b/components/PickerBase/PickerBase.styling.comp.cy.js
@@ -14,24 +14,25 @@ describe('Test the PickerBase component styling', () => {
   /*
    * There are 8 possibilities for styling...
    *
-   * required   showValidityStyling    isValid   Tested by Test
-   * false      false                  false     5. Not required, Not showing, not valid
-   * false      false                  true      6. Not required, Not showing, valid
-   * false      true                   false     7. Not required, Showing, not valid
-   * false      true                   true      8. Not required, Showing, valid
-   * true       false                  false     5. Not required, Not showing, not valid
-   * true       false                  true      6. Not required, Not showing, valid
-   * true       true                   false     7. Not required, Showing, not valid
-   * true       true                   true      8. Not required, Showing, valid
+   * required   showValidityStyling    isEmpty   Tested by Test
+   * false      false                  false     5. Not required, Not showing, not empty
+   * false      false                  true      6. Not required, Not showing, empty
+   * false      true                   false     7. Not required, Showing, not empty
+   * false      true                   true      8. Not required, Showing, empty
+   * true       false                  false     5. Not required, Not showing, not empty
+   * true       false                  true      6. Not required, Not showing, empty
+   * true       true                   false     7. Not required, Showing, not empty
+   * true       true                   true      8. Not required, Showing, empty
    */
 
-  it('1. Not required, Not showing, not valid', () => {
+  it('1. Not required, Not showing, not empty', () => {
     const readySpy = cy.spy().as('readySpy');
 
     cy.mount(PickerBase, {
       props: {
         required: false,
         showValidityStyling: false,
+        picked: ['Option 1'],
         label: 'Picker',
         options: ['Option 1', 'Option 2', 'Option 3', 'Option 4'],
         invalidFeedbackText: 'Invalid feedback text.',
@@ -54,43 +55,14 @@ describe('Test the PickerBase component styling', () => {
       });
   });
 
-  it('2. Not required, Not showing, valid', () => {
+  it('2. Not required, Not showing, empty', () => {
     const readySpy = cy.spy().as('readySpy');
 
     cy.mount(PickerBase, {
       props: {
         required: false,
         showValidityStyling: false,
-        label: 'Picker',
-        options: ['Option 1', 'Option 2', 'Option 3', 'Option 4'],
-        picked: ['Option 1'],
-        invalidFeedbackText: 'Invalid feedback text.',
-        onReady: readySpy,
-      },
-    });
-
-    cy.get('@readySpy')
-      .should('have.been.calledOnce')
-      .then(() => {
-        cy.get('[data-cy="picker-options"]')
-          .find('input')
-          .eq(0)
-          .should('not.have.class', 'is-valid');
-        cy.get('[data-cy="picker-options"]')
-          .find('input')
-          .eq(0)
-          .should('not.have.class', 'is-invalid');
-        cy.get('[data-cy="picker-invalid-feedback"]').should('not.be.visible');
-      });
-  });
-
-  it('3. Not required, Showing, not valid', () => {
-    const readySpy = cy.spy().as('readySpy');
-
-    cy.mount(PickerBase, {
-      props: {
-        required: false,
-        showValidityStyling: true,
+        picked: [],
         label: 'Picker',
         options: ['Option 1', 'Option 2', 'Option 3', 'Option 4'],
         invalidFeedbackText: 'Invalid feedback text.',
@@ -113,16 +85,16 @@ describe('Test the PickerBase component styling', () => {
       });
   });
 
-  it('4. Not required, Showing, valid', () => {
+  it('3. Not required, Showing, not empty', () => {
     const readySpy = cy.spy().as('readySpy');
 
     cy.mount(PickerBase, {
       props: {
         required: false,
         showValidityStyling: true,
+        picked: ['Option 1'],
         label: 'Picker',
         options: ['Option 1', 'Option 2', 'Option 3', 'Option 4'],
-        picked: ['Option 1'],
         invalidFeedbackText: 'Invalid feedback text.',
         onReady: readySpy,
       },
@@ -143,13 +115,14 @@ describe('Test the PickerBase component styling', () => {
       });
   });
 
-  it('5. Required, Not showing, not valid', () => {
+  it('4. Not required, Showing, empty', () => {
     const readySpy = cy.spy().as('readySpy');
 
     cy.mount(PickerBase, {
       props: {
-        required: true,
-        showValidityStyling: false,
+        required: false,
+        showValidityStyling: true,
+        picked: [],
         label: 'Picker',
         options: ['Option 1', 'Option 2', 'Option 3', 'Option 4'],
         invalidFeedbackText: 'Invalid feedback text.',
@@ -172,16 +145,16 @@ describe('Test the PickerBase component styling', () => {
       });
   });
 
-  it('6. Required, Not showing, valid', () => {
+  it('5. Required, Not showing, not empty', () => {
     const readySpy = cy.spy().as('readySpy');
 
     cy.mount(PickerBase, {
       props: {
         required: true,
         showValidityStyling: false,
-        label: 'Picker',
-        options: ['Option 1', 'Option 2', 'Option 3', 'Option 4'],
         picked: ['Option 1'],
+        label: 'Picker',
+        options: ['Option 1', 'Option 2', 'Option 3', 'Option 4'],
         invalidFeedbackText: 'Invalid feedback text.',
         onReady: readySpy,
       },
@@ -202,13 +175,74 @@ describe('Test the PickerBase component styling', () => {
       });
   });
 
-  it('7. Required, Showing, not valid', () => {
+  it('6. Required, Not showing, empty', () => {
+    const readySpy = cy.spy().as('readySpy');
+
+    cy.mount(PickerBase, {
+      props: {
+        required: true,
+        showValidityStyling: false,
+        picked: [],
+        label: 'Picker',
+        options: ['Option 1', 'Option 2', 'Option 3', 'Option 4'],
+        invalidFeedbackText: 'Invalid feedback text.',
+        onReady: readySpy,
+      },
+    });
+
+    cy.get('@readySpy')
+      .should('have.been.calledOnce')
+      .then(() => {
+        cy.get('[data-cy="picker-options"]')
+          .find('input')
+          .eq(0)
+          .should('not.have.class', 'is-valid');
+        cy.get('[data-cy="picker-options"]')
+          .find('input')
+          .eq(0)
+          .should('not.have.class', 'is-invalid');
+        cy.get('[data-cy="picker-invalid-feedback"]').should('not.be.visible');
+      });
+  });
+
+  it('7. Required, Showing, not empty', () => {
     const readySpy = cy.spy().as('readySpy');
 
     cy.mount(PickerBase, {
       props: {
         required: true,
         showValidityStyling: true,
+        picked: ['Option 1'],
+        label: 'Picker',
+        options: ['Option 1', 'Option 2', 'Option 3', 'Option 4'],
+        invalidFeedbackText: 'Invalid feedback text.',
+        onReady: readySpy,
+      },
+    });
+
+    cy.get('@readySpy')
+      .should('have.been.calledOnce')
+      .then(() => {
+        cy.get('[data-cy="picker-options"]')
+          .find('input')
+          .eq(0)
+          .should('have.class', 'is-valid');
+        cy.get('[data-cy="picker-options"]')
+          .find('input')
+          .eq(0)
+          .should('not.have.class', 'is-invalid');
+        cy.get('[data-cy="picker-invalid-feedback"]').should('not.be.visible');
+      });
+  });
+
+  it('8. Required, Showing, empty', () => {
+    const readySpy = cy.spy().as('readySpy');
+
+    cy.mount(PickerBase, {
+      props: {
+        required: true,
+        showValidityStyling: true,
+        picked: [],
         label: 'Picker',
         options: ['Option 1', 'Option 2', 'Option 3', 'Option 4'],
         invalidFeedbackText: 'Invalid feedback text.',
@@ -228,36 +262,6 @@ describe('Test the PickerBase component styling', () => {
           .eq(0)
           .should('have.class', 'is-invalid');
         cy.get('[data-cy="picker-invalid-feedback"]').should('be.visible');
-      });
-  });
-
-  it('8. Required, Showing, valid', () => {
-    const readySpy = cy.spy().as('readySpy');
-
-    cy.mount(PickerBase, {
-      props: {
-        required: true,
-        showValidityStyling: true,
-        label: 'Picker',
-        options: ['Option 1', 'Option 2', 'Option 3', 'Option 4'],
-        picked: ['Option 1'],
-        invalidFeedbackText: 'Invalid feedback text.',
-        onReady: readySpy,
-      },
-    });
-
-    cy.get('@readySpy')
-      .should('have.been.calledOnce')
-      .then(() => {
-        cy.get('[data-cy="picker-options"]')
-          .find('input')
-          .eq(0)
-          .should('have.class', 'is-valid');
-        cy.get('[data-cy="picker-options"]')
-          .find('input')
-          .eq(0)
-          .should('not.have.class', 'is-invalid');
-        cy.get('[data-cy="picker-invalid-feedback"]').should('not.be.visible');
       });
   });
 });

--- a/components/PickerBase/PickerBase.vue
+++ b/components/PickerBase/PickerBase.vue
@@ -178,10 +178,14 @@ export default {
     },
     // Controls component styling (i.e. when green check or red X and invalid feedback) should be displayed.
     validationStyling() {
-      if (!this.showValidityStyling) {
-        return null;
+      if (this.showValidityStyling) {
+        if (!this.required && this.checked.length == 0) {
+          return null;
+        } else {
+          return this.isValid;
+        }
       } else {
-        return this.isValid;
+        return null;
       }
     },
   },

--- a/components/README.md
+++ b/components/README.md
@@ -94,12 +94,12 @@ Custom FarmData2 Vue Components.
       - If the component is required then blank/empty/no value/etc is not considered a valid value.
     - The submit function in the page will use this value to determine if the submit button should be enabled or disabled and whether or not to add non-required fields to the submission.
 
-  - The component indicates the type of styling to be used using its `invalidStyling` computed property.
+  - The component indicates the type of styling to be used using its `validityStyling` computed property.
 
     - This function returns:
       - `true` to apply valid styling (green check)
       - `false` to apply invalid styling (red x and invalidFeedbackText)
-      - `null` to not apply either styling. This should be applied when showValidityStyling is set false, and also non-required inputs that are blank.
+      - `null` to not apply either styling. This should be applied when showValidityStyling is set false, and also to non-required inputs that are blank/empty.
 
   - The `showValidityStyling` prop should be is set by the entry point to
     - `true` when "Submit" is clicked

--- a/components/README.md
+++ b/components/README.md
@@ -257,7 +257,8 @@ Use: `cy.task('logObject', obj)` to log an object to the console.
   - check events (`*.events.comp.cy.js`)
 
     - check that all events listed in the component's `emits` property are emitted properly
-      - At least one test per event.
+      - If the component computes `isValid` for itself then the `valid` event should be tested exhaustively.
+      - At least one test per event for all other events:
         - Do something that should cause the event to be emitted.
           - e.g. change the selection, type some text, etc...
           - e.g. Use `cy.intercept` to generate network errors on the appropriate route.

--- a/components/SelectorBase/SelectorBase.events.comp.cy.js
+++ b/components/SelectorBase/SelectorBase.events.comp.cy.js
@@ -11,7 +11,41 @@ describe('Test the SelectorBase component events', () => {
     cy.saveSessionStorage();
   });
 
-  it('Emits "valid" true on creation when not required', () => {
+  /**
+   * Does 4 checks on validity computation
+   *
+   * required   empty     test
+   * false      false     1. valid event: Not required, not empty
+   * false      true      2. valid event: Not required, empty
+   * true       false     3. valid event: Required, not empty
+   * true       true      4. valid event: Required, empty
+   */
+
+  it('1. valid event: Not required, not empty', () => {
+    const readySpy = cy.spy().as('readySpy');
+    const validSpy = cy.spy().as('validSpy');
+
+    cy.mount(SelectorBase, {
+      props: {
+        invalidFeedbackText: 'Invalid feedback text.',
+        label: `TheLabel`,
+        required: false,
+        options: ['One', 'Two', 'Three', 'Four', 'Five'],
+        selected: ['One'],
+        onReady: readySpy,
+        onValid: validSpy,
+      },
+    });
+
+    cy.get('@readySpy')
+      .should('have.been.calledOnce')
+      .then(() => {
+        cy.get('@validSpy').should('have.been.calledOnce');
+        cy.get('@validSpy').should('have.been.calledWith', true);
+      });
+  });
+
+  it('2. valid event: Not required, empty', () => {
     const readySpy = cy.spy().as('readySpy');
     const validSpy = cy.spy().as('validSpy');
 
@@ -34,7 +68,31 @@ describe('Test the SelectorBase component events', () => {
       });
   });
 
-  it('Emits "valid" false on creation when required and no selection given', () => {
+  it('3. valid event: Required, Not empty', () => {
+    const readySpy = cy.spy().as('readySpy');
+    const validSpy = cy.spy().as('validSpy');
+
+    cy.mount(SelectorBase, {
+      props: {
+        invalidFeedbackText: 'Invalid feedback text.',
+        label: `TheLabel`,
+        required: true,
+        options: ['One', 'Two', 'Three', 'Four', 'Five'],
+        selected: ['One'],
+        onReady: readySpy,
+        onValid: validSpy,
+      },
+    });
+
+    cy.get('@readySpy')
+      .should('have.been.calledOnce')
+      .then(() => {
+        cy.get('@validSpy').should('have.been.calledOnce');
+        cy.get('@validSpy').should('have.been.calledWith', true);
+      });
+  });
+
+  it('4. valid event: Required, empty', () => {
     const readySpy = cy.spy().as('readySpy');
     const validSpy = cy.spy().as('validSpy');
 
@@ -54,30 +112,6 @@ describe('Test the SelectorBase component events', () => {
       .then(() => {
         cy.get('@validSpy').should('have.been.calledOnce');
         cy.get('@validSpy').should('have.been.calledWith', false);
-      });
-  });
-
-  it('Emits "valid" true on creation when required and selection given', () => {
-    const readySpy = cy.spy().as('readySpy');
-    const validSpy = cy.spy().as('validSpy');
-
-    cy.mount(SelectorBase, {
-      props: {
-        invalidFeedbackText: 'Invalid feedback text.',
-        label: `TheLabel`,
-        required: true,
-        options: ['One', 'Two', 'Three', 'Four', 'Five'],
-        selected: 'One',
-        onReady: readySpy,
-        onValid: validSpy,
-      },
-    });
-
-    cy.get('@readySpy')
-      .should('have.been.calledOnce')
-      .then(() => {
-        cy.get('@validSpy').should('have.been.calledOnce');
-        cy.get('@validSpy').should('have.been.calledWith', true);
       });
   });
 

--- a/components/SelectorBase/SelectorBase.styling.comp.cy.js
+++ b/components/SelectorBase/SelectorBase.styling.comp.cy.js
@@ -12,16 +12,143 @@ describe('Test the styling of the SelectorBase component', () => {
   });
 
   /*
-   * There are 4 possibilities for styling...
+   * There are 8 possibilities for styling...
    *
-   * showValidityStyling    isValid   Tested by Test
-   * false                  false     1. Not showing, not valid
-   * false                  true      2. Not showing, valid
-   * true                   false     3. Showing, not valid
-   * true                   true      4. Showing, valid
+   * required   showValidityStyling    empty     Tested by Test
+   * false      false                  false     1. Not required, not showing, not empty
+   * false      false                  true      2. Not required, not showing, empty
+   * false      true                   false     3. Not required, showing, not empty
+   * false      true                   true      4. Not required, showing, empty
+   * true       false                  false     5. required, not showing, not empty
+   * true       false                  true      6. required, not showing, empty
+   * true       true                   false     7. required, showing, not empty
+   * true       true                   true      8. required, showing, empty
    */
 
-  it('1. Not showing, not valid', () => {
+  it('1. Not required, not showing, not empty', () => {
+    const readySpy = cy.spy().as('readySpy');
+
+    cy.mount(SelectorBase, {
+      props: {
+        required: false,
+        showValidityStyling: false,
+        invalidFeedbackText: 'Invalid feedback text.',
+        label: `TheLabel`,
+        options: ['One', 'Two', 'Three', 'Four', 'Five'],
+        selected: 'One',
+        onReady: readySpy,
+      },
+    });
+
+    cy.get('@readySpy')
+      .should('have.been.calledOnce')
+      .then(() => {
+        cy.get('[data-cy="selector-input"]').should(
+          'not.have.class',
+          'is-valid'
+        );
+        cy.get('[data-cy="selector-input"]').should(
+          'not.have.class',
+          'is-invalid'
+        );
+        cy.get('[data-cy="selector-invalid-feedback"]').should(
+          'not.be.visible'
+        );
+      });
+  });
+
+  it('2. Not required, not showing, empty', () => {
+    const readySpy = cy.spy().as('readySpy');
+
+    cy.mount(SelectorBase, {
+      props: {
+        required: false,
+        showValidityStyling: false,
+        invalidFeedbackText: 'Invalid feedback text.',
+        label: `TheLabel`,
+        options: ['One', 'Two', 'Three', 'Four', 'Five'],
+        onReady: readySpy,
+      },
+    });
+
+    cy.get('@readySpy')
+      .should('have.been.calledOnce')
+      .then(() => {
+        cy.get('[data-cy="selector-input"]').should(
+          'not.have.class',
+          'is-valid'
+        );
+        cy.get('[data-cy="selector-input"]').should(
+          'not.have.class',
+          'is-invalid'
+        );
+        cy.get('[data-cy="selector-invalid-feedback"]').should(
+          'not.be.visible'
+        );
+      });
+  });
+
+  it('3. Not required, showing, not empty', () => {
+    const readySpy = cy.spy().as('readySpy');
+
+    cy.mount(SelectorBase, {
+      props: {
+        required: false,
+        showValidityStyling: true,
+        invalidFeedbackText: 'Invalid feedback text.',
+        label: `TheLabel`,
+        options: ['One', 'Two', 'Three', 'Four', 'Five'],
+        selected: 'One',
+        onReady: readySpy,
+      },
+    });
+
+    cy.get('@readySpy')
+      .should('have.been.calledOnce')
+      .then(() => {
+        cy.get('[data-cy="selector-input"]').should('have.class', 'is-valid');
+        cy.get('[data-cy="selector-input"]').should(
+          'not.have.class',
+          'is-invalid'
+        );
+        cy.get('[data-cy="selector-invalid-feedback"]').should(
+          'not.be.visible'
+        );
+      });
+  });
+
+  it('4. Not required, showing, empty', () => {
+    const readySpy = cy.spy().as('readySpy');
+
+    cy.mount(SelectorBase, {
+      props: {
+        required: false,
+        showValidityStyling: true,
+        invalidFeedbackText: 'Invalid feedback text.',
+        label: `TheLabel`,
+        options: ['One', 'Two', 'Three', 'Four', 'Five'],
+        onReady: readySpy,
+      },
+    });
+
+    cy.get('@readySpy')
+      .should('have.been.calledOnce')
+      .then(() => {
+        cy.get('[data-cy="selector-input"]').should(
+          'not.have.class',
+          'is-valid'
+        );
+        cy.get('[data-cy="selector-input"]').should(
+          'not.have.class',
+          'is-invalid'
+        );
+        cy.get('[data-cy="selector-invalid-feedback"]').should(
+          'not.be.visible'
+        );
+      });
+  });
+
+  it('5. Required, not showing, not empty', () => {
     const readySpy = cy.spy().as('readySpy');
 
     cy.mount(SelectorBase, {
@@ -52,7 +179,7 @@ describe('Test the styling of the SelectorBase component', () => {
       });
   });
 
-  it('2. Not showing, valid', () => {
+  it('6. Required, not showing, empty', () => {
     const readySpy = cy.spy().as('readySpy');
 
     cy.mount(SelectorBase, {
@@ -84,7 +211,7 @@ describe('Test the styling of the SelectorBase component', () => {
       });
   });
 
-  it('3. Showing, not valid', () => {
+  it('7. Required, showing, not empty', () => {
     const readySpy = cy.spy().as('readySpy');
 
     cy.mount(SelectorBase, {
@@ -110,7 +237,7 @@ describe('Test the styling of the SelectorBase component', () => {
       });
   });
 
-  it('4. Showing, valid', () => {
+  it('8. Required, showing, empty', () => {
     const readySpy = cy.spy().as('readySpy');
 
     cy.mount(SelectorBase, {

--- a/components/SelectorBase/SelectorBase.vue
+++ b/components/SelectorBase/SelectorBase.vue
@@ -22,7 +22,7 @@
           id="selector-input"
           data-cy="selector-input"
           v-model="selectedOption"
-          v-bind:state="validationStyling"
+          v-bind:state="validityStyling"
           v-bind:required="required"
         >
           <template v-slot:first>
@@ -78,7 +78,7 @@
         <BFormInvalidFeedback
           id="selector-invalid-feedback"
           data-cy="selector-invalid-feedback"
-          v-bind:state="validationStyling"
+          v-bind:state="validityStyling"
         >
           {{ invalidFeedbackText }}
         </BFormInvalidFeedback>
@@ -207,17 +207,24 @@ export default {
     };
   },
   computed: {
+    isEmpty() {
+      return this.selectedOption == null || this.selectedOption == '';
+    },
     isValid() {
       if (this.required) {
-        return this.selectedOption != null && this.selectedOption != '';
+        return !this.isEmpty;
       } else {
         return true;
       }
     },
     // Controls component styling (i.e. when green check or red X and invalid feedback) should be displayed.
-    validationStyling() {
+    validityStyling() {
       if (this.showValidityStyling) {
-        return this.isValid;
+        if (!this.required && this.isEmpty) {
+          return null;
+        } else {
+          return this.isValid;
+        }
       } else {
         return null;
       }


### PR DESCRIPTION
**Pull Request Description**

Updates the computation of `showValidityStyling` in components such that invalid styling is not shown when non-required values are empty.

Closes #165 

---

**Licensing Certification**

FarmData2 is a [Free Cultural Work](https://freedomdefined.org/Definition) and all accepted contributions are licensed as described in the LICENSE.md file. This requires that the contributor holds the rights to do so. By submitting this pull request **I certify that I satisfy the terms of the [Developer Certificate of Origin](https://developercertificate.org/)** for its contents.
