### PR TITLE
fix: builds single css file for each module

### DIFF
--- a/bin/templates/entrypoint/libraries.yml
+++ b/bin/templates/entrypoint/libraries.yml
@@ -6,8 +6,6 @@
       minified: true
       attributes: { type: 'module' }
   css:
-    theme:
-      %ENTRY_POINT%/%ENTRY_POINT%.css: {}
     component:
-      shared/index.css: {}
+      style/style.css: {}
     

--- a/modules/farm_fd2/src/module/farm_fd2.libraries.yml
+++ b/modules/farm_fd2/src/module/farm_fd2.libraries.yml
@@ -6,9 +6,8 @@ main:
       attributes: { type: 'module' }
   css:
     component:
-      main/main.css: {}
-      shared/index.css: {}
-      
+      style/style.css: {}
+
 tray_seeding:
   js:
     tray_seeding/tray_seeding.js:
@@ -17,9 +16,7 @@ tray_seeding:
       attributes: { type: 'module' }
   css:
     component:
-      tray_seeding/tray_seeding.css: {}
-      shared/index.css: {}
-      SubmitResetButtons/SubmitResetButtons.css: {}
+      style/style.css: {}
 
 seeding:
   js:
@@ -29,8 +26,7 @@ seeding:
       attributes: { type: 'module' }
   css:
     component:
-      seeding/seeding.css: {}
-      shared/index.css: {}
+      style/style.css: {}
 
 direct_seeding:
   js:
@@ -40,10 +36,7 @@ direct_seeding:
       attributes: { type: 'module' }
   css:
     component:
-      direct_seeding/direct_seeding.css: {}
-      shared/index.css: {}
-      SoilDisturbance/SoilDisturbance.css: {}
-      SubmitResetButtons/SubmitResetButtons.css: {}
+      style/style.css: {}
 
 transplanting:
   js:
@@ -53,7 +46,4 @@ transplanting:
       attributes: { type: 'module' }
   css:
     component:
-      transplanting/transplanting.css: {}
-      shared/index.css: {}
-      SoilDisturbance/SoilDisturbance.css: {}
-      SubmitResetButtons/SubmitResetButtons.css: {}
+      style/style.css: {}

--- a/modules/farm_fd2/vite.config.js
+++ b/modules/farm_fd2/vite.config.js
@@ -63,7 +63,7 @@ let viteConfig = {
   build: {
     outDir: '../../dist/farmdata2',
     emptyOutDir: true,
-    exclude: ['**/*.cy.js', '**/*.cy.comp.js', '**/*.cy.unit.js'],
+    cssCodeSplit: false,
     rollupOptions: {
       input: Object.fromEntries(
         glob.sync('modules/farm_fd2/src/entrypoints/*/*.html').map((dir) => {
@@ -74,19 +74,7 @@ let viteConfig = {
       output: {
         // Ensures that the entry point and css names are not hashed.
         entryFileNames: '[name]/[name].js',
-        assetFileNames: (assetInfo) => {
-          let name = assetInfo.name.split('/').at(0);
-          let ext = assetInfo.name.split('.').at(1);
-          if (ext === 'css') {
-            if (name.startsWith('_plugin-vue_')) {
-              return 'shared/index.css';
-            } else {
-              return '[name]/[name].css';
-            }
-          } else {
-            return 'shared/[name].[ext]';
-          }
-        },
+        assetFileNames: '[name]/[name].[ext]',
         chunkFileNames: '[name]/[name].js',
       },
     },

--- a/modules/farm_fd2_examples/src/module/farm_fd2_examples.libraries.yml
+++ b/modules/farm_fd2_examples/src/module/farm_fd2_examples.libraries.yml
@@ -5,10 +5,9 @@ main:
       minified: true
       attributes: { type: 'module' }
   css:
-    theme:
-      main/main.css: {}
     component:
-      shared/index.css: {}
+      style/style.css: {}
+
 component_examples:
   js:
     component_examples/component_examples.js:
@@ -16,10 +15,9 @@ component_examples:
       minified: true
       attributes: { type: 'module' }
   css:
-    theme:
-      component_examples/component_examples.css: {}
     component:
-      shared/index.css: {}
+      style/style.css: {}
+
 bed_picker:
   js:
     bed_picker/bed_picker.js:
@@ -27,10 +25,9 @@ bed_picker:
       minified: true
       attributes: { type: 'module' }
   css:
-    theme:
-      bed_picker/bed_picker.css: {}
     component:
-      shared/index.css: {}
+      style/style.css: {}
+
 date_selector:
   js:
     date_selector/date_selector.js:
@@ -38,10 +35,9 @@ date_selector:
       minified: true
       attributes: { type: 'module' }
   css:
-    theme:
-      date_selector/date_selector.css: {}
     component:
-      shared/index.css: {}
+      style/style.css: {}
+
 picker_base:
   js:
     picker_base/picker_base.js:
@@ -49,10 +45,9 @@ picker_base:
       minified: true
       attributes: { type: 'module' }
   css:
-    theme:
-      picker_base/picker_base.css: {}
     component:
-      shared/index.css: {}
+      style/style.css: {}
+
 selector_base:
   js:
     selector_base/selector_base.js:
@@ -60,10 +55,9 @@ selector_base:
       minified: true
       attributes: { type: 'module' }
   css:
-    theme:
-      selector_base/selector_base.css: {}
     component:
-      shared/index.css: {}
+      style/style.css: {}
+
 picklist_base:
   js:
     picklist_base/picklist_base.js:
@@ -71,11 +65,9 @@ picklist_base:
       minified: true
       attributes: { type: 'module' }
   css:
-    theme:
-      picklist_base/picklist_base.css: {}
     component:
-      shared/index.css: {}
-      PicklistBase/PicklistBase.css: {}
+      style/style.css: {}
+
 transplanting_picklist:
   js:
     transplanting_picklist/transplanting_picklist.js:
@@ -83,8 +75,5 @@ transplanting_picklist:
       minified: true
       attributes: { type: 'module' }
   css:
-    theme:
-      transplanting_picklist/transplanting_picklist.css: {}
     component:
-      shared/index.css: {}
-      PicklistBase/PicklistBase.css: {}
+      style/style.css: {}

--- a/modules/farm_fd2_examples/vite.config.js
+++ b/modules/farm_fd2_examples/vite.config.js
@@ -54,7 +54,7 @@ let viteConfig = {
   build: {
     outDir: '../../dist/fd2_examples',
     emptyOutDir: true,
-    exclude: ['**/*.cy.js', '**/*.cy.comp.js', '**/*.cy.unit.js'],
+    cssCodeSplit: false,
     rollupOptions: {
       input: Object.fromEntries(
         glob
@@ -67,19 +67,7 @@ let viteConfig = {
       output: {
         // Ensures that the entry point and css names are not hashed.
         entryFileNames: '[name]/[name].js',
-        assetFileNames: (assetInfo) => {
-          let name = assetInfo.name.split('/').at(0);
-          let ext = assetInfo.name.split('.').at(1);
-          if (ext === 'css') {
-            if (name.startsWith('_plugin-vue_')) {
-              return 'shared/index.css';
-            } else {
-              return '[name]/[name].css';
-            }
-          } else {
-            return 'shared/[name].[ext]';
-          }
-        },
+        assetFileNames: '[name]/[name].[ext]',
         chunkFileNames: '[name]/[name].js',
       },
     },

--- a/modules/farm_fd2_school/src/module/farm_fd2_school.libraries.yml
+++ b/modules/farm_fd2_school/src/module/farm_fd2_school.libraries.yml
@@ -5,7 +5,5 @@ main:
       minified: true
       attributes: { type: 'module' }
   css:
-    theme:
-      main/main.css: {}
     component:
-      shared/index.css: {}
+      style/style.css: {}

--- a/modules/farm_fd2_school/vite.config.js
+++ b/modules/farm_fd2_school/vite.config.js
@@ -54,7 +54,7 @@ let viteConfig = {
   build: {
     outDir: '../../dist/fd2_school',
     emptyOutDir: true,
-    exclude: ['**/*.cy.js', '**/*.cy.comp.js', '**/*.cy.unit.js'],
+    cssCodeSplit: false,
     rollupOptions: {
       input: Object.fromEntries(
         glob
@@ -67,19 +67,7 @@ let viteConfig = {
       output: {
         // Ensures that the entry point and css names are not hashed.
         entryFileNames: '[name]/[name].js',
-        assetFileNames: (assetInfo) => {
-          let name = assetInfo.name.split('/').at(0);
-          let ext = assetInfo.name.split('.').at(1);
-          if (ext === 'css') {
-            if (name.startsWith('_plugin-vue_')) {
-              return 'shared/index.css';
-            } else {
-              return '[name]/[name].css';
-            }
-          } else {
-            return 'shared/[name].[ext]';
-          }
-        },
+        assetFileNames: '[name]/[name].[ext]',
         chunkFileNames: '[name]/[name].js',
       },
     },


### PR DESCRIPTION
**Pull Request Description**

This PR changes the vite builds so that there is a single `css` file for each module.  Vite was splitting some of the CSS into component specific files (e.g. `CropSelector/CropSelector.css`)  Then to have this styling work within an entry point that `css` file would need to be added to the `*.libraries.yml` file so that Drupal makes it available to the page. This was complicated, and a bit unpredictable because it was unclear why or when vite would do this. So, instead a single `css` file is now created in `style/style.css` and that file is included in the `*.libraries.yml` for each entry point.  That introduces a small inefficiency as all of the CSS is loaded on each entry point even if it is not used.  But this should be a small overhead.

Closes #202 

---

**Licensing Certification**

FarmData2 is a [Free Cultural Work](https://freedomdefined.org/Definition) and all accepted contributions are licensed as described in the LICENSE.md file. This requires that the contributor holds the rights to do so. By submitting this pull request **I certify that I satisfy the terms of the [Developer Certificate of Origin](https://developercertificate.org/)** for its contents.
