### PR TITLE
refactor: switches to pgrep for finding servers

### DIFF
--- a/.fd2-cspell.txt
+++ b/.fd2-cspell.txt
@@ -33,6 +33,7 @@ newgrp
 novnc
 PASA
 pgid
+pgrep
 Picklist
 pietmichal
 Pietraszko

--- a/bin/killZombieServers.bash
+++ b/bin/killZombieServers.bash
@@ -1,5 +1,5 @@
 # shellcheck disable=SC2009
-PIDs=$(ps -aux | grep "vite.config.js build --watch$" | tr -s " " | cut -d " " -f 2)
+PIDs=$(pgrep -f "vite.config.js")
 
 for pid in $PIDs; do
   echo "Killing process: $pid"


### PR DESCRIPTION
Switches the `killZombieServers.bash` script to use `pgrep` instead of `grep`ing `ps -ax` as it gives a cleaner result.

---

**Licensing Certification**

FarmData2 is a [Free Cultural Work](https://freedomdefined.org/Definition) and all accepted contributions are licensed as described in the LICENSE.md file. This requires that the contributor holds the rights to do so. By submitting this pull request **I certify that I satisfy the terms of the [Developer Certificate of Origin](https://developercertificate.org/)** for its contents.
