### PR TITLE
feat(dev): adds the vue force dev plugin to firefox

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -38,7 +38,7 @@ services:
     depends_on:
       - db
       - farmos
-    image: farmdata2/fd2dev:fd2.7
+    image: farmdata2/fd2dev:fd2.8
     container_name: fd2_dev
     init: true
     volumes:


### PR DESCRIPTION
**Pull Request Description**

Updates `docker/docker-compose.yml` to use a new `fd2dev` image that includes the Vue force dev plugin.  This plugin enables developer mode for all pages.  This allows the Vue dev tools to be used on pages running within farmOS.  This simplifies the development environment by allowing all work to occur within the live FD2 within farmOS.

Closes #133

---

**Licensing Certification**

FarmData2 is a [Free Cultural Work](https://freedomdefined.org/Definition) and all accepted contributions are licensed as described in the LICENSE.md file. This requires that the contributor holds the rights to do so. By submitting this pull request **I certify that I satisfy the terms of the [Developer Certificate of Origin](https://developercertificate.org/)** for its contents.

Co-authored-by: Jingyu (Marcel) Lee <46755208+JingyuMarcelLee@users.noreply.github.com>