### PR TITLE
feat(fd2): submit tray and direct seedings forms as a transaction

### DIFF
--- a/library/farmosUtil/farmosUtil.transaction.unit.cy.js
+++ b/library/farmosUtil/farmosUtil.transaction.unit.cy.js
@@ -21,8 +21,8 @@ describe('Test the plant asset functions', () => {
 
   const op2 = {
     name: 'op2',
-    create: async () => {
-      return { status: 'op2 success', id: '2', attributes: { name: 'op2' } };
+    create: async (results) => {
+      return { status: 'op2 success', id: '2', attributes: { name: 'op2' }, prior: results.op1.attributes.name };
     },
     delete: async () => {},
   };
@@ -57,6 +57,7 @@ describe('Test the plant asset functions', () => {
     cy.get('@result').then((result) => {
       expect(result.op1.status).to.equal('op1 success');
       expect(result.op2.status).to.equal('op2 success');
+      expect(result.op2.prior).to.equal('op1');
     });
   });
 
@@ -71,8 +72,8 @@ describe('Test the plant asset functions', () => {
         })
         .catch((error) => {
           expect(error.message).to.equal('Error running transaction.');
-          expect(error.result.op1).to.be.null;
-          expect(error.result.op2).to.be.null;
+          expect(error.results.op1).to.be.null;
+          expect(error.results.op2).to.be.null;
         })
     );
   });
@@ -88,11 +89,11 @@ describe('Test the plant asset functions', () => {
         })
         .catch((error) => {
           expect(error.message).to.contain('Error running transaction.');
-          expect(error.result.op1).to.be.null;
-          expect(error.result.badDelete).not.to.be.null;
-          expect(error.result.badDelete.attributes.name).to.equal('badDelete');
-          expect(error.result.op2).to.be.null;
-          expect(error.result.badOp).to.be.null;
+          expect(error.results.op1).to.be.null;
+          expect(error.results.badDelete).not.to.be.null;
+          expect(error.results.badDelete.attributes.name).to.equal('badDelete');
+          expect(error.results.op2).to.be.null;
+          expect(error.results.badOp).to.be.null;
         })
     );
   });
@@ -157,9 +158,9 @@ describe('Test the plant asset functions', () => {
       })
       .catch((error) => {
         expect(error.message).to.equal('Error running transaction.');
-        expect(error.result.op1).to.be.null;
-        expect(error.result.createPlantAsset).to.be.null;
-        expect(error.result.badOp).to.be.null;
+        expect(error.results.op1).to.be.null;
+        expect(error.results.createPlantAsset).to.be.null;
+        expect(error.results.badOp).to.be.null;
       });
   });
 });

--- a/library/farmosUtil/farmosUtil.transaction.unit.cy.js
+++ b/library/farmosUtil/farmosUtil.transaction.unit.cy.js
@@ -71,6 +71,8 @@ describe('Test the plant asset functions', () => {
         })
         .catch((error) => {
           expect(error.message).to.equal('Error running transaction.');
+          expect(error.result.op1).to.be.null;
+          expect(error.result.op2).to.be.null;
         })
     );
   });
@@ -86,10 +88,11 @@ describe('Test the plant asset functions', () => {
         })
         .catch((error) => {
           expect(error.message).to.contain('Error running transaction.');
-          expect(error.message).to.contain(
-            'Delete the following logs or assets:'
-          );
-          expect(error.message).to.contain('badDelete');
+          expect(error.result.op1).to.be.null;
+          expect(error.result.badDelete).not.to.be.null;
+          expect(error.result.badDelete.attributes.name).to.equal('badDelete');
+          expect(error.result.op2).to.be.null;
+          expect(error.result.badOp).to.be.null;
         })
     );
   });
@@ -154,6 +157,9 @@ describe('Test the plant asset functions', () => {
       })
       .catch((error) => {
         expect(error.message).to.equal('Error running transaction.');
+        expect(error.result.op1).to.be.null;
+        expect(error.result.createPlantAsset).to.be.null;
+        expect(error.result.badOp).to.be.null;
       });
   });
 });

--- a/library/farmosUtil/farmosUtil.transaction.unit.cy.js
+++ b/library/farmosUtil/farmosUtil.transaction.unit.cy.js
@@ -70,7 +70,7 @@ describe('Test the plant asset functions', () => {
           throw new Error('Transaction should have failed.');
         })
         .catch((error) => {
-          expect(error.message).to.contain('Error running transaction.');
+          expect(error.message).to.equal('Error running transaction.');
         })
     );
   });
@@ -92,5 +92,68 @@ describe('Test the plant asset functions', () => {
           expect(error.message).to.contain('badDelete');
         })
     );
+  });
+
+  it('Successful transaction in farmOS', () => {
+    const formData = {
+      cropName: 'ARUGULA',
+      comment: 'test comment',
+    };
+    const assetName = 'test asset';
+
+    const createPlantAsset = {
+      name: 'createPlantAsset',
+      create: async () => {
+        return await farmosUtil.createPlantAsset(
+          assetName,
+          formData.cropName,
+          formData.comment
+        );
+      },
+      delete: async (uuid) => {
+        await farmosUtil.deletePlantAsset(uuid);
+      },
+    };
+
+    const ops = [op1, createPlantAsset, op2];
+
+    cy.wrap(farmosUtil.runTransaction(ops)).as('result');
+
+    cy.get('@result').then((result) => {
+      expect(result.createPlantAsset.attributes.name).to.equal(assetName);
+    });
+  });
+
+  it('Failed transaction in farmOS', () => {
+    const formData = {
+      cropName: 'WATERMELON',
+      comment: 'test comment',
+    };
+    const assetName = 'test asset';
+
+    const createPlantAsset = {
+      name: 'createPlantAsset',
+      create: async () => {
+        return await farmosUtil.createPlantAsset(
+          assetName,
+          formData.cropName,
+          formData.comment
+        );
+      },
+      delete: async (uuid) => {
+        await farmosUtil.deletePlantAsset(uuid);
+      },
+    };
+
+    const ops = [op1, createPlantAsset, badOp];
+
+    farmosUtil
+      .runTransaction(ops)
+      .then(() => {
+        throw new Error('Transaction should have failed.');
+      })
+      .catch((error) => {
+        expect(error.message).to.equal('Error running transaction.');
+      });
   });
 });

--- a/library/farmosUtil/farmosUtil.transaction.unit.cy.js
+++ b/library/farmosUtil/farmosUtil.transaction.unit.cy.js
@@ -1,0 +1,96 @@
+import * as farmosUtil from './farmosUtil.js';
+
+describe('Test the plant asset functions', () => {
+  beforeEach(() => {
+    cy.restoreLocalStorage();
+    cy.restoreSessionStorage();
+  });
+
+  afterEach(() => {
+    cy.saveLocalStorage();
+    cy.saveSessionStorage();
+  });
+
+  const op1 = {
+    name: 'op1',
+    create: async () => {
+      return { status: 'op1 success', id: '1', attributes: { name: 'op1' } };
+    },
+    delete: async () => {},
+  };
+
+  const op2 = {
+    name: 'op2',
+    create: async () => {
+      return { status: 'op2 success', id: '2', attributes: { name: 'op2' } };
+    },
+    delete: async () => {},
+  };
+
+  const badOp = {
+    name: 'badOp',
+    create: async () => {
+      throw new Error('badOp error');
+    },
+    delete: async () => {},
+  };
+
+  const badDelete = {
+    name: 'badDelete',
+    create: async () => {
+      return {
+        status: 'badDelete success',
+        id: '3',
+        attributes: { name: 'badDelete' },
+      };
+    },
+    delete: async () => {
+      throw new Error('badDelete error');
+    },
+  };
+
+  it('Successful transaction', () => {
+    const ops = [op1, op2];
+
+    cy.wrap(farmosUtil.runTransaction(ops)).as('result');
+
+    cy.get('@result').then((result) => {
+      expect(result.op1.status).to.equal('op1 success');
+      expect(result.op2.status).to.equal('op2 success');
+    });
+  });
+
+  it('Failed transaction with successful deletes', () => {
+    const ops = [op1, op2, badOp];
+
+    cy.wrap(
+      farmosUtil
+        .runTransaction(ops)
+        .then(() => {
+          throw new Error('Transaction should have failed.');
+        })
+        .catch((error) => {
+          expect(error.message).to.contain('Error running transaction.');
+        })
+    );
+  });
+
+  it('Failed transaction with failed deletes', () => {
+    const ops = [op1, badDelete, op2, badOp];
+
+    cy.wrap(
+      farmosUtil
+        .runTransaction(ops)
+        .then(() => {
+          throw new Error('Transaction should have failed.');
+        })
+        .catch((error) => {
+          expect(error.message).to.contain('Error running transaction.');
+          expect(error.message).to.contain(
+            'Delete the following logs or assets:'
+          );
+          expect(error.message).to.contain('badDelete');
+        })
+    );
+  });
+});

--- a/modules/farm_fd2/src/entrypoints/direct_seeding/lib.js
+++ b/modules/farm_fd2/src/entrypoints/direct_seeding/lib.js
@@ -26,210 +26,229 @@ import * as farmosUtil from '@libs/farmosUtil/farmosUtil';
  * @throws {Error} if an error occurs while creating the farmOS records.
  */
 export async function submitForm(formData) {
-  let plantAsset = null;
-  let bedFeetQuantity = null;
-  let rowsPerBedQuantity = null;
-  let rowFeetQuantity = null;
-  let bedWidthQuantity = null;
-  let seedingLog = null;
-  let equipmentAssets = [];
-  let depthQuantity = null;
-  let speedQuantity = null;
-  let areaQuantity = null;
-  let activityLog = null;
-
   try {
     const assetName = formData.seedingDate + '_ds_' + formData.cropName;
+    const ops = [];
+    const equipmentAssets = [];
 
-    plantAsset = await farmosUtil.createPlantAsset(
-      assetName,
-      formData.cropName,
-      formData.comment
-    );
+    const plantAsset = {
+      name: 'plantAsset',
+      create: async () => {
+        return await farmosUtil.createPlantAsset(
+          assetName,
+          formData.cropName,
+          formData.comment
+        );
+      },
+      delete: async (uuid) => {
+        await farmosUtil.deletePlantAsset(uuid);
+      },
+    };
+    ops.push(plantAsset);
 
-    bedFeetQuantity = await farmosUtil.createStandardQuantity(
-      'length',
-      formData.bedFeet,
-      'Bed Feet',
-      'FEET'
-    );
+    const bedFeetQuantity = {
+      name: 'bedFeetQuantity',
+      create: async () => {
+        return await farmosUtil.createStandardQuantity(
+          'length',
+          formData.bedFeet,
+          'Bed Feet',
+          'FEET'
+        );
+      },
+      delete: async (uuid) => {
+        await farmosUtil.deleteStandardQuantity(uuid);
+      },
+    };
+    ops.push(bedFeetQuantity);
 
-    rowsPerBedQuantity = await farmosUtil.createStandardQuantity(
-      'ratio',
-      formData.rowsPerBed,
-      'Rows/Bed',
-      'ROWS/BED'
-    );
+    const rowsPerBedQuantity = {
+      name: 'rowsPerBedQuantity',
+      create: async () => {
+        return await farmosUtil.createStandardQuantity(
+          'ratio',
+          formData.rowsPerBed,
+          'Rows/Bed',
+          'ROWS/BED'
+        );
+      },
+      delete: async (uuid) => {
+        await farmosUtil.deleteStandardQuantity(uuid);
+      },
+    };
+    ops.push(rowsPerBedQuantity);
 
-    rowFeetQuantity = await farmosUtil.createStandardQuantity(
-      'length',
-      formData.bedFeet * formData.rowsPerBed,
-      'Row Feet',
-      'FEET',
-      plantAsset,
-      'increment'
-    );
+    const rowFeetQuantity = {
+      name: 'rowFeetQuantity',
+      create: async (results) => {
+        return await farmosUtil.createStandardQuantity(
+          'length',
+          formData.bedFeet * formData.rowsPerBed,
+          'Row Feet',
+          'FEET',
+          results.plantAsset,
+          'increment'
+        );
+      },
+      delete: async (uuid) => {
+        await farmosUtil.deleteStandardQuantity(uuid);
+      },
+    };
+    ops.push(rowFeetQuantity);
 
-    bedWidthQuantity = await farmosUtil.createStandardQuantity(
-      'length',
-      formData.bedWidth,
-      'Bed Width',
-      'INCHES'
-    );
+    const bedWidthQuantity = {
+      name: 'bedWidthQuantity',
+      create: async () => {
+        return await farmosUtil.createStandardQuantity(
+          'length',
+          formData.bedWidth,
+          'Bed Width',
+          'INCHES'
+        );
+      },
+      delete: async (uuid) => {
+        await farmosUtil.deleteStandardQuantity(uuid);
+      },
+    };
+    ops.push(bedWidthQuantity);
 
-    seedingLog = await farmosUtil.createSeedingLog(
-      formData.seedingDate,
-      formData.locationName,
-      formData.beds,
-      ['seeding', 'seeding_direct'],
-      plantAsset,
-      [bedFeetQuantity, rowsPerBedQuantity, rowFeetQuantity, bedWidthQuantity]
-    );
+    const seedingLog = {
+      name: 'seedingLog',
+      create: async (results) => {
+        return await farmosUtil.createSeedingLog(
+          formData.seedingDate,
+          formData.locationName,
+          formData.beds,
+          ['seeding', 'seeding_direct'],
+          results.plantAsset,
+          [
+            results.bedFeetQuantity,
+            results.rowsPerBedQuantity,
+            results.rowFeetQuantity,
+            results.bedWidthQuantity,
+          ]
+        );
+      },
+      delete: async (uuid) => {
+        await farmosUtil.deleteSeedingLog(uuid);
+      },
+    };
+    ops.push(seedingLog);
 
     if (formData.equipment.length > 0) {
-      depthQuantity = await farmosUtil.createStandardQuantity(
-        'length',
-        formData.depth,
-        'Depth',
-        'INCHES'
-      );
+      const depthQuantity = {
+        name: 'depthQuantity',
+        create: async () => {
+          return await farmosUtil.createStandardQuantity(
+            'length',
+            formData.depth,
+            'Depth',
+            'INCHES'
+          );
+        },
+        delete: async (uuid) => {
+          await farmosUtil.deleteStandardQuantity(uuid);
+        },
+      };
+      ops.push(depthQuantity);
 
-      speedQuantity = await farmosUtil.createStandardQuantity(
-        'rate',
-        formData.speed,
-        'Speed',
-        'MPH'
-      );
+      const speedQuantity = {
+        name: 'speedQuantity',
+        create: async () => {
+          return await farmosUtil.createStandardQuantity(
+            'rate',
+            formData.speed,
+            'Speed',
+            'MPH'
+          );
+        },
+        delete: async (uuid) => {
+          await farmosUtil.deleteStandardQuantity(uuid);
+        },
+      };
+      ops.push(speedQuantity);
 
-      areaQuantity = await farmosUtil.createStandardQuantity(
-        'ratio',
-        formData.area,
-        'Area',
-        'PERCENT'
-      );
+      const areaQuantity = {
+        name: 'areaQuantity',
+        create: async () => {
+          return await farmosUtil.createStandardQuantity(
+            'ratio',
+            formData.area,
+            'Area',
+            'PERCENT'
+          );
+        },
+        delete: async (uuid) => {
+          await farmosUtil.deleteStandardQuantity(uuid);
+        },
+      };
+      ops.push(areaQuantity);
 
       const equipmentMap = await farmosUtil.getEquipmentNameToAssetMap();
       for (const equipmentName of formData.equipment) {
         equipmentAssets.push(equipmentMap.get(equipmentName));
       }
 
-      activityLog = await farmosUtil.createSoilDisturbanceActivityLog(
-        formData.seedingDate,
-        formData.locationName,
-        formData.beds,
-        ['tillage', 'seeding_direct'],
-        plantAsset,
-        [depthQuantity, speedQuantity, areaQuantity],
-        equipmentAssets
-      );
+      const activityLog = {
+        name: 'activityLog',
+        create: async (results) => {
+          return await farmosUtil.createSoilDisturbanceActivityLog(
+            formData.seedingDate,
+            formData.locationName,
+            formData.beds,
+            ['tillage', 'seeding_direct'],
+            results.plantAsset,
+            [
+              results.depthQuantity,
+              results.speedQuantity,
+              results.areaQuantity,
+            ],
+            equipmentAssets
+          );
+        },
+        delete: async (uuid) => {
+          await farmosUtil.deleteSoilDisturbanceActivityLog(uuid);
+        },
+      };
+      ops.push(activityLog);
     }
 
-    return {
-      plantAsset: plantAsset,
-      bedFeetQuantity: bedFeetQuantity,
-      rowsPerBedQuantity: rowsPerBedQuantity,
-      rowFeetQuantity: rowFeetQuantity,
-      bedWidthQuantity: bedWidthQuantity,
-      seedingLog: seedingLog,
-      depthQuantity: depthQuantity,
-      speedQuantity: speedQuantity,
-      areaQuantity: areaQuantity,
-      equipment: equipmentAssets,
-      activityLog: activityLog,
-    };
+    const result = await farmosUtil.runTransaction(ops);
+    if (equipmentAssets.length > 0) {
+      result['equipment'] = equipmentAssets;
+    } else {
+      result['equipment'] = null;
+      result['depthQuantity'] = null;
+      result['speedQuantity'] = null;
+      result['areaQuantity'] = null;
+      result['activityLog'] = null;
+    }
+
+    return result;
   } catch (error) {
-    console.log('DirectSeeding: \n' + error.message);
-    console.log(error);
+    console.error('DirectSeeding: \n' + error.message);
+    console.error(error);
 
-    /*
-     * Attempt to delete any of the records that were created.  It is likely
-     * that if there was an error creating the records then there will
-     * be errors deleting them too.  So we try/catch those and swallow
-     * the exceptions and just emit a new error at the end.
-     */
+    let errorMsg = 'Error creating direct seeding.';
 
-    if (seedingLog) {
-      try {
-        await farmosUtil.deleteSeedingLog(seedingLog.id);
-      } catch (error) {
-        console.log('Unable to delete seeding log: ' + seedingLog.id);
+    for (const key of Object.keys(error.results)) {
+      if (error.results[key]) {
+        errorMsg +=
+          '\n  Result of operation ' + key + ' could not be cleaned up.';
+        if (
+          error.results[key].attributes &&
+          error.results[key].attributes.name
+        ) {
+          errorMsg += '\n   Manually delete log or asset with:';
+          errorMsg += '\n     name: ' + error.results[key].attributes.name;
+          //errorMsg += '\n     uuid: ' + error.results[key].id;
+        } else {
+          errorMsg += '\n   May be safely ignored';
+          //errorMsg += '\n     uuid: ' + error.results[key].id;
+        }
       }
     }
 
-    if (rowFeetQuantity) {
-      try {
-        await farmosUtil.deleteStandardQuantity(rowFeetQuantity.id);
-      } catch (error) {
-        console.log('Unable to delete rowFeetQuantity: ' + rowFeetQuantity.id);
-      }
-    }
-
-    if (rowsPerBedQuantity) {
-      try {
-        await farmosUtil.deleteStandardQuantity(rowsPerBedQuantity.id);
-      } catch (error) {
-        console.log(
-          'Unable to delete rowsPerBedQuantity: ' + rowsPerBedQuantity.id
-        );
-      }
-    }
-
-    if (bedWidthQuantity) {
-      try {
-        await farmosUtil.deleteStandardQuantity(bedWidthQuantity.id);
-      } catch (error) {
-        console.log(
-          'Unable to delete bedWidthQuantity: ' + bedWidthQuantity.id
-        );
-      }
-    }
-
-    if (bedFeetQuantity) {
-      try {
-        await farmosUtil.deleteStandardQuantity(bedFeetQuantity.id);
-      } catch (error) {
-        console.log('Unable to delete bedFeetQuantity: ' + bedFeetQuantity.id);
-      }
-    }
-
-    /*
-     * Don't need to do the activity log, because if it didn't work
-     * it wouldn't have been created and if it did work then everything
-     * worked.
-     */
-
-    if (depthQuantity) {
-      try {
-        await farmosUtil.deleteStandardQuantity(depthQuantity.id);
-      } catch (error) {
-        console.log('Unable to delete depthQuantity: ' + depthQuantity.id);
-      }
-    }
-
-    if (speedQuantity) {
-      try {
-        await farmosUtil.deleteStandardQuantity(speedQuantity.id);
-      } catch (error) {
-        console.log('Unable to delete speedQuantity: ' + speedQuantity.id);
-      }
-    }
-
-    if (areaQuantity) {
-      try {
-        await farmosUtil.deleteStandardQuantity(areaQuantity.id);
-      } catch (error) {
-        console.log('Unable to delete areaQuantity: ' + areaQuantity.id);
-      }
-    }
-
-    if (plantAsset) {
-      try {
-        await farmosUtil.deletePlantAsset(plantAsset.id);
-      } catch (error) {
-        console.log('Unable to delete plantAsset: ' + plantAsset.id);
-      }
-    }
-
-    throw Error('Error creating direct seeding.', error);
+    throw Error(errorMsg, error);
   }
 }

--- a/modules/farm_fd2/src/entrypoints/direct_seeding/lib.submitError.unit.cy.js
+++ b/modules/farm_fd2/src/entrypoints/direct_seeding/lib.submitError.unit.cy.js
@@ -82,7 +82,35 @@ describe('Error when submitting using the direct_seeding lib.', () => {
             throw new Error('The submission should have failed.');
           })
           .catch((error) => {
-            expect(error.message).to.equal('Error creating direct seeding.');
+            expect(error.message).to.contain('Error creating direct seeding.');
+            expect(error.message).to.contain(
+              'Result of operation plantAsset could not be cleaned up.'
+            );
+            expect(error.message).to.contain(
+              'Result of operation bedFeetQuantity could not be cleaned up.'
+            );
+            expect(error.message).to.contain(
+              'Result of operation rowsPerBedQuantity could not be cleaned up.'
+            );
+            expect(error.message).to.contain(
+              'Result of operation rowFeetQuantity could not be cleaned up.'
+            );
+            expect(error.message).to.contain(
+              'Result of operation bedWidthQuantity could not be cleaned up.'
+            );
+            expect(error.message).to.contain(
+              'Result of operation seedingLog could not be cleaned up.'
+            );
+            expect(error.message).to.contain(
+              'Result of operation depthQuantity could not be cleaned up.'
+            );
+            expect(error.message).to.contain(
+              'Result of operation speedQuantity could not be cleaned up.'
+            );
+            expect(error.message).to.contain(
+              'Result of operation areaQuantity could not be cleaned up.'
+            );
+
             expect(standardQuantityDeletes).to.equal(7);
             expect(seedingLogDeletes).to.equal(1);
             expect(plantAssetDeletes).to.equal(1);

--- a/modules/farm_fd2/src/entrypoints/tray_seeding/lib.js
+++ b/modules/farm_fd2/src/entrypoints/tray_seeding/lib.js
@@ -20,110 +20,124 @@ import * as farmosUtil from '@libs/farmosUtil/farmosUtil';
  * @throws {Error} if an error occurs while creating the farmOS records.
  */
 export async function submitForm(formData) {
-  let plantAsset = null;
-  let traysQuantity = null;
-  let traySizeQuantity = null;
-  let seedsQuantity = null;
-  let seedingLog = null;
-
   try {
     const assetName = formData.seedingDate + '_ts_' + formData.cropName;
-    plantAsset = await farmosUtil.createPlantAsset(
-      assetName,
-      formData.cropName,
-      formData.comment
-    );
 
-    traysQuantity = await farmosUtil.createStandardQuantity(
-      'count',
-      formData.trays,
-      'Trays',
-      'TRAYS',
-      plantAsset,
-      'increment'
-    );
-
-    traySizeQuantity = await farmosUtil.createStandardQuantity(
-      'ratio',
-      formData.traySize,
-      'Tray Size',
-      'CELLS/TRAY'
-    );
-
-    seedsQuantity = await farmosUtil.createStandardQuantity(
-      'count',
-      formData.seedsPerCell * formData.trays * formData.traySize,
-      'Seeds',
-      'SEEDS'
-    );
-
-    seedingLog = await farmosUtil.createSeedingLog(
-      formData.seedingDate,
-      formData.locationName,
-      [],
-      ['seeding', 'seeding_tray'],
-      plantAsset,
-      [traysQuantity, traySizeQuantity, seedsQuantity]
-    );
-
-    return {
-      plantAsset: plantAsset,
-      traysQuantity: traysQuantity,
-      traySizeQuantity: traySizeQuantity,
-      seedsQuantity: seedsQuantity,
-      seedingLog: seedingLog,
-    };
-  } catch (error) {
-    console.log('TraySeeding: \n' + error.message);
-    console.log(error);
-
-    /*
-     * If an error occurred we will delete any of the farmOS records that were created.
-     * These must be deleted in the opposite order from the order in which they were
-     * created to ensure that a record is not deleted before something that refers to it.
-     */
-    if (seedingLog) {
-      try {
-        await farmosUtil.deleteSeedingLog(seedingLog.id);
-      } catch (error) {
-        console.log('Unable to delete seeding log: ' + seedingLog.id);
-      }
-    }
-
-    if (seedsQuantity) {
-      try {
-        await farmosUtil.deleteStandardQuantity(seedsQuantity.id);
-      } catch (error) {
-        console.log('Unable to delete seedsQuantity: ' + seedsQuantity.id);
-      }
-    }
-
-    if (traySizeQuantity) {
-      try {
-        await farmosUtil.deleteStandardQuantity(traySizeQuantity.id);
-      } catch (error) {
-        console.log(
-          'Unable to delete traySizeQuantity: ' + traySizeQuantity.id
+    const plantAsset = {
+      name: 'plantAsset',
+      create: async () => {
+        return await farmosUtil.createPlantAsset(
+          assetName,
+          formData.cropName,
+          formData.comment
         );
+      },
+      delete: async (uuid) => {
+        await farmosUtil.deletePlantAsset(uuid);
+      },
+    };
+
+    const traysQuantity = {
+      name: 'traysQuantity',
+      create: async (results) => {
+        return await farmosUtil.createStandardQuantity(
+          'count',
+          formData.trays,
+          'Trays',
+          'TRAYS',
+          results.plantAsset,
+          'increment'
+        );
+      },
+      delete: async (uuid) => {
+        await farmosUtil.deleteStandardQuantity(uuid);
+      },
+    };
+
+    const traySizeQuantity = {
+      name: 'traySizeQuantity',
+      create: async () => {
+        return await farmosUtil.createStandardQuantity(
+          'ratio',
+          formData.traySize,
+          'Tray Size',
+          'CELLS/TRAY'
+        );
+      },
+      delete: async (uuid) => {
+        await farmosUtil.deleteStandardQuantity(uuid);
+      },
+    };
+
+    const seedsQuantity = {
+      name: 'seedsQuantity',
+      create: async () => {
+        return await farmosUtil.createStandardQuantity(
+          'count',
+          formData.seedsPerCell * formData.trays * formData.traySize,
+          'Seeds',
+          'SEEDS'
+        );
+      },
+      delete: async (uuid) => {
+        await farmosUtil.deleteStandardQuantity(uuid);
+      },
+    };
+
+    const seedingLog = {
+      name: 'seedingLog',
+      create: async (results) => {
+        return await farmosUtil.createSeedingLog(
+          formData.seedingDate,
+          formData.locationName,
+          [],
+          ['seeding', 'seeding_tray'],
+          results.plantAsset,
+          [
+            results.traysQuantity,
+            results.traySizeQuantity,
+            results.seedsQuantity,
+          ]
+        );
+      },
+      delete: async (uuid) => {
+        await farmosUtil.deleteSeedingLog(uuid);
+      },
+    };
+
+    const ops = [
+      plantAsset,
+      traysQuantity,
+      traySizeQuantity,
+      seedsQuantity,
+      seedingLog,
+    ];
+
+    return await farmosUtil.runTransaction(ops);
+  } catch (error) {
+    console.error('TraySeeding: \n' + error.message);
+    console.error(error);
+
+    let errorMsg = 'Error creating tray seeding.';
+
+    for (const key of Object.keys(error.results)) {
+      if (error.results[key]) {
+        errorMsg +=
+          '\n  Result of operation ' + key + ' could not be cleaned up.';
+        if (
+          error.results[key].attributes &&
+          error.results[key].attributes.name
+        ) {
+          errorMsg += '\n   Manually delete log or asset with:';
+          errorMsg += '\n     name: ' + error.results[key].attributes.name;
+          //errorMsg += '\n     uuid: ' + error.results[key].id;
+        } else {
+          errorMsg += '\n   May be safely ignored';
+          //errorMsg += '\n     uuid: ' + error.results[key].id;
+        }
       }
     }
 
-    if (traysQuantity) {
-      try {
-        await farmosUtil.deleteStandardQuantity(traysQuantity.id);
-      } catch (error) {
-        console.log('Unable to delete traysQuantity: ' + traysQuantity.id);
-      }
-    }
-
-    if (plantAsset) {
-      try {
-        await farmosUtil.deletePlantAsset(plantAsset.id);
-      } catch (error) {
-        console.log('Unable to delete plantAsset: ' + plantAsset.id);
-      }
-    }
-
-    throw Error('Error creating tray seeding.', error);
+    throw Error(errorMsg, error);
   }
 }

--- a/modules/farm_fd2/src/entrypoints/tray_seeding/lib.submitError.unit.cy.js
+++ b/modules/farm_fd2/src/entrypoints/tray_seeding/lib.submitError.unit.cy.js
@@ -65,7 +65,19 @@ describe('Test error when submitting tray seeding lib', () => {
             throw new Error('The submission should have failed.');
           })
           .catch((error) => {
-            expect(error.message).to.equal('Error creating tray seeding.');
+            expect(error.message).to.contain('Error creating tray seeding.');
+            expect(error.message).to.contain(
+              'Result of operation plantAsset could not be cleaned up.'
+            );
+            expect(error.message).to.contain(
+              'Result of operation traysQuantity could not be cleaned up.'
+            );
+            expect(error.message).to.contain(
+              'Result of operation traySizeQuantity could not be cleaned up.'
+            );
+            expect(error.message).to.contain(
+              'Result of operation seedsQuantity could not be cleaned up.'
+            );
             expect(standardQuantityDeletes).to.equal(3);
             expect(plantAssetDeletes).to.equal(1);
           }),


### PR DESCRIPTION
**Pull Request Description**

When submitting a form (e.g. tray seeding) multiple quantities, logs and assets are created.  This can result in an issue of there is an error when creating one or more of them.  When such an error occurs, ideally all logs, assets or quantities that were created should be deleted.  The `runTransaction` function added to `farmosUtil.js` facilitates this by making it easy to specify a set of operations with `create` and `delete` functions.  It then runs each operation's `create` function in sequence.  if one fails, it will run the `delete` function for each operation that had previously succeeded. 

This is not a perfect solution however, because if the error is caused by a network outage, then the delete operations probably will not succeed either.  But it is a step in the right direction.

The implementations of `submitForm` in the `lib.js` for the Tray Seeding and Direct Seeding entry points has been refactored to use `runTransaction` instead of managing the undo manually.

---

**Licensing Certification**

FarmData2 is a [Free Cultural Work](https://freedomdefined.org/Definition) and all accepted contributions are licensed as described in the LICENSE.md file. This requires that the contributor holds the rights to do so. By submitting this pull request **I certify that I satisfy the terms of the [Developer Certificate of Origin](https://developercertificate.org/)** for its contents.
