### PR TITLE
fix(fd2): removes unnecessary quantity deletes

### DIFF
--- a/library/farmosUtil/farmosUtil.js
+++ b/library/farmosUtil/farmosUtil.js
@@ -1510,11 +1510,13 @@ export async function getEquipmentIdToAssetMap(categories = []) {
  * @return {Object} an object with an attribute for each operation.
  * The attribute name is the operation name and its value is the result of the operation (i.e. the value returned from the `do` function).
  * The value of the attribute for an operation will be null if the operation was not successful (i.e. the `do` function throws an error).
+ * The value of the attribute for an operation will be `undefined` if the operation was not attempted.
  *
  * @throws {Error} if unable to execute the `do` function one of the operations or if unable to execute the `undo` of all operations in the transaction.
  * The `cause` of the error will include a `results` attribute with the same format as the returned object.
- * If an operation was successfully undone the attribute for that operation will have the value `null`.
+ * If an operation was successfully undone the attribute for that operation will have the value `undone`.
  * If an operation was not successfully undone the attribute for that operation will be the result of the operation.
+ * If an operation was not attempted the attribute for that operation will be `undefined`.
  *
  * @category Utilities
  */
@@ -1535,15 +1537,17 @@ export async function runTransaction(operations) {
     for (const operation of undo.reverse()) {
       try {
         await operation.undo(done);
-        done[operation.name] = null;
-        console.error('    deleted ' + operation.name);
+        done[operation.name] = 'undone';
+        console.error('    ' + operation.name + ' undone.');
       } catch (error) {
-        console.error('    failed to delete ' + operation.name);
-        console.error('      uuid: ' + done[operation.name].id);
+        console.error('    failed to undo ' + operation.name);
+
         if (
+          done[operation.name].id &&
           done[operation.name].attributes &&
           done[operation.name].attributes.name
         ) {
+          console.error('      uuid: ' + done[operation.name].id);
           console.error('      name: ' + done[operation.name].attributes.name);
         }
       }

--- a/library/farmosUtil/farmosUtil.js
+++ b/library/farmosUtil/farmosUtil.js
@@ -1509,14 +1509,13 @@ export async function getEquipmentIdToAssetMap(categories = []) {
  *
  * @return {Object} an object with an attribute for each operation.
  * The attribute name is the operation name and its value is the result of the operation (i.e. the value returned from the `do` function).
- * The value of the attribute for an operation will be null if the operation was not successful (i.e. the `do` function throws an error).
- * The value of the attribute for an operation will be `undefined` if the operation was not attempted.
  *
  * @throws {Error} if unable to execute the `do` function one of the operations or if unable to execute the `undo` of all operations in the transaction.
  * The `cause` of the error will include a `results` attribute with the same format as the returned object.
- * If an operation was successfully undone the attribute for that operation will have the value `undone`.
- * If an operation was not successfully undone the attribute for that operation will be the result of the operation.
- * If an operation was not attempted the attribute for that operation will be `undefined`.
+ * If an operation was completed and has been undone the attribute for that operation will have the value `undone`.
+ * If an operation was completed but has not been undone the attribute for that operation will be the result of the operation.
+ * If an operation was attempted but failed (and thus was not undone) the attribute for that operation will be `null`.
+ * If an operation was never attempted (and thus also not undone) the attribute for that operation will be `undefined`.
  *
  * @category Utilities
  */

--- a/modules/farm_fd2/src/entrypoints/direct_seeding/lib.js
+++ b/modules/farm_fd2/src/entrypoints/direct_seeding/lib.js
@@ -57,7 +57,11 @@ export async function submitForm(formData) {
         );
       },
       undo: async (results) => {
-        await farmosUtil.deleteStandardQuantity(results['bedFeetQuantity'].id);
+        if (results['seedingLog'] != 'undone') {
+          await farmosUtil.deleteStandardQuantity(
+            results['bedFeetQuantity'].id
+          );
+        }
       },
     };
     ops.push(bedFeetQuantity);
@@ -73,9 +77,11 @@ export async function submitForm(formData) {
         );
       },
       undo: async (results) => {
-        await farmosUtil.deleteStandardQuantity(
-          results['rowsPerBedQuantity'].id
-        );
+        if (results['seedingLog'] != 'undone') {
+          await farmosUtil.deleteStandardQuantity(
+            results['rowsPerBedQuantity'].id
+          );
+        }
       },
     };
     ops.push(rowsPerBedQuantity);
@@ -93,7 +99,11 @@ export async function submitForm(formData) {
         );
       },
       undo: async (results) => {
-        await farmosUtil.deleteStandardQuantity(results['rowFeetQuantity'].id);
+        if (results['seedingLog'] != 'undone') {
+          await farmosUtil.deleteStandardQuantity(
+            results['rowFeetQuantity'].id
+          );
+        }
       },
     };
     ops.push(rowFeetQuantity);
@@ -109,7 +119,11 @@ export async function submitForm(formData) {
         );
       },
       undo: async (results) => {
-        await farmosUtil.deleteStandardQuantity(results['bedWidthQuantity'].id);
+        if (results['seedingLog'] != 'undone') {
+          await farmosUtil.deleteStandardQuantity(
+            results['bedWidthQuantity'].id
+          );
+        }
       },
     };
     ops.push(bedWidthQuantity);
@@ -236,7 +250,7 @@ export async function submitForm(formData) {
     let errorMsg = 'Error creating direct seeding.';
 
     for (const key of Object.keys(error.results)) {
-      if (error.results[key]) {
+      if (error.results[key] && error.results[key] != 'undone') {
         errorMsg +=
           '\n  Result of operation ' + key + ' could not be cleaned up.';
         if (

--- a/modules/farm_fd2/src/entrypoints/direct_seeding/lib.submitError.unit.cy.js
+++ b/modules/farm_fd2/src/entrypoints/direct_seeding/lib.submitError.unit.cy.js
@@ -32,91 +32,171 @@ describe('Error when submitting using the direct_seeding lib.', () => {
     cy.saveSessionStorage();
   });
 
-  it(
-    'Records are deleted if there is a submission error',
-    { retries: 4 },
-    () => {
-      /*
-       * Create a error on submission of the activity log which is the
-       * final step.  At that point all other records should have been
-       * created and thus should also all be deleted.
-       */
-      cy.intercept('POST', '**/api/log/activity', {
+  it('Check error messages when cannot clean up', { retries: 4 }, () => {
+    /*
+     * Create a error on submission of the activity log which is the
+     * final step.  At that point all other records should have been
+     * created and thus should also all be deleted.
+     */
+    cy.intercept('POST', '**/api/log/activity', {
+      statusCode: 401,
+    });
+
+    /*
+     * Now create an intercept with a spy for each of the other endpoints
+     * where records are being deleted.  We'll then check that each was
+     * called the appropriate number of times.
+     */
+    let standardQuantityDeletes = 0;
+    cy.intercept('DELETE', '**/api/quantity/standard/*', (req) => {
+      standardQuantityDeletes++;
+      req.reply({
         statusCode: 401,
       });
+    });
 
-      /*
-       * Now create an intercept with a spy for each of the other endpoints
-       * where records are being deleted.  We'll then check that each was
-       * called the appropriate number of times.
-       */
-      let standardQuantityDeletes = 0;
-      cy.intercept('DELETE', '**/api/quantity/standard/*', (req) => {
-        standardQuantityDeletes++;
-        req.reply({
-          statusCode: 401,
-        });
+    let seedingLogDeletes = 0;
+    cy.intercept('DELETE', '**/api/log/seeding/*', (req) => {
+      seedingLogDeletes++;
+      req.reply({
+        statusCode: 401,
       });
+    });
 
-      let seedingLogDeletes = 0;
-      cy.intercept('DELETE', '**/api/log/seeding/*', (req) => {
-        seedingLogDeletes++;
-        req.reply({
-          statusCode: 401,
-        });
+    let plantAssetDeletes = 0;
+    cy.intercept('DELETE', '**/api/asset/plant/*', (req) => {
+      plantAssetDeletes++;
+      req.reply({
+        statusCode: 401,
       });
+    });
 
-      let plantAssetDeletes = 0;
-      cy.intercept('DELETE', '**/api/asset/plant/*', (req) => {
-        plantAssetDeletes++;
-        req.reply({
-          statusCode: 401,
-        });
+    cy.wrap(
+      lib
+        .submitForm(form)
+        .then(() => {
+          // Shouldn't run because submitForm throws an error.
+          throw new Error('The submission should have failed.');
+        })
+        .catch((error) => {
+          expect(error.message).to.contain('Error creating direct seeding.');
+          expect(error.message).to.contain(
+            'Result of operation plantAsset could not be cleaned up.'
+          );
+          expect(error.message).to.contain(
+            'Result of operation bedFeetQuantity could not be cleaned up.'
+          );
+          expect(error.message).to.contain(
+            'Result of operation rowsPerBedQuantity could not be cleaned up.'
+          );
+          expect(error.message).to.contain(
+            'Result of operation rowFeetQuantity could not be cleaned up.'
+          );
+          expect(error.message).to.contain(
+            'Result of operation bedWidthQuantity could not be cleaned up.'
+          );
+          expect(error.message).to.contain(
+            'Result of operation seedingLog could not be cleaned up.'
+          );
+          expect(error.message).to.contain(
+            'Result of operation depthQuantity could not be cleaned up.'
+          );
+          expect(error.message).to.contain(
+            'Result of operation speedQuantity could not be cleaned up.'
+          );
+          expect(error.message).to.contain(
+            'Result of operation areaQuantity could not be cleaned up.'
+          );
+
+          expect(standardQuantityDeletes).to.equal(7);
+          expect(seedingLogDeletes).to.equal(1);
+          expect(plantAssetDeletes).to.equal(1);
+        }),
+      { timeout: 10000 }
+    );
+  });
+
+  it('Check quantities deleted explicitly if seeding log not created', () => {
+    cy.intercept('POST', '**/api/log/seeding', {
+      statusCode: 401,
+    });
+
+    let standardQuantityDeletes = 0;
+    cy.intercept('DELETE', '**/api/quantity/standard/*', (req) => {
+      standardQuantityDeletes++;
+      req.reply({
+        statusCode: 200,
       });
+    });
 
-      cy.wrap(
-        lib
-          .submitForm(form)
-          .then(() => {
-            // Shouldn't run because submitForm throws an error.
-            throw new Error('The submission should have failed.');
-          })
-          .catch((error) => {
-            expect(error.message).to.contain('Error creating direct seeding.');
-            expect(error.message).to.contain(
-              'Result of operation plantAsset could not be cleaned up.'
-            );
-            expect(error.message).to.contain(
-              'Result of operation bedFeetQuantity could not be cleaned up.'
-            );
-            expect(error.message).to.contain(
-              'Result of operation rowsPerBedQuantity could not be cleaned up.'
-            );
-            expect(error.message).to.contain(
-              'Result of operation rowFeetQuantity could not be cleaned up.'
-            );
-            expect(error.message).to.contain(
-              'Result of operation bedWidthQuantity could not be cleaned up.'
-            );
-            expect(error.message).to.contain(
-              'Result of operation seedingLog could not be cleaned up.'
-            );
-            expect(error.message).to.contain(
-              'Result of operation depthQuantity could not be cleaned up.'
-            );
-            expect(error.message).to.contain(
-              'Result of operation speedQuantity could not be cleaned up.'
-            );
-            expect(error.message).to.contain(
-              'Result of operation areaQuantity could not be cleaned up.'
-            );
+    let plantAssetDeletes = 0;
+    cy.intercept('DELETE', '**/api/asset/plant/*', (req) => {
+      plantAssetDeletes++;
+      req.reply({
+        statusCode: 200,
+      });
+    });
 
-            expect(standardQuantityDeletes).to.equal(7);
-            expect(seedingLogDeletes).to.equal(1);
-            expect(plantAssetDeletes).to.equal(1);
-          }),
-        { timeout: 10000 }
-      );
-    }
-  );
+    cy.wrap(
+      lib
+        .submitForm(form)
+        .then(() => {
+          // Shouldn't run because submitForm throws an error.
+          throw new Error('The submission should have failed.');
+        })
+        .catch((error) => {
+          expect(error.message).not.to.contain('bedWidthQuantity');
+          expect(error.message).not.to.contain('rowFeetQuantity');
+          expect(error.message).not.to.contain('rosPerBedQuantity.');
+          expect(error.message).not.to.contain('rowFeetQuantity');
+          expect(standardQuantityDeletes).to.equal(4);
+          expect(plantAssetDeletes).to.equal(1);
+        })
+    );
+  });
+
+  it.only('Check quantities not deleted explicitly if seeding log created and deleted', () => {
+    cy.intercept('POST', '**/api/log/activity', {
+      statusCode: 401,
+    });
+
+    let seedingLogDeletes = 0;
+    cy.intercept('POST', '**/api/log/seeding', () => {
+      seedingLogDeletes++;
+    });
+
+    let standardQuantityDeletes = 0;
+    cy.intercept('DELETE', '**/api/quantity/standard/*', (req) => {
+      standardQuantityDeletes++;
+      req.reply({
+        statusCode: 200,
+      });
+    });
+
+    let plantAssetDeletes = 0;
+    cy.intercept('DELETE', '**/api/asset/plant/*', (req) => {
+      plantAssetDeletes++;
+      req.reply({
+        statusCode: 200,
+      });
+    });
+
+    cy.wrap(
+      lib
+        .submitForm(form)
+        .then(() => {
+          // Shouldn't run because submitForm throws an error.
+          throw new Error('The submission should have failed.');
+        })
+        .catch((error) => {
+          expect(error.message).not.to.contain('bedWidthQuantity');
+          expect(error.message).not.to.contain('rowFeetQuantity');
+          expect(error.message).not.to.contain('rosPerBedQuantity.');
+          expect(error.message).not.to.contain('rowFeetQuantity');
+          expect(standardQuantityDeletes).to.equal(3);
+          expect(seedingLogDeletes).to.equal(1);
+          expect(plantAssetDeletes).to.equal(1);
+        })
+    );
+  });
 });

--- a/modules/farm_fd2/src/entrypoints/direct_seeding/lib.submitError.unit.cy.js
+++ b/modules/farm_fd2/src/entrypoints/direct_seeding/lib.submitError.unit.cy.js
@@ -155,7 +155,7 @@ describe('Error when submitting using the direct_seeding lib.', () => {
     );
   });
 
-  it.only('Check quantities not deleted explicitly if seeding log created and deleted', () => {
+  it('Check quantities not deleted explicitly if seeding log created and deleted', () => {
     cy.intercept('POST', '**/api/log/activity', {
       statusCode: 401,
     });

--- a/modules/farm_fd2/src/entrypoints/direct_seeding/lib.submitNoEquipment.unit.cy.js
+++ b/modules/farm_fd2/src/entrypoints/direct_seeding/lib.submitNoEquipment.unit.cy.js
@@ -236,7 +236,7 @@ describe('Submit w/o equipment using the direct_seeding lib.', () => {
     );
   });
 
-  it('Check activity log not created', () => {
+  it('Check soil disturbance activity log not created', () => {
     expect(result.depthQuantity).to.be.null;
     expect(result.speedQuantity).to.be.null;
     expect(result.activityLog).to.be.null;

--- a/modules/farm_fd2/src/entrypoints/transplanting/lib.js
+++ b/modules/farm_fd2/src/entrypoints/transplanting/lib.js
@@ -85,12 +85,13 @@ export async function submitForm(formData) {
       },
       undo: async (results) => {
         for (const trayQuantity of results.trayInventoryQuantities) {
-          const parent = trayQuantity.parent;
-          await farmosUtil.deleteStandardQuantity(trayQuantity.id);
+          if (results['transplantingLog'] != 'undone') {
+            await farmosUtil.deleteStandardQuantity(trayQuantity.id);
+          }
 
           // The inventory decrement was deleted so make sure the asset
           // is not archived.
-          await farmosUtil.unarchivePlantAsset(parent.id, false);
+          await farmosUtil.unarchivePlantAsset(trayQuantity.parent.id, false);
         }
       },
     };
@@ -111,7 +112,9 @@ export async function submitForm(formData) {
         );
       },
       undo: async (results) => {
-        await farmosUtil.deletePlantAsset(results['transplantingAsset'].id);
+        if (results['transplantingLog'] != 'undone') {
+          await farmosUtil.deletePlantAsset(results['transplantingAsset'].id);
+        }
       },
     };
     ops.push(transplantingAsset);
@@ -127,9 +130,11 @@ export async function submitForm(formData) {
         );
       },
       undo: async (results) => {
-        await farmosUtil.deleteStandardQuantity(
-          results['transplantingBedFeetQuantity'].id
-        );
+        if (results['transplantingLog'] != 'undone') {
+          await farmosUtil.deleteStandardQuantity(
+            results['transplantingBedFeetQuantity'].id
+          );
+        }
       },
     };
     ops.push(transplantingBedFeetQuantity);
@@ -145,9 +150,11 @@ export async function submitForm(formData) {
         );
       },
       undo: async (results) => {
-        await farmosUtil.deleteStandardQuantity(
-          results['transplantingBedWidthQuantity'].id
-        );
+        if (results['transplantingLog'] != 'undone') {
+          await farmosUtil.deleteStandardQuantity(
+            results['transplantingBedWidthQuantity'].id
+          );
+        }
       },
     };
     ops.push(transplantingBedWidthQuantity);
@@ -163,9 +170,11 @@ export async function submitForm(formData) {
         );
       },
       undo: async (results) => {
-        await farmosUtil.deleteStandardQuantity(
-          results['transplantingRowsPerBedQuantity'].id
-        );
+        if (results['transplantingLog'] != 'undone') {
+          await farmosUtil.deleteStandardQuantity(
+            results['transplantingRowsPerBedQuantity'].id
+          );
+        }
       },
     };
     ops.push(transplantingRowsPerBedQuantity);
@@ -183,9 +192,11 @@ export async function submitForm(formData) {
         );
       },
       undo: async (results) => {
-        await farmosUtil.deleteStandardQuantity(
-          results['transplantingRowFeetQuantity'].id
-        );
+        if (results['transplantingLog'] != 'undone') {
+          await farmosUtil.deleteStandardQuantity(
+            results['transplantingRowFeetQuantity'].id
+          );
+        }
       },
     };
     ops.push(transplantingRowFeetQuantity);

--- a/modules/farm_fd2/src/entrypoints/transplanting/lib.js
+++ b/modules/farm_fd2/src/entrypoints/transplanting/lib.js
@@ -91,7 +91,7 @@ export async function submitForm(formData) {
 
           // The inventory decrement was deleted so make sure the asset
           // is not archived.
-          await farmosUtil.unarchivePlantAsset(trayQuantity.parent.id, false);
+          await farmosUtil.archivePlantAsset(trayQuantity.parent.id, false);
         }
       },
     };


### PR DESCRIPTION
**Pull Request Description**

When a log referencing quantities is deleted those quantities are also deleted.  Thus, if a transaction fails and deletes a log with quantities, it is not necessary to delete the quantities.  This PR updates:

- the `runTransaction` function so that `undo` methods have the information they need to skip these deletes.
- the Direct Seeding and Transplanting forms to use the information to avoid errors caused by attempting to delete quantities that were already deleted when the log was deleted..

Closes #218 

---

**Licensing Certification**

FarmData2 is a [Free Cultural Work](https://freedomdefined.org/Definition) and all accepted contributions are licensed as described in the LICENSE.md file. This requires that the contributor holds the rights to do so. By submitting this pull request **I certify that I satisfy the terms of the [Developer Certificate of Origin](https://developercertificate.org/)** for its contents.
