### PR TITLE
fix(fd2): enforces asset and log naming conventions

### DIFF
--- a/docs/DataModel.md
+++ b/docs/DataModel.md
@@ -98,9 +98,15 @@ Every operation in FarmData2 has one or more logs associated with it.
 
 #### Seeding Logs
 
+`yyyy-mm-dd_<type>_<crop>` - where `<type>` is `ts`, `ds`, or `cs` as defined above.
+
 #### Transplanting Logs
 
+`yyyy-mm-dd_xp_<crop>`
+
 #### Tillage Logs
+
+`yyyy-mm-dd_sd_<location>`
 
 #### Amendment Logs
 

--- a/library/farmosUtil/farmosUtil.js
+++ b/library/farmosUtil/farmosUtil.js
@@ -1565,7 +1565,7 @@ export async function runTransaction(operations) {
 /**
  * Create a plant asset (i.e. an asset of type `asset--plant`).
  *
- * @param {string} assetName the name of the plant asset to create.
+ * @param {string} date the date on which the plant asset was created.
  * @param {string} cropName the name of the crop to associate with the plant asset.
  * @param {string} [comment = ""] a comment the comment to associate with this plant asset.
  * @param {Array<Object>} [parents = []] an array of `asset--plant` objects to associate as parents of the new plant asset.
@@ -1575,7 +1575,7 @@ export async function runTransaction(operations) {
  * @category Plant
  */
 export async function createPlantAsset(
-  assetName,
+  date, 
   cropName,
   comment = '',
   parents = []
@@ -1588,6 +1588,8 @@ export async function createPlantAsset(
     parentArray.push({ type: 'asset--plant', id: parent.id });
   }
 
+  const assetName = date + '_' + cropName;
+  
   // create an asset--plant
   const plantAsset = farm.asset.create({
     type: 'asset--plant',

--- a/library/farmosUtil/farmosUtil.js
+++ b/library/farmosUtil/farmosUtil.js
@@ -2042,7 +2042,7 @@ export async function createSoilDisturbanceActivityLog(
   }
 
   let assetName =
-    dayjs(disturbanceDate).format('YYYY-MM-DD') + '_ds_' + locationName;
+    dayjs(disturbanceDate).format('YYYY-MM-DD') + '_sd_' + locationName;
 
   const activityLogData = {
     type: 'log--activity',

--- a/library/farmosUtil/farmosUtil.js
+++ b/library/farmosUtil/farmosUtil.js
@@ -2311,10 +2311,17 @@ export async function createTransplantingActivityLog(
   const quantitiesArray = getQuantityObjects(quantities);
   const logCategoriesArray = await getLogCategoryObjects(['transplanting']);
 
+  const cropIdToTermMap = await getCropIdToTermMap();
+  const logName =
+    dayjs(transplantingDate).format('YYYY-MM-DD') +
+    '_xp_' +
+    cropIdToTermMap.get(plantAsset.relationships.plant_type[0].id).attributes
+      .name;
+
   const activityLogData = {
     type: 'log--activity',
     attributes: {
-      name: plantAsset.attributes.name,
+      name: logName,
       timestamp: dayjs(transplantingDate).format(),
       status: 'done',
       is_movement: true,

--- a/library/farmosUtil/farmosUtil.js
+++ b/library/farmosUtil/farmosUtil.js
@@ -1575,7 +1575,7 @@ export async function runTransaction(operations) {
  * @category Plant
  */
 export async function createPlantAsset(
-  date, 
+  date,
   cropName,
   comment = '',
   parents = []
@@ -1589,7 +1589,7 @@ export async function createPlantAsset(
   }
 
   const assetName = date + '_' + cropName;
-  
+
   // create an asset--plant
   const plantAsset = farm.asset.create({
     type: 'asset--plant',
@@ -1919,10 +1919,23 @@ export async function createSeedingLog(
   const quantitiesArray = getQuantityObjects(quantities);
   const logCategoriesArray = await getLogCategoryObjects(logCategories);
 
+  // Generate log name based on conventions in docs/DataModel.md.
+  const cropIdToNameMap = await getCropIdToTermMap();
+  let logName = dayjs(seedingDate).format('YYYY-MM-DD');
+  if (logCategories.includes('seeding_tray')) {
+    logName += '_ts_';
+  } else if (logCategories.includes('seeding_direct')) {
+    logName += '_ds_';
+  } else if (logCategories.includes('seeding_cover_crop')) {
+    logName += '_cs_';
+  }
+  logName += cropIdToNameMap.get(plantAsset.relationships.plant_type[0].id)
+    .attributes.name;
+
   const seedingLogData = {
     type: 'log--seeding',
     attributes: {
-      name: plantAsset.attributes.name,
+      name: logName,
       timestamp: dayjs(seedingDate).format(),
       status: 'done',
       is_movement: true,

--- a/library/farmosUtil/farmosUtil.js
+++ b/library/farmosUtil/farmosUtil.js
@@ -2041,10 +2041,13 @@ export async function createSoilDisturbanceActivityLog(
     });
   }
 
+  let assetName =
+    dayjs(disturbanceDate).format('YYYY-MM-DD') + '_sd_' + locationName;
+
   const activityLogData = {
     type: 'log--activity',
     attributes: {
-      name: plantAsset.attributes.name,
+      name: assetName,
       timestamp: dayjs(disturbanceDate).format(),
       status: 'done',
       purchase_date: dayjs(disturbanceDate).format(),

--- a/library/farmosUtil/farmosUtil.js
+++ b/library/farmosUtil/farmosUtil.js
@@ -2042,7 +2042,7 @@ export async function createSoilDisturbanceActivityLog(
   }
 
   let assetName =
-    dayjs(disturbanceDate).format('YYYY-MM-DD') + '_sd_' + locationName;
+    dayjs(disturbanceDate).format('YYYY-MM-DD') + '_ds_' + locationName;
 
   const activityLogData = {
     type: 'log--activity',

--- a/library/farmosUtil/farmosUtil.plant.unit.cy.js
+++ b/library/farmosUtil/farmosUtil.plant.unit.cy.js
@@ -33,13 +33,23 @@ describe('Test the plant asset functions', () => {
   });
 
   it('Create a plant asset with parents', () => {
-    cy.wrap(farmosUtil.createPlantAsset('1999-01-02', 'ARUGULA', 'p1')).as('p1');
-    cy.wrap(farmosUtil.createPlantAsset('1999-01-03', 'ARUGULA', 'p2')).as('p2');
-    cy.wrap(farmosUtil.createPlantAsset('1999-01-04', 'ARUGULA', 'p3')).as('p3');
+    cy.wrap(farmosUtil.createPlantAsset('1999-01-02', 'ARUGULA', 'p1')).as(
+      'p1'
+    );
+    cy.wrap(farmosUtil.createPlantAsset('1999-01-03', 'ARUGULA', 'p2')).as(
+      'p2'
+    );
+    cy.wrap(farmosUtil.createPlantAsset('1999-01-04', 'ARUGULA', 'p3')).as(
+      'p3'
+    );
 
     cy.getAll(['@p1', '@p2', '@p3']).then(([p1, p2, p3]) => {
       cy.wrap(
-        farmosUtil.createPlantAsset('1999-01-05', 'ARUGULA', 'child', [p1, p2, p3])
+        farmosUtil.createPlantAsset('1999-01-05', 'ARUGULA', 'child', [
+          p1,
+          p2,
+          p3,
+        ])
       ).as('plant');
     });
 
@@ -64,7 +74,7 @@ describe('Test the plant asset functions', () => {
 
     cy.wrap(
       farmosUtil
-        .createPlantAsset('testPlant', 'ARUGULA', 'testComment')
+        .createPlantAsset('1999-01-02', 'ARUGULA', 'testComment')
         .then(() => {
           throw new Error('Creating plant asset should have failed.');
         })
@@ -76,7 +86,7 @@ describe('Test the plant asset functions', () => {
 
   it('Delete a plant asset', () => {
     cy.wrap(
-      farmosUtil.createPlantAsset('testPlant', 'ARUGULA', 'testComment')
+      farmosUtil.createPlantAsset('1999-01-02', 'ARUGULA', 'testComment')
     ).then((plantAsset) => {
       cy.wrap(farmosUtil.deletePlantAsset(plantAsset.id)).then((result) => {
         expect(result.status).to.equal(204);
@@ -102,7 +112,9 @@ describe('Test the plant asset functions', () => {
   });
 
   it('Archive/Unarchive a plant asset', () => {
-    cy.wrap(farmosUtil.createPlantAsset('1999-01-02', 'ARUGULA', 'p1')).as('p1');
+    cy.wrap(farmosUtil.createPlantAsset('1999-01-02', 'ARUGULA', 'p1')).as(
+      'p1'
+    );
 
     cy.get('@p1').then((p1) => {
       expect(p1.attributes.name).to.equal('1999-01-02_ARUGULA');

--- a/library/farmosUtil/farmosUtil.plant.unit.cy.js
+++ b/library/farmosUtil/farmosUtil.plant.unit.cy.js
@@ -18,12 +18,12 @@ describe('Test the plant asset functions', () => {
   });
 
   it('Create a plant asset', () => {
-    cy.wrap(farmosUtil.createPlantAsset('testPlant', 'ARUGULA', 'testComment'))
+    cy.wrap(farmosUtil.createPlantAsset('1999-01-03', 'ARUGULA', 'testComment'))
       .then((plantAsset) => {
         cy.wrap(farmosUtil.getPlantAsset(plantAsset.id));
       })
       .then((result) => {
-        expect(result.attributes.name).to.equal('testPlant');
+        expect(result.attributes.name).to.equal('1999-01-03_ARUGULA');
         expect(result.attributes.status).to.equal('active');
         expect(result.attributes.notes.value).to.equal('testComment');
         expect(result.relationships.plant_type[0].id).to.equal(
@@ -33,18 +33,18 @@ describe('Test the plant asset functions', () => {
   });
 
   it('Create a plant asset with parents', () => {
-    cy.wrap(farmosUtil.createPlantAsset('p1', 'ARUGULA', 'p1')).as('p1');
-    cy.wrap(farmosUtil.createPlantAsset('p2', 'ARUGULA', 'p2')).as('p2');
-    cy.wrap(farmosUtil.createPlantAsset('p3', 'ARUGULA', 'p3')).as('p3');
+    cy.wrap(farmosUtil.createPlantAsset('1999-01-02', 'ARUGULA', 'p1')).as('p1');
+    cy.wrap(farmosUtil.createPlantAsset('1999-01-03', 'ARUGULA', 'p2')).as('p2');
+    cy.wrap(farmosUtil.createPlantAsset('1999-01-04', 'ARUGULA', 'p3')).as('p3');
 
     cy.getAll(['@p1', '@p2', '@p3']).then(([p1, p2, p3]) => {
       cy.wrap(
-        farmosUtil.createPlantAsset('child', 'ARUGULA', 'child', [p1, p2, p3])
+        farmosUtil.createPlantAsset('1999-01-05', 'ARUGULA', 'child', [p1, p2, p3])
       ).as('plant');
     });
 
     cy.getAll(['@plant', '@p1', '@p2', '@p3']).then(([plant, p1, p2, p3]) => {
-      expect(plant.attributes.name).to.equal('child');
+      expect(plant.attributes.name).to.equal('1999-01-05_ARUGULA');
       expect(plant.attributes.status).to.equal('active');
       expect(plant.attributes.notes.value).to.equal('child');
       expect(plant.relationships.plant_type[0].id).to.equal(
@@ -102,10 +102,10 @@ describe('Test the plant asset functions', () => {
   });
 
   it('Archive/Unarchive a plant asset', () => {
-    cy.wrap(farmosUtil.createPlantAsset('p1', 'ARUGULA', 'p1')).as('p1');
+    cy.wrap(farmosUtil.createPlantAsset('1999-01-02', 'ARUGULA', 'p1')).as('p1');
 
     cy.get('@p1').then((p1) => {
-      expect(p1.attributes.name).to.equal('p1');
+      expect(p1.attributes.name).to.equal('1999-01-02_ARUGULA');
       expect(p1.attributes.status).to.equal('active');
 
       cy.wrap(farmosUtil.archivePlantAsset(p1.id, true)).as('archived');
@@ -116,7 +116,7 @@ describe('Test the plant asset functions', () => {
     });
 
     cy.get('@p1-archived').then((p1Archived) => {
-      expect(p1Archived.attributes.name).to.equal('p1');
+      expect(p1Archived.attributes.name).to.equal('1999-01-02_ARUGULA');
       expect(p1Archived.attributes.status).to.equal('archived');
 
       cy.wrap(farmosUtil.archivePlantAsset(p1Archived.id), false).as(
@@ -129,7 +129,7 @@ describe('Test the plant asset functions', () => {
     });
 
     cy.get('@p1-unArchived').then((p1unArchived) => {
-      expect(p1unArchived.attributes.name).to.equal('p1');
+      expect(p1unArchived.attributes.name).to.equal('1999-01-02_ARUGULA');
       expect(p1unArchived.attributes.status).to.equal('active');
     });
   });

--- a/library/farmosUtil/farmosUtil.quantity.unit.cy.js
+++ b/library/farmosUtil/farmosUtil.quantity.unit.cy.js
@@ -78,7 +78,7 @@ describe('Test the quantity functions', () => {
 
   it('Create a quantity with an inventory adjustment', () => {
     cy.wrap(
-      farmosUtil.createPlantAsset('testPlant', 'ARUGULA', 'testComment')
+      farmosUtil.createPlantAsset('1999-01-02', 'ARUGULA', 'testComment')
     ).as('plantAsset');
 
     cy.get('@plantAsset').then((plantAsset) => {

--- a/library/farmosUtil/farmosUtil.seeding.unit.cy.js
+++ b/library/farmosUtil/farmosUtil.seeding.unit.cy.js
@@ -34,7 +34,7 @@ describe('Test the seeding log functions', () => {
 
   it('Create a tray seeding log', () => {
     cy.wrap(
-      farmosUtil.createPlantAsset('testPlant', 'ARUGULA', 'testComment')
+      farmosUtil.createPlantAsset('1999-01-02', 'ARUGULA', 'testComment')
     ).as('plantAsset');
 
     cy.wrap(
@@ -90,7 +90,7 @@ describe('Test the seeding log functions', () => {
 
   it('Create a direct seeding log w/ beds', () => {
     cy.wrap(
-      farmosUtil.createPlantAsset('testPlant', 'ARUGULA', 'testComment')
+      farmosUtil.createPlantAsset('1999-01-02', 'ARUGULA', 'testComment')
     ).as('plantAsset');
 
     cy.wrap(
@@ -157,7 +157,7 @@ describe('Test the seeding log functions', () => {
     });
 
     cy.wrap(
-      farmosUtil.createPlantAsset('testPlant', 'ARUGULA', 'testComment')
+      farmosUtil.createPlantAsset('1999-01-02', 'ARUGULA', 'testComment')
     ).as('plantAsset');
 
     cy.get('@plantAsset').then((plantAsset) => {
@@ -184,7 +184,7 @@ describe('Test the seeding log functions', () => {
 
   it('Delete a seeding log', () => {
     cy.wrap(
-      farmosUtil.createPlantAsset('testPlant', 'ARUGULA', 'testComment')
+      farmosUtil.createPlantAsset('1999-01-02', 'ARUGULA', 'testComment')
     ).as('plantAsset');
 
     cy.wrap(

--- a/library/farmosUtil/farmosUtil.seeding.unit.cy.js
+++ b/library/farmosUtil/farmosUtil.seeding.unit.cy.js
@@ -60,7 +60,7 @@ describe('Test the seeding log functions', () => {
           expect(result.attributes.timestamp).to.contain('1999-01-02');
           expect(result.attributes.purchase_date).to.contain('1999-01-02');
 
-          expect(result.attributes.name).to.equal(plantAsset.attributes.name);
+          expect(result.attributes.name).to.equal('1999-01-02_ts_ARUGULA');
 
           expect(result.attributes.status).to.equal('done');
           expect(result.attributes.is_movement).to.equal(true);
@@ -116,7 +116,7 @@ describe('Test the seeding log functions', () => {
           expect(result.attributes.timestamp).to.contain('1999-01-02');
           expect(result.attributes.purchase_date).to.contain('1999-01-02');
 
-          expect(result.attributes.name).to.equal(plantAsset.attributes.name);
+          expect(result.attributes.name).to.equal('1999-01-02_ds_ARUGULA');
 
           expect(result.attributes.status).to.equal('done');
           expect(result.attributes.is_movement).to.equal(true);
@@ -149,6 +149,38 @@ describe('Test the seeding log functions', () => {
         });
       }
     );
+  });
+
+  it('Create a cover crop seeding log', () => {
+    cy.wrap(
+      farmosUtil.createPlantAsset('1999-01-02', 'ARUGULA', 'testComment')
+    ).as('plantAsset');
+
+    cy.wrap(
+      farmosUtil.createStandardQuantity('count', 7, 'testLabel', 'TRAYS')
+    ).as('quantity');
+
+    cy.getAll(['@plantAsset', '@quantity']).then(([plantAsset, quantity]) => {
+      cy.wrap(
+        farmosUtil.createSeedingLog(
+          '01/02/1999',
+          'CHUAU',
+          [],
+          ['seeding', 'seeding_cover_crop'],
+          plantAsset,
+          [quantity]
+        )
+      ).as('seedingLog');
+    });
+
+    cy.get('@seedingLog').then((seedingLog) => {
+      cy.wrap(farmosUtil.getSeedingLog(seedingLog.id)).then((result) => {
+        expect(result.attributes.timestamp).to.contain('1999-01-02');
+        expect(result.attributes.purchase_date).to.contain('1999-01-02');
+
+        expect(result.attributes.name).to.equal('1999-01-02_cs_ARUGULA');
+      });
+    });
   });
 
   it('Error creating seeding log', { retries: 4 }, () => {

--- a/library/farmosUtil/farmosUtil.soil.unit.cy.js
+++ b/library/farmosUtil/farmosUtil.soil.unit.cy.js
@@ -80,7 +80,7 @@ describe('Test the soil disturbance activity log functions', () => {
       cy.wrap(farmosUtil.getSoilDisturbanceActivityLog(soilLog.id)).then(
         (result) => {
           expect(result.type).to.equal('log--activity');
-          expect(result.attributes.name).to.equal(plantAsset.attributes.name);
+          expect(result.attributes.name).to.equal('1999-01-02_sd_A');
           expect(result.attributes.timestamp).to.contain('1999-01-02');
           expect(result.attributes.status).to.equal('done');
           expect(result.attributes.is_movement).to.equal(false);
@@ -157,7 +157,7 @@ describe('Test the soil disturbance activity log functions', () => {
       cy.wrap(farmosUtil.getSoilDisturbanceActivityLog(soilLog.id)).then(
         (result) => {
           expect(result.type).to.equal('log--activity');
-          expect(result.attributes.name).to.equal(plantAsset.attributes.name);
+          expect(result.attributes.name).to.equal('1999-01-02_sd_CHUAU');
           expect(result.attributes.timestamp).to.contain('1999-01-02');
           expect(result.attributes.status).to.equal('done');
           expect(result.attributes.is_movement).to.equal(false);

--- a/library/farmosUtil/farmosUtil.soil.unit.cy.js
+++ b/library/farmosUtil/farmosUtil.soil.unit.cy.js
@@ -80,7 +80,7 @@ describe('Test the soil disturbance activity log functions', () => {
       cy.wrap(farmosUtil.getSoilDisturbanceActivityLog(soilLog.id)).then(
         (result) => {
           expect(result.type).to.equal('log--activity');
-          expect(result.attributes.name).to.equal('1999-01-02_ds_A');
+          expect(result.attributes.name).to.equal('1999-01-02_sd_A');
           expect(result.attributes.timestamp).to.contain('1999-01-02');
           expect(result.attributes.status).to.equal('done');
           expect(result.attributes.is_movement).to.equal(false);
@@ -157,7 +157,7 @@ describe('Test the soil disturbance activity log functions', () => {
       cy.wrap(farmosUtil.getSoilDisturbanceActivityLog(soilLog.id)).then(
         (result) => {
           expect(result.type).to.equal('log--activity');
-          expect(result.attributes.name).to.equal('1999-01-02_ds_CHUAU');
+          expect(result.attributes.name).to.equal('1999-01-02_sd_CHUAU');
           expect(result.attributes.timestamp).to.contain('1999-01-02');
           expect(result.attributes.status).to.equal('done');
           expect(result.attributes.is_movement).to.equal(false);

--- a/library/farmosUtil/farmosUtil.soil.unit.cy.js
+++ b/library/farmosUtil/farmosUtil.soil.unit.cy.js
@@ -80,7 +80,7 @@ describe('Test the soil disturbance activity log functions', () => {
       cy.wrap(farmosUtil.getSoilDisturbanceActivityLog(soilLog.id)).then(
         (result) => {
           expect(result.type).to.equal('log--activity');
-          expect(result.attributes.name).to.equal('1999-01-02_sd_A');
+          expect(result.attributes.name).to.equal('1999-01-02_ds_A');
           expect(result.attributes.timestamp).to.contain('1999-01-02');
           expect(result.attributes.status).to.equal('done');
           expect(result.attributes.is_movement).to.equal(false);
@@ -157,7 +157,7 @@ describe('Test the soil disturbance activity log functions', () => {
       cy.wrap(farmosUtil.getSoilDisturbanceActivityLog(soilLog.id)).then(
         (result) => {
           expect(result.type).to.equal('log--activity');
-          expect(result.attributes.name).to.equal('1999-01-02_sd_CHUAU');
+          expect(result.attributes.name).to.equal('1999-01-02_ds_CHUAU');
           expect(result.attributes.timestamp).to.contain('1999-01-02');
           expect(result.attributes.status).to.equal('done');
           expect(result.attributes.is_movement).to.equal(false);

--- a/library/farmosUtil/farmosUtil.soil.unit.cy.js
+++ b/library/farmosUtil/farmosUtil.soil.unit.cy.js
@@ -39,7 +39,7 @@ describe('Test the soil disturbance activity log functions', () => {
 
   it('Create a soil disturbance activity log for a field', () => {
     cy.wrap(
-      farmosUtil.createPlantAsset('testPlant', 'ARUGULA', 'testComment')
+      farmosUtil.createPlantAsset('1999-01-02', 'ARUGULA', 'testComment')
     ).as('plantAsset');
 
     cy.wrap(
@@ -119,7 +119,7 @@ describe('Test the soil disturbance activity log functions', () => {
 
   it('Create a soil disturbance activity log for a Greenhouse w/ beds', () => {
     cy.wrap(
-      farmosUtil.createPlantAsset('testPlant', 'ARUGULA', 'testComment')
+      farmosUtil.createPlantAsset('1999-01-02', 'ARUGULA', 'testComment')
     ).as('plantAsset');
 
     cy.wrap(
@@ -209,7 +209,7 @@ describe('Test the soil disturbance activity log functions', () => {
     });
 
     cy.wrap(
-      farmosUtil.createPlantAsset('testPlant', 'ARUGULA', 'testComment')
+      farmosUtil.createPlantAsset('1999-01-02', 'ARUGULA', 'testComment')
     ).as('plantAsset');
 
     cy.get('@plantAsset').then((plantAsset) => {
@@ -238,7 +238,7 @@ describe('Test the soil disturbance activity log functions', () => {
 
   it('Delete a soil disturbance activity log', () => {
     cy.wrap(
-      farmosUtil.createPlantAsset('testPlant', 'ARUGULA', 'testComment')
+      farmosUtil.createPlantAsset('1999-01-02', 'ARUGULA', 'testComment')
     ).as('plantAsset');
 
     cy.get('@plantAsset').then((plantAsset) => {

--- a/library/farmosUtil/farmosUtil.transaction.unit.cy.js
+++ b/library/farmosUtil/farmosUtil.transaction.unit.cy.js
@@ -118,13 +118,12 @@ describe('Test the plant asset functions', () => {
       cropName: 'ARUGULA',
       comment: 'test comment',
     };
-    const assetName = 'test asset';
 
     const createPlantAsset = {
       name: 'createPlantAsset',
       do: async () => {
         return await farmosUtil.createPlantAsset(
-          assetName,
+          '1999-01-02',
           formData.cropName,
           formData.comment
         );
@@ -139,7 +138,9 @@ describe('Test the plant asset functions', () => {
     cy.wrap(farmosUtil.runTransaction(ops)).as('result');
 
     cy.get('@result').then((result) => {
-      expect(result.createPlantAsset.attributes.name).to.equal(assetName);
+      expect(result.createPlantAsset.attributes.name).to.equal(
+        '1999-01-02_ARUGULA'
+      );
     });
   });
 

--- a/library/farmosUtil/farmosUtil.transaction.unit.cy.js
+++ b/library/farmosUtil/farmosUtil.transaction.unit.cy.js
@@ -149,13 +149,12 @@ describe('Test the plant asset functions', () => {
       cropName: 'WATERMELON',
       comment: 'test comment',
     };
-    const assetName = 'test asset';
 
     const createPlantAsset = {
       name: 'createPlantAsset',
       do: async () => {
         return await farmosUtil.createPlantAsset(
-          assetName,
+          '1999-01-02',
           formData.cropName,
           formData.comment
         );

--- a/library/farmosUtil/farmosUtil.transplanting.unit.cy.js
+++ b/library/farmosUtil/farmosUtil.transplanting.unit.cy.js
@@ -108,7 +108,7 @@ describe('Test the transplanting activity log functions', () => {
     ]).then(
       ([transplantingLog, bedFeetQuantity, traysQuantity, transplantAsset]) => {
         expect(transplantingLog.attributes.name).to.equal(
-          '1999-01-02_BROCCOLI'
+          '1999-01-02_xp_BROCCOLI'
         );
         expect(transplantingLog.attributes.timestamp).to.contain('1999-01-02');
         expect(transplantingLog.type).to.equal('log--activity');

--- a/library/farmosUtil/farmosUtil.transplanting.unit.cy.js
+++ b/library/farmosUtil/farmosUtil.transplanting.unit.cy.js
@@ -39,18 +39,16 @@ describe('Test the transplanting activity log functions', () => {
     });
 
     // Create a new plant asset for the transplanted crop
-    cy.getAll(['@seedlings', '@seedlingAsset']).then(
-      ([seedlings, seedlingAsset]) => {
-        cy.wrap(
-          farmosUtil.createPlantAsset(
-            'transplantTest',
-            seedlings[0].crop,
-            'testing transplanting',
-            [seedlingAsset]
-          )
-        ).as('transplantAsset');
-      }
-    );
+    cy.get('@seedlingAsset').then((seedlingAsset) => {
+      cy.wrap(
+        farmosUtil.createPlantAsset(
+          '1999-01-02',
+          'BROCCOLI',
+          'testing transplanting',
+          [seedlingAsset]
+        )
+      ).as('transplantAsset');
+    });
 
     // Create quantities for the transplanting log
     cy.getAll(['@transplantAsset', '@seedlingAsset', '@seedlings']).then(
@@ -109,7 +107,9 @@ describe('Test the transplanting activity log functions', () => {
       '@transplantAsset',
     ]).then(
       ([transplantingLog, bedFeetQuantity, traysQuantity, transplantAsset]) => {
-        expect(transplantingLog.attributes.name).to.equal('transplantTest');
+        expect(transplantingLog.attributes.name).to.equal(
+          '1999-01-02_BROCCOLI'
+        );
         expect(transplantingLog.attributes.timestamp).to.contain('1999-01-02');
         expect(transplantingLog.type).to.equal('log--activity');
         expect(transplantingLog.attributes.status).to.equal('done');
@@ -157,7 +157,7 @@ describe('Test the transplanting activity log functions', () => {
     cy.get('@readTransplantAsset').then((transplantAsset) => {
       expect(transplantAsset.type).to.equal('asset--plant');
 
-      expect(transplantAsset.attributes.name).to.equal('transplantTest');
+      expect(transplantAsset.attributes.name).to.equal('1999-01-02_BROCCOLI');
       expect(transplantAsset.attributes.status).to.equal('active');
 
       expect(transplantAsset.attributes.inventory).to.have.length(1);
@@ -204,7 +204,7 @@ describe('Test the transplanting activity log functions', () => {
     // Create a new plant asset for the transplanted crop
     cy.wrap(
       farmosUtil.createPlantAsset(
-        'transplantTest',
+        '1999-01-02',
         'BROCCOLI',
         'testing transplanting'
       )
@@ -236,7 +236,7 @@ describe('Test the transplanting activity log functions', () => {
   it('Delete a transplanting log', () => {
     cy.wrap(
       farmosUtil.createPlantAsset(
-        'transplantTest',
+        '1999-01-02',
         'BROCCOLI',
         'testing transplanting'
       )

--- a/modules/farm_fd2/src/entrypoints/direct_seeding/lib.js
+++ b/modules/farm_fd2/src/entrypoints/direct_seeding/lib.js
@@ -27,7 +27,6 @@ import * as farmosUtil from '@libs/farmosUtil/farmosUtil';
  */
 export async function submitForm(formData) {
   try {
-    const assetName = formData.seedingDate + '_ds_' + formData.cropName;
     const ops = [];
     const equipmentAssets = [];
 
@@ -35,7 +34,7 @@ export async function submitForm(formData) {
       name: 'plantAsset',
       do: async () => {
         return await farmosUtil.createPlantAsset(
-          assetName,
+          formData.seedingDate,
           formData.cropName,
           formData.comment
         );

--- a/modules/farm_fd2/src/entrypoints/direct_seeding/lib.submit.unit.cy.js
+++ b/modules/farm_fd2/src/entrypoints/direct_seeding/lib.submit.unit.cy.js
@@ -59,9 +59,7 @@ describe('Submission using the direct_seeding lib.', () => {
     cy.wrap(farmosUtil.getPlantAsset(result.plantAsset.id)).then(
       (plantAsset) => {
         expect(plantAsset.type).to.equal('asset--plant');
-        expect(plantAsset.attributes.name).to.equal(
-          result.plantAsset.attributes.name
-        );
+        expect(plantAsset.attributes.name).to.equal('1950-01-02_BROCCOLI');
         expect(plantAsset.attributes.status).to.equal('active');
         expect(plantAsset.attributes.notes.value).to.equal(form.comment);
 
@@ -193,9 +191,7 @@ describe('Submission using the direct_seeding lib.', () => {
     cy.wrap(farmosUtil.getSeedingLog(result.seedingLog.id)).then(
       (seedingLog) => {
         expect(seedingLog.type).to.equal('log--seeding');
-        expect(seedingLog.attributes.name).to.equal(
-          result.seedingLog.attributes.name
-        );
+        expect(seedingLog.attributes.name).to.equal('1950-01-02_ds_BROCCOLI');
         expect(seedingLog.attributes.timestamp).to.contain('1950-01-02');
         expect(seedingLog.attributes.status).to.equal('done');
         expect(seedingLog.attributes.is_movement).to.be.true;
@@ -324,9 +320,7 @@ describe('Submission using the direct_seeding lib.', () => {
       farmosUtil.getSoilDisturbanceActivityLog(result.activityLog.id)
     ).then((activityLog) => {
       expect(activityLog.type).to.equal('log--activity');
-      expect(activityLog.attributes.name).to.equal(
-        result.plantAsset.attributes.name
-      );
+      expect(activityLog.attributes.name).to.equal('1950-01-02_sd_ALF');
       expect(activityLog.attributes.timestamp).to.contain('1950-01-02');
       expect(activityLog.attributes.status).to.equal('done');
       expect(activityLog.attributes.is_movement).to.equal(false);

--- a/modules/farm_fd2/src/entrypoints/transplanting/lib.js
+++ b/modules/farm_fd2/src/entrypoints/transplanting/lib.js
@@ -97,15 +97,11 @@ export async function submitForm(formData) {
     };
     ops.push(trayInventoryQuantities);
 
-    // Create the plant asset representing the transplanted crop.
-    // Include the original tray seeded plant assets as parents.
-    const assetName = formData.transplantingDate + '_' + formData.cropName;
-
     const transplantingAsset = {
       name: 'transplantingAsset',
       do: async (results) => {
         return await farmosUtil.createPlantAsset(
-          assetName,
+          formData.transplantingDate,
           formData.cropName,
           formData.comment,
           results.parents

--- a/modules/farm_fd2/src/entrypoints/transplanting/lib.js
+++ b/modules/farm_fd2/src/entrypoints/transplanting/lib.js
@@ -72,9 +72,6 @@ export async function submitForm(formData) {
           );
           const traysPicked = formData.picked[i].trays;
 
-          console.log('Tray quantity: ' + trayInvenotry);
-          console.log('Trays picked: ' + traysPicked);
-
           // All of the trays in the planting have been transplanted.
           if (traysPicked == trayInvenotry) {
             await farmosUtil.archivePlantAsset(results.parents[i].id, true);

--- a/modules/farm_fd2/src/entrypoints/tray_seeding/lib.js
+++ b/modules/farm_fd2/src/entrypoints/tray_seeding/lib.js
@@ -21,13 +21,11 @@ import * as farmosUtil from '@libs/farmosUtil/farmosUtil';
  */
 export async function submitForm(formData) {
   try {
-    const assetName = formData.seedingDate + '_ts_' + formData.cropName;
-
     const plantAsset = {
       name: 'plantAsset',
       do: async () => {
         return await farmosUtil.createPlantAsset(
-          assetName,
+          formData.seedingDate,
           formData.cropName,
           formData.comment
         );


### PR DESCRIPTION
**Pull Request Description**

The naming conventions for logs and assets as described in `docs/DataModel.md` are now enforced in the code.

Closes #208 

---

**Licensing Certification**

FarmData2 is a [Free Cultural Work](https://freedomdefined.org/Definition) and all accepted contributions are licensed as described in the LICENSE.md file. This requires that the contributor holds the rights to do so. By submitting this pull request **I certify that I satisfy the terms of the [Developer Certificate of Origin](https://developercertificate.org/)** for its contents.
