### PR TITLE
Update Port Number for FarmData2 Environment Access

### DIFF
--- a/docs/install/local.md
+++ b/docs/install/local.md
@@ -69,7 +69,7 @@ The FarmData2 Development Environment will restart much faster that the first ti
 1. Wait for the message "FarmData2 Development Environment started" to appear in your terminal.
 1. [Connect to the FarmData2 Development Environment](connecting.md):
    - Using your web browser by visiting:
-     - `http://localhost:6109`
+     - `http://localhost:6901`
    - Or by using a VNC client and connecting to:
      - `localhost:5901`
 1. When you are done working:


### PR DESCRIPTION
**Pull Request Description**

Updated the documentation to correct the port number for accessing the FarmData2 development environment from 6109 to 6901, ensuring accurate setup instructions. Verified the new port ensures proper access.

**Licensing Certification**

FarmData2 is a [Free Cultural Work](https://freedomdefined.org/Definition) and all accepted contributions are licensed as described in the LICENSE.md file. This requires that the contributor holds the rights to do so. By submitting this pull request **I certify that I satisfy the terms of the [Developer Certificate of Origin](https://developercertificate.org/)** for its contents.
