### PR TITLE
removes area quantity from lib.js in direct seeding submit form

### DIFF
--- a/modules/farm_fd2/src/entrypoints/direct_seeding/App.vue
+++ b/modules/farm_fd2/src/entrypoints/direct_seeding/App.vue
@@ -61,9 +61,6 @@
           v-bind:pickedBeds="form.beds"
           v-bind:showValidityStyling="validity.show"
           v-on:valid="validity.location = $event"
-          v-on:update:beds="
-            (checkedBeds, totalBeds) => handleBedsUpdate(checkedBeds, totalBeds)
-          "
           v-on:error="(msg) => showErrorToast('Network Error', msg)"
           v-on:ready="createdCount++"
         />
@@ -146,12 +143,11 @@
               v-bind:equipment="form.equipment"
               v-bind:depth="form.depth"
               v-bind:speed="form.speed"
-              v-bind:area="form.area"
+              v-bind:includeArea="includeArea"
               v-on:valid="validity.soilDisturbance = $event"
               v-on:update:equipment="form.equipment = $event"
               v-on:update:depth="form.depth = $event"
               v-on:update:speed="form.speed = $event"
-              v-on:update:area="form.area = $event"
               v-on:error="(msg) => showErrorToast('Network Error', msg)"
               v-on:ready="createdCount++"
             />
@@ -230,7 +226,6 @@ export default {
         equipment: [],
         depth: 0,
         speed: 0,
-        area: '',
         comment: null,
       },
       validity: {
@@ -244,6 +239,7 @@ export default {
         soilDisturbance: false,
         comment: false,
       },
+      includeArea: false,
       enableSubmit: true,
       enableReset: true,
       errorShown: false,
@@ -251,15 +247,6 @@ export default {
     };
   },
   methods: {
-    handleBedsUpdate(checkedBeds, totalBeds) {
-      this.form.beds = checkedBeds;
-
-      if (checkedBeds.length == 0) {
-        this.form.area = '';
-      } else {
-        this.form.area = (checkedBeds.length / totalBeds) * 100;
-      }
-    },
     submit() {
       this.validity.show = true;
 
@@ -315,7 +302,6 @@ export default {
       this.form.cropName = null;
       this.form.beds = [];
       this.form.bedFeet = 100;
-      this.form.area = '';
       this.form.comment = null;
       this.enableSubmit = true;
     },

--- a/modules/farm_fd2/src/entrypoints/direct_seeding/App.vue
+++ b/modules/farm_fd2/src/entrypoints/direct_seeding/App.vue
@@ -61,6 +61,7 @@
           v-bind:pickedBeds="form.beds"
           v-bind:showValidityStyling="validity.show"
           v-on:valid="validity.location = $event"
+          v-on:update:beds="(checkedBeds) => handleBedsUpdate(checkedBeds)"
           v-on:error="(msg) => showErrorToast('Network Error', msg)"
           v-on:ready="createdCount++"
         />
@@ -247,6 +248,9 @@ export default {
     };
   },
   methods: {
+    handleBedsUpdate(checkedBeds) {
+      this.form.beds = checkedBeds;
+    },
     submit() {
       this.validity.show = true;
 

--- a/modules/farm_fd2/src/entrypoints/direct_seeding/direct_seeding.soilDisturbance.e2e.cy.js
+++ b/modules/farm_fd2/src/entrypoints/direct_seeding/direct_seeding.soilDisturbance.e2e.cy.js
@@ -60,60 +60,7 @@ describe('Direct Seeding: Soil Disturbance Component', () => {
 
     cy.get('[data-cy="soil-disturbance-depth"]').should('be.visible');
     cy.get('[data-cy="soil-disturbance-speed"]').should('be.visible');
-    cy.get('[data-cy="soil-disturbance-area"]').should('be.visible');
+    cy.get('[data-cy="soil-disturbance-area"]').should('not.exist');
     cy.get('[data-cy="soil-disturbance-passes"]').should('not.exist');
-  });
-
-  it('Check area computation with no beds', () => {
-    cy.get(
-      '[data-cy="direct-seeding-soil-disturbance-accordion-title"]'
-    ).click();
-    cy.get('[data-cy="equipment-selector-1"]')
-      .find('[data-cy="selector-input"]')
-      .select('Tractor');
-
-    cy.get('[data-cy="soil-disturbance-area"]')
-      .find('[data-cy="numeric-input"]')
-      .should('have.value', '');
-
-    cy.get('[data-cy="location-selector"]')
-      .find('[data-cy="selector-input"]')
-      .select('A');
-
-    cy.get('[data-cy="soil-disturbance-area"]')
-      .find('[data-cy="numeric-input"]')
-      .should('have.value', '');
-  });
-
-  it('Check area computation with beds', () => {
-    cy.get(
-      '[data-cy="direct-seeding-soil-disturbance-accordion-title"]'
-    ).click();
-    cy.get('[data-cy="equipment-selector-1"]')
-      .find('[data-cy="selector-input"]')
-      .select('Tractor');
-
-    cy.get('[data-cy="soil-disturbance-area"]')
-      .find('[data-cy="numeric-input"]')
-      .should('have.value', '');
-
-    cy.get('[data-cy="location-selector"]')
-      .find('[data-cy="selector-input"]')
-      .select('CHUAU');
-
-    // Pick CHUAU-1
-    cy.get('[data-cy="picker-options"]').find('input').eq(0).check();
-
-    cy.get('[data-cy="soil-disturbance-area"]')
-      .find('[data-cy="numeric-input"]')
-      .should('have.value', '20');
-
-    cy.get('[data-cy="location-selector"]')
-      .find('[data-cy="selector-input"]')
-      .select('A');
-
-    cy.get('[data-cy="soil-disturbance-area"]')
-      .find('[data-cy="numeric-input"]')
-      .should('have.value', '');
   });
 });

--- a/modules/farm_fd2/src/entrypoints/direct_seeding/direct_seeding.submission.e2e.cy.js
+++ b/modules/farm_fd2/src/entrypoints/direct_seeding/direct_seeding.submission.e2e.cy.js
@@ -68,12 +68,6 @@ describe('Direct Seeding: Submission tests', () => {
     cy.get('[data-cy="soil-disturbance-speed"]')
       .find('[data-cy="numeric-input"]')
       .type('5');
-    cy.get('[data-cy="soil-disturbance-area"]')
-      .find('[data-cy="numeric-input"]')
-      .clear();
-    cy.get('[data-cy="soil-disturbance-area"]')
-      .find('[data-cy="numeric-input"]')
-      .type('50');
 
     cy.get('[data-cy="comment-input"]').type('test comment');
     cy.get('[data-cy="comment-input"]').blur();
@@ -155,9 +149,6 @@ describe('Direct Seeding: Submission tests', () => {
     cy.get('[data-cy="direct-seeding-bed-feet"]')
       .find('[data-cy="numeric-input"]')
       .should('have.value', '100');
-    cy.get('[data-cy="soil-disturbance-area"]')
-      .find('[data-cy="numeric-input"]')
-      .should('have.value', '');
     cy.get('[data-cy="comment-input"]').should('have.value', '');
 
     // Finally check that the toast is hidden.

--- a/modules/farm_fd2/src/entrypoints/direct_seeding/direct_seeding.submitReset.e2e.cy.js
+++ b/modules/farm_fd2/src/entrypoints/direct_seeding/direct_seeding.submitReset.e2e.cy.js
@@ -65,12 +65,6 @@ describe('Direct Seeding: Submit/Reset Buttons component', () => {
     cy.get('[data-cy="soil-disturbance-speed"]')
       .find('[data-cy="numeric-input"]')
       .type('3');
-    cy.get('[data-cy="soil-disturbance-area"]')
-      .find('[data-cy="numeric-input"]')
-      .clear();
-    cy.get('[data-cy="soil-disturbance-area"]')
-      .find('[data-cy="numeric-input"]')
-      .type('25');
 
     cy.get('[data-cy="comment-input"]').clear();
     cy.get('[data-cy="comment-input"]').type('Test comment');
@@ -169,26 +163,6 @@ describe('Direct Seeding: Submit/Reset Buttons component', () => {
     cy.get('[data-cy="submit-button"]').should('be.enabled');
   });
 
-  it('Invalid area disables submit if equipment is selected', () => {
-    populateForm();
-    cy.get('[data-cy="submit-button"]').should('be.enabled');
-    cy.get('[data-cy="soil-disturbance-area"]')
-      .find('[data-cy="numeric-input"]')
-      .clear();
-    cy.get('[data-cy="soil-disturbance-area"]')
-      .find('[data-cy="numeric-input"]')
-      .blur();
-
-    cy.get('[data-cy="submit-button"]').click();
-    cy.get('[data-cy="submit-button"]').should('be.disabled');
-
-    cy.get('[data-cy="equipment-selector-1"]')
-      .find('[data-cy="selector-delete-button"]')
-      .click();
-
-    cy.get('[data-cy="submit-button"]').should('be.enabled');
-  });
-
   it('Reset button resets form', () => {
     populateForm();
     cy.get('[data-cy="reset-button"]').click();
@@ -249,8 +223,5 @@ describe('Direct Seeding: Submit/Reset Buttons component', () => {
     cy.get('[data-cy="soil-disturbance-speed"]')
       .find('[data-cy="numeric-input"]')
       .should('have.value', '0.0');
-    cy.get('[data-cy="soil-disturbance-area"]')
-      .find('[data-cy="numeric-input"]')
-      .should('have.value', '');
   });
 });

--- a/modules/farm_fd2/src/entrypoints/direct_seeding/lib.js
+++ b/modules/farm_fd2/src/entrypoints/direct_seeding/lib.js
@@ -19,7 +19,6 @@ import * as farmosUtil from '@libs/farmosUtil/farmosUtil';
  *   equipment: [ {asset--equipment} ],
  *   depth: {quantity--standard},
  *   speed: {quantity--standard},
- *   area: {quantity--standard},
  *   activityLog: {log--activity},
  * }
  * ```
@@ -183,22 +182,6 @@ export async function submitForm(formData) {
       };
       ops.push(speedQuantity);
 
-      const areaQuantity = {
-        name: 'areaQuantity',
-        do: async () => {
-          return await farmosUtil.createStandardQuantity(
-            'ratio',
-            formData.area,
-            'Area',
-            'PERCENT'
-          );
-        },
-        undo: async (results) => {
-          await farmosUtil.deleteStandardQuantity(results['areaQuantity'].id);
-        },
-      };
-      ops.push(areaQuantity);
-
       const equipmentMap = await farmosUtil.getEquipmentNameToAssetMap();
       for (const equipmentName of formData.equipment) {
         equipmentAssets.push(equipmentMap.get(equipmentName));
@@ -213,11 +196,7 @@ export async function submitForm(formData) {
             formData.beds,
             ['tillage', 'seeding_direct'],
             results.plantAsset,
-            [
-              results.depthQuantity,
-              results.speedQuantity,
-              results.areaQuantity,
-            ],
+            [results.depthQuantity, results.speedQuantity],
             equipmentAssets
           );
         },
@@ -237,7 +216,6 @@ export async function submitForm(formData) {
       result['equipment'] = null;
       result['depthQuantity'] = null;
       result['speedQuantity'] = null;
-      result['areaQuantity'] = null;
       result['activityLog'] = null;
     }
 

--- a/modules/farm_fd2/src/entrypoints/direct_seeding/lib.submit.unit.cy.js
+++ b/modules/farm_fd2/src/entrypoints/direct_seeding/lib.submit.unit.cy.js
@@ -19,7 +19,6 @@ describe('Submission using the direct_seeding lib.', () => {
     equipment: ['Tractor'],
     depth: 6,
     speed: 5,
-    area: 75,
     comment: 'A comment',
   };
 
@@ -291,30 +290,6 @@ describe('Submission using the direct_seeding lib.', () => {
     );
   });
 
-  it('Check the area quantity--standard', () => {
-    cy.wrap(farmosUtil.getStandardQuantity(result.areaQuantity.id)).then(
-      (areaQuantity) => {
-        expect(areaQuantity.type).to.equal('quantity--standard');
-        expect(areaQuantity.attributes.measure).to.equal('ratio');
-        expect(areaQuantity.attributes.value.decimal).to.equal(
-          form.area.toString()
-        );
-        expect(areaQuantity.attributes.label).to.equal('Area');
-
-        expect(areaQuantity.attributes.inventory_adjustment).to.be.null;
-
-        expect(areaQuantity.relationships.units.type).to.equal(
-          'taxonomy_term--unit'
-        );
-        expect(areaQuantity.relationships.units.id).to.equal(
-          result.areaQuantity.relationships.units.id
-        );
-
-        expect(areaQuantity.relationships.inventory_asset).to.be.null;
-      }
-    );
-  });
-
   it('Check the soil disturbance log--activity', () => {
     cy.wrap(
       farmosUtil.getSoilDisturbanceActivityLog(result.activityLog.id)
@@ -348,15 +323,12 @@ describe('Submission using the direct_seeding lib.', () => {
         categoryMap.get('seeding_direct').id
       );
 
-      expect(activityLog.relationships.quantity.length).to.equal(3);
+      expect(activityLog.relationships.quantity.length).to.equal(2);
       expect(activityLog.relationships.quantity[0].id).to.equal(
         result.depthQuantity.id
       );
       expect(activityLog.relationships.quantity[1].id).to.equal(
         result.speedQuantity.id
-      );
-      expect(activityLog.relationships.quantity[2].id).to.equal(
-        result.areaQuantity.id
       );
       expect(activityLog.relationships.equipment.length).to.equal(1);
       expect(activityLog.relationships.equipment[0].id).to.equal(

--- a/modules/farm_fd2/src/entrypoints/direct_seeding/lib.submitError.unit.cy.js
+++ b/modules/farm_fd2/src/entrypoints/direct_seeding/lib.submitError.unit.cy.js
@@ -18,7 +18,6 @@ describe('Error when submitting using the direct_seeding lib.', () => {
     equipment: ['Tractor'],
     depth: 6,
     speed: 5,
-    area: 50,
     comment: 'A comment',
   };
 
@@ -104,11 +103,8 @@ describe('Error when submitting using the direct_seeding lib.', () => {
           expect(error.message).to.contain(
             'Result of operation speedQuantity could not be cleaned up.'
           );
-          expect(error.message).to.contain(
-            'Result of operation areaQuantity could not be cleaned up.'
-          );
 
-          expect(standardQuantityDeletes).to.equal(7);
+          expect(standardQuantityDeletes).to.equal(6);
           expect(seedingLogDeletes).to.equal(1);
           expect(plantAssetDeletes).to.equal(1);
         }),
@@ -193,7 +189,7 @@ describe('Error when submitting using the direct_seeding lib.', () => {
           expect(error.message).not.to.contain('rowFeetQuantity');
           expect(error.message).not.to.contain('rosPerBedQuantity.');
           expect(error.message).not.to.contain('rowFeetQuantity');
-          expect(standardQuantityDeletes).to.equal(3);
+          expect(standardQuantityDeletes).to.equal(2);
           expect(seedingLogDeletes).to.equal(1);
           expect(plantAssetDeletes).to.equal(1);
         })


### PR DESCRIPTION
**Pull Request Description**

Removed the area quantity from submitForm for the direct seeding in the lib.js file.
Updated relevant tests to pass.

closes #264 


---

**Licensing Certification**

FarmData2 is a [Free Cultural Work](https://freedomdefined.org/Definition) and all accepted contributions are licensed as described in the LICENSE.md file. This requires that the contributor holds the rights to do so. By submitting this pull request **I certify that I satisfy the terms of the [Developer Certificate of Origin](https://developercertificate.org/)** for its contents.
