### PR TITLE
fix(fd2): archives tray seeded plant assets when fully transplanted

### DIFF
--- a/library/farmosUtil/farmosUtil.inventory.unit.cy.js
+++ b/library/farmosUtil/farmosUtil.inventory.unit.cy.js
@@ -1,0 +1,78 @@
+import * as farmosUtil from './farmosUtil.js';
+
+describe('Test the getAssetInventory function', () => {
+  beforeEach(async () => {
+    const farm = await farmosUtil.getFarmOSInstance();
+
+    cy.wrap(
+      farm.asset.create({
+        type: 'asset--plant',
+        attributes: {
+          name: 'testAsset',
+          status: 'active',
+          inventory: [
+            {
+              measure: 'speed',
+              value: 1,
+              units: 'MPH',
+            },
+            {
+              measure: 'length',
+              value: 3,
+              units: 'FEET',
+            },
+            {
+              measure: 'count',
+              value: 2,
+              units: 'TRAYS',
+            },
+          ],
+        },
+      })
+    ).as('asset');
+  });
+
+  it('Get an existing inventory', () => {
+    cy.get('@asset').then((asset) => {
+      expect(asset.attributes.inventory).to.have.length(3);
+      const trays = farmosUtil.getAssetInventory(asset, 'count', 'TRAYS');
+      expect(trays).to.equal(2);
+      const feet = farmosUtil.getAssetInventory(asset, 'length', 'FEET');
+      expect(feet).to.equal(3);
+      const mph = farmosUtil.getAssetInventory(asset, 'speed', 'MPH');
+      expect(mph).to.equal(1);
+    });
+  });
+
+  it('Get a non-existing inventory due to measure', () => {
+    cy.get('@asset').then((asset) => {
+      expect(asset.attributes.inventory).to.have.length(3);
+      const trays = farmosUtil.getAssetInventory(asset, 'length', 'TRAYS');
+      expect(trays).to.equal(null);
+      const feet = farmosUtil.getAssetInventory(asset, 'speed', 'FEET');
+      expect(feet).to.equal(null);
+      const mph = farmosUtil.getAssetInventory(asset, 'count', 'MPH');
+      expect(mph).to.equal(null);
+    });
+  });
+
+  it('Get a non-existing inventory due to units', () => {
+    cy.get('@asset').then((asset) => {
+      expect(asset.attributes.inventory).to.have.length(3);
+      const one = farmosUtil.getAssetInventory(asset, 'count', 'FEET');
+      expect(one).to.equal(null);
+      const two = farmosUtil.getAssetInventory(asset, 'length', 'MPH');
+      expect(two).to.equal(null);
+      const three = farmosUtil.getAssetInventory(asset, 'speed', 'TRAYS');
+      expect(three).to.equal(null);
+    });
+  });
+
+  it('Get a non-existing inventory due to both', () => {
+    cy.get('@asset').then((asset) => {
+      expect(asset.attributes.inventory).to.have.length(3);
+      const none = farmosUtil.getAssetInventory(asset, 'blah', 'blah');
+      expect(none).to.equal(null);
+    });
+  });
+});

--- a/library/farmosUtil/farmosUtil.js
+++ b/library/farmosUtil/farmosUtil.js
@@ -2121,6 +2121,25 @@ export function extractQuantity(quantityString, unitName) {
 }
 
 /**
+ * Get an inventory value from an asset.
+ *
+ * @param {Object} asset the asset to search.
+ * @param {string} measure the measure of the inventory value.
+ * @param {string} units the units of the inventory value.
+ * @return the inventory value or `null` if not found.
+ *
+ * @category Utilities
+ */
+export function getAssetInventory(asset, measure, units) {
+  for (const inventory of asset.attributes.inventory) {
+    if (inventory.measure === measure && inventory.units === units) {
+      return inventory.value;
+    }
+  }
+  return null;
+}
+
+/**
  * Get information about all of the seedlings that are candidates for transplanting.
  * These seedlings are plant assets that were tray seeded and have a positive inventory of trays.
  *

--- a/library/farmosUtil/farmosUtil.js
+++ b/library/farmosUtil/farmosUtil.js
@@ -1653,6 +1653,25 @@ export async function deletePlantAsset(plantAssetId) {
 }
 
 /**
+ * Archive or unarchive the plant asset with the specified id.
+ *
+ * @param {string} plantAssetId the id of the plant asset.
+ * @param {boolean} archived `true` to archive or unarchive the plant asset, or `false` to unarchive it.
+ */
+export async function archivePlantAsset(plantAssetId, archived) {
+  const farm = await getFarmOSInstance();
+
+  const plantAsset = await getPlantAsset(plantAssetId);
+  if (archived) {
+    plantAsset.attributes.status = 'archived';
+  } else {
+    plantAsset.attributes.status = 'active';
+  }
+
+  return await farm.asset.send(plantAsset);
+}
+
+/**
  * Create a standard quantity (i.e. a quantity of type `quantity--standard`).
  *
  * @param {string} measure the measure type of the quantity (e.g. 'count', 'weight', 'volume')

--- a/library/farmosUtil/farmosUtil.plant.unit.cy.js
+++ b/library/farmosUtil/farmosUtil.plant.unit.cy.js
@@ -100,4 +100,37 @@ describe('Test the plant asset functions', () => {
         })
     );
   });
+
+  it('Archive/Unarchive a plant asset', () => {
+    cy.wrap(farmosUtil.createPlantAsset('p1', 'ARUGULA', 'p1')).as('p1');
+
+    cy.get('@p1').then((p1) => {
+      expect(p1.attributes.name).to.equal('p1');
+      expect(p1.attributes.status).to.equal('active');
+
+      cy.wrap(farmosUtil.archivePlantAsset(p1.id, true)).as('archived');
+    });
+
+    cy.get('@archived').then((archived) => {
+      cy.wrap(farmosUtil.getPlantAsset(archived.id)).as('p1-archived');
+    });
+
+    cy.get('@p1-archived').then((p1Archived) => {
+      expect(p1Archived.attributes.name).to.equal('p1');
+      expect(p1Archived.attributes.status).to.equal('archived');
+
+      cy.wrap(farmosUtil.archivePlantAsset(p1Archived.id), false).as(
+        'unArchived'
+      );
+    });
+
+    cy.get('@unArchived').then((unArchived) => {
+      cy.wrap(farmosUtil.getPlantAsset(unArchived.id)).as('p1-unArchived');
+    });
+
+    cy.get('@p1-unArchived').then((p1unArchived) => {
+      expect(p1unArchived.attributes.name).to.equal('p1');
+      expect(p1unArchived.attributes.status).to.equal('active');
+    });
+  });
 });

--- a/modules/farm_fd2/src/entrypoints/transplanting/lib.js
+++ b/modules/farm_fd2/src/entrypoints/transplanting/lib.js
@@ -65,16 +65,32 @@ export async function submitForm(formData) {
 
           trayInventoryQuantitiesArray.push(trayQuantity);
 
-          // TODO: archive the original plant asset if inventory == 0 ????
+          const trayInvenotry = farmosUtil.getAssetInventory(
+            results.parents[i],
+            'count',
+            'TRAYS'
+          );
+          const traysPicked = formData.picked[i].trays;
+
+          console.log('Tray quantity: ' + trayInvenotry);
+          console.log('Trays picked: ' + traysPicked);
+
+          // All of the trays in the planting have been transplanted.
+          if (traysPicked == trayInvenotry) {
+            await farmosUtil.archivePlantAsset(results.parents[i].id, true);
+          }
         }
 
         return trayInventoryQuantitiesArray;
       },
       undo: async (results) => {
         for (const trayQuantity of results.trayInventoryQuantities) {
+          const parent = trayQuantity.parent;
           await farmosUtil.deleteStandardQuantity(trayQuantity.id);
 
-          // TODO: unarchive the original plant asset if inventory > 0 ????
+          // The inventory decrement was deleted so make sure the asset
+          // is not archived.
+          await farmosUtil.unarchivePlantAsset(parent.id, false);
         }
       },
     };


### PR DESCRIPTION
**Pull Request Description**

When a tray seeded plant asset has been fully transplanted its `TRAYS` inventory will be 0.  The changes in this PR ensure that the plant asset is archived when this happens.

Closes #220 

---

**Licensing Certification**

FarmData2 is a [Free Cultural Work](https://freedomdefined.org/Definition) and all accepted contributions are licensed as described in the LICENSE.md file. This requires that the contributor holds the rights to do so. By submitting this pull request **I certify that I satisfy the terms of the [Developer Certificate of Origin](https://developercertificate.org/)** for its contents.
