### PR TITLE
fix(fd2): updates sticky fields in direct seeding and transplanting forms

### DIFF
--- a/components/NumericInput/NumericInput.behavior.comp.cy.js
+++ b/components/NumericInput/NumericInput.behavior.comp.cy.js
@@ -83,4 +83,35 @@ describe('Test the NumericInput component behavior', () => {
         });
     });
   });
+
+  it('Check change to empty value.', () => {
+    const readySpy = cy.spy().as('readySpy');
+
+    cy.mount(NumericInput, {
+      props: {
+        label: 'Test',
+        invalidFeedbackText: 'Test feedback text',
+        value: 50,
+        onReady: readySpy,
+      },
+    }).then(({ wrapper }) => {
+      cy.get('@readySpy')
+        .should('have.been.calledOnce')
+        .then(() => {
+          cy.get('[data-cy="numeric-input"]').should('have.value', '50');
+        })
+        .then(() => {
+          wrapper.setProps({ value: '' });
+          cy.get('[data-cy="numeric-input"]').should('have.value', '');
+        })
+        .then(() => {
+          wrapper.setProps({ value: NaN });
+          cy.get('[data-cy="numeric-input"]').should('have.value', '');
+        })
+        .then(() => {
+          wrapper.setProps({ value: null });
+          cy.get('[data-cy="numeric-input"]').should('have.value', '');
+        });
+    });
+  });
 });

--- a/components/NumericInput/NumericInput.vue
+++ b/components/NumericInput/NumericInput.vue
@@ -312,7 +312,9 @@ export default {
       this.$emit('valid', this.isValid);
     },
     value() {
-      this.valueAsString = this.formatter(this.value);
+      if (!isNaN(this.value)) {
+        this.valueAsString = this.formatter(this.value);
+      }
     },
     valueAsString() {
       /**

--- a/modules/farm_fd2/src/entrypoints/direct_seeding/App.vue
+++ b/modules/farm_fd2/src/entrypoints/direct_seeding/App.vue
@@ -230,7 +230,7 @@ export default {
         equipment: [],
         depth: 0,
         speed: 0,
-        area: 100,
+        area: '',
         comment: null,
       },
       validity: {
@@ -255,7 +255,7 @@ export default {
       this.form.beds = checkedBeds;
 
       if (checkedBeds.length == 0) {
-        this.form.area = 100;
+        this.form.area = '';
       } else {
         this.form.area = (checkedBeds.length / totalBeds) * 100;
       }
@@ -305,17 +305,17 @@ export default {
       if (!sticky) {
         this.form.seedingDate = dayjs().format('YYYY-MM-DD');
         this.form.locationName = null;
-        this.form.beds = [];
-        this.form.bedFeet = 100;
         this.form.rowsPerBed = '1';
         this.form.bedWidth = 60;
         this.form.equipment = [];
         this.form.depth = 0;
         this.form.speed = 0;
-        this.form.area = 100;
       }
 
       this.form.cropName = null;
+      this.form.beds = [];
+      this.form.bedFeet = 100;
+      this.form.area = '';
       this.form.comment = null;
       this.enableSubmit = true;
     },

--- a/modules/farm_fd2/src/entrypoints/direct_seeding/direct_seeding.soilDisturbance.e2e.cy.js
+++ b/modules/farm_fd2/src/entrypoints/direct_seeding/direct_seeding.soilDisturbance.e2e.cy.js
@@ -63,4 +63,57 @@ describe('Direct Seeding: Soil Disturbance Component', () => {
     cy.get('[data-cy="soil-disturbance-area"]').should('be.visible');
     cy.get('[data-cy="soil-disturbance-passes"]').should('not.exist');
   });
+
+  it('Check area computation with no beds', () => {
+    cy.get(
+      '[data-cy="direct-seeding-soil-disturbance-accordion-title"]'
+    ).click();
+    cy.get('[data-cy="equipment-selector-1"]')
+      .find('[data-cy="selector-input"]')
+      .select('Tractor');
+
+    cy.get('[data-cy="soil-disturbance-area"]')
+      .find('[data-cy="numeric-input"]')
+      .should('have.value', '');
+
+    cy.get('[data-cy="location-selector"]')
+      .find('[data-cy="selector-input"]')
+      .select('A');
+
+    cy.get('[data-cy="soil-disturbance-area"]')
+      .find('[data-cy="numeric-input"]')
+      .should('have.value', '');
+  });
+
+  it('Check area computation with beds', () => {
+    cy.get(
+      '[data-cy="direct-seeding-soil-disturbance-accordion-title"]'
+    ).click();
+    cy.get('[data-cy="equipment-selector-1"]')
+      .find('[data-cy="selector-input"]')
+      .select('Tractor');
+
+    cy.get('[data-cy="soil-disturbance-area"]')
+      .find('[data-cy="numeric-input"]')
+      .should('have.value', '');
+
+    cy.get('[data-cy="location-selector"]')
+      .find('[data-cy="selector-input"]')
+      .select('CHUAU');
+
+    // Pick CHUAU-1
+    cy.get('[data-cy="picker-options"]').find('input').eq(0).check();
+
+    cy.get('[data-cy="soil-disturbance-area"]')
+      .find('[data-cy="numeric-input"]')
+      .should('have.value', '20');
+
+    cy.get('[data-cy="location-selector"]')
+      .find('[data-cy="selector-input"]')
+      .select('A');
+
+    cy.get('[data-cy="soil-disturbance-area"]')
+      .find('[data-cy="numeric-input"]')
+      .should('have.value', '');
+  });
 });

--- a/modules/farm_fd2/src/entrypoints/direct_seeding/direct_seeding.submission.e2e.cy.js
+++ b/modules/farm_fd2/src/entrypoints/direct_seeding/direct_seeding.submission.e2e.cy.js
@@ -118,19 +118,6 @@ describe('Direct Seeding: Submission tests', () => {
     cy.get('[data-cy="direct-seeding-location"]')
       .find('[data-cy="selector-input"]')
       .should('have.value', 'ALF');
-    cy.get('[data-cy="direct-seeding-location"]')
-      .find('[data-cy="picker-options"]')
-      .find('input')
-      .eq(0)
-      .should('be.checked');
-    cy.get('[data-cy="direct-seeding-location"]')
-      .find('[data-cy="picker-options"]')
-      .find('input')
-      .eq(3)
-      .should('be.checked');
-    cy.get('[data-cy="direct-seeding-bed-feet"]')
-      .find('[data-cy="numeric-input"]')
-      .should('have.value', '200');
     cy.get('[data-cy="direct-seeding-bed-width"]')
       .find('[data-cy="numeric-input"]')
       .should('have.value', '30');
@@ -150,14 +137,27 @@ describe('Direct Seeding: Submission tests', () => {
     cy.get('[data-cy="soil-disturbance-speed"]')
       .find('[data-cy="numeric-input"]')
       .should('have.value', '5.0');
-    cy.get('[data-cy="soil-disturbance-area"]')
-      .find('[data-cy="numeric-input"]')
-      .should('have.value', '50');
 
     // Check that the other parts of the form are reset.
     cy.get('[data-cy="direct-seeding-crop"]')
       .find('[data-cy="selector-input"]')
       .should('have.value', null);
+    cy.get('[data-cy="direct-seeding-location"]')
+      .find('[data-cy="picker-options"]')
+      .find('input')
+      .eq(0)
+      .should('not.be.checked');
+    cy.get('[data-cy="direct-seeding-location"]')
+      .find('[data-cy="picker-options"]')
+      .find('input')
+      .eq(3)
+      .should('not.be.checked');
+    cy.get('[data-cy="direct-seeding-bed-feet"]')
+      .find('[data-cy="numeric-input"]')
+      .should('have.value', '100');
+    cy.get('[data-cy="soil-disturbance-area"]')
+      .find('[data-cy="numeric-input"]')
+      .should('have.value', '');
     cy.get('[data-cy="comment-input"]').should('have.value', '');
 
     // Finally check that the toast is hidden.

--- a/modules/farm_fd2/src/entrypoints/direct_seeding/direct_seeding.submitReset.e2e.cy.js
+++ b/modules/farm_fd2/src/entrypoints/direct_seeding/direct_seeding.submitReset.e2e.cy.js
@@ -251,6 +251,6 @@ describe('Direct Seeding: Submit/Reset Buttons component', () => {
       .should('have.value', '0.0');
     cy.get('[data-cy="soil-disturbance-area"]')
       .find('[data-cy="numeric-input"]')
-      .should('have.value', '100');
+      .should('have.value', '');
   });
 });

--- a/modules/farm_fd2/src/entrypoints/transplanting/App.vue
+++ b/modules/farm_fd2/src/entrypoints/transplanting/App.vue
@@ -254,12 +254,6 @@
       {{ pageDoneLoading }}
     </div>
   </div>
-  <div
-    data-cy="page-loaded"
-    v-show="false"
-  >
-    {{ pageDoneLoading }}
-  </div>
 </template>
 
 <script>
@@ -303,7 +297,7 @@ export default {
         equipment: [],
         depth: 0,
         speed: 0,
-        area: 100,
+        area: '',
         comment: '',
       },
       validity: {
@@ -342,7 +336,7 @@ export default {
       this.form.beds = checkedBeds;
 
       if (checkedBeds.length == 0) {
-        this.form.area = 100;
+        this.form.area = '';
       } else {
         this.form.area = (checkedBeds.length / totalBeds) * 100;
       }
@@ -386,23 +380,23 @@ export default {
         this.enableSubmit = false;
       }
     },
-    reset(sticky=false) {
+    reset(sticky = false) {
       this.validity.show = false;
 
       if (!sticky) {
         this.form.transplantingDate = dayjs().format('YYYY-MM-DD');
         this.form.location = null;
-        this.form.beds = [];
-        this.form.bedFeet = 100;
         this.form.bedWidth = 60;
         this.form.rowsPerBed = '1';
         this.form.equipment = [];
         this.form.depth = 0;
         this.form.speed = 0;
-        this.form.area = 100;
       }
 
+      this.form.beds = [];
       this.form.cropName = null;
+      this.form.bedFeet = 100;
+      this.form.area = '';
       this.form.comment = null;
       this.enableSubmit = true;
     },


### PR DESCRIPTION
**Pull Request Description**

The Beds, Bed feet and Area fields in the Direct Seeding and Transplanting forms were changed so that they are not sticky.  The Area field required an update to the `NumericInput` component to allow it to be blank.  Finally an extraneous duplicate `page-loaded` element was removed from the Transplanting form.

Closes #224 
Closes #226 

---

**Licensing Certification**

FarmData2 is a [Free Cultural Work](https://freedomdefined.org/Definition) and all accepted contributions are licensed as described in the LICENSE.md file. This requires that the contributor holds the rights to do so. By submitting this pull request **I certify that I satisfy the terms of the [Developer Certificate of Origin](https://developercertificate.org/)** for its contents.
