### PR TITLE
fix(dev): uses vite to build e2e tests

### DIFF
--- a/.cypress.module.config.js
+++ b/.cypress.module.config.js
@@ -1,5 +1,7 @@
 import { defineConfig } from 'cypress';
+import Cypress from 'cypress';
 import { execSync } from 'child_process';
+import vitePreprocessor from 'cypress-vite';
 
 export default defineConfig({
   screenshotOnRunFailure: false,
@@ -14,7 +16,14 @@ export default defineConfig({
       framework: 'vue',
       bundler: 'vite',
     },
-    setupNodeEvents(on) {
+    setupNodeEvents(on, config) {
+      on(
+        'file:preprocessor',
+        vitePreprocessor({
+          configFile: config.env.module + '/vite.config.e2e.js',
+          mode: 'development',
+        })
+      );
       on('task', {
         log(message) {
           console.log(message);

--- a/.cypress.module.config.js
+++ b/.cypress.module.config.js
@@ -1,5 +1,4 @@
 import { defineConfig } from 'cypress';
-import Cypress from 'cypress';
 import { execSync } from 'child_process';
 import vitePreprocessor from 'cypress-vite';
 

--- a/bin/test.bash
+++ b/bin/test.bash
@@ -47,7 +47,7 @@ cleanup() {
 
   # Set default EXIT_CODE to 130 if not provided
   EXIT_CODE=${1:-130}
-  
+
   # Terminate the dev server if it's running
   if [ -n "$DEV_GID" ]; then
     echo "Terminating the dev server..."
@@ -76,7 +76,7 @@ cleanup() {
     echo "Builder terminated."
   fi
   # Exit the script
-  exit $EXIT_CODE
+  exit "$EXIT_CODE"
 }
 # Trap SIGINT (Ctrl-C) and SIGTERM
 trap cleanup SIGINT SIGTERM
@@ -198,22 +198,26 @@ if [ -n "$UNIT_TESTS" ]; then
 fi
 
 # Setup to run e2e or component or unit tests.
+CYPRESS_ENV="none=none"
 if [ -n "$E2E_TESTS" ]; then
   echo "End-to-end testing requested."
   CYPRESS_TEST_TYPE="e2e"
   if [ -n "$TEST_FD2" ]; then
     echo "  Testing the farm_fd2 module."
     PROJECT_DIR="modules/farm_fd2"
+    CYPRESS_ENV="module=./$PROJECT_DIR"
     CYPRESS_CONFIG_FILE="../../.cypress.module.config.js"
     URL_PREFIX="fd2"
   elif [ -n "$TEST_EXAMPLES" ]; then
     echo "  Testing the farm_fd2_examples module."
     PROJECT_DIR="modules/farm_fd2_examples"
+    CYPRESS_ENV="module=./$PROJECT_DIR"
     CYPRESS_CONFIG_FILE="../../.cypress.module.config.js"
     URL_PREFIX="fd2_examples"
   else
     echo "  Testing the farm_fd2_school module."
     PROJECT_DIR="modules/farm_fd2_school"
+    CYPRESS_ENV="module=./$PROJECT_DIR"
     CYPRESS_CONFIG_FILE="../../.cypress.module.config.js"
     URL_PREFIX="fd2_school"
   fi
@@ -332,15 +336,15 @@ safe_cd $PROJECT_DIR
 
 if [ -n "$CYPRESS_GUI" ]; then
   echo "Running test in the Cypress GUI."
-  npx cypress open --"$CYPRESS_TEST_TYPE" --config-file "$CYPRESS_CONFIG_FILE" > /dev/null
+  npx cypress open --env "$CYPRESS_ENV" --"$CYPRESS_TEST_TYPE" --config-file "$CYPRESS_CONFIG_FILE" > /dev/null
   EXIT_CODE=$?
 else
   echo "Running tests headless."
-  npx cypress run --"$CYPRESS_TEST_TYPE" --config-file "$CYPRESS_CONFIG_FILE"
+  npx cypress run --env "$CYPRESS_ENV" --"$CYPRESS_TEST_TYPE" --config-file "$CYPRESS_CONFIG_FILE"
   EXIT_CODE=$?
 fi
 
 echo "Tests complete."
 
 # Runs normal cleanup
-cleanup $EXIT_CODE
+cleanup "$EXIT_CODE"

--- a/modules/farm_fd2/vite.config.e2e.js
+++ b/modules/farm_fd2/vite.config.e2e.js
@@ -1,0 +1,24 @@
+import { fileURLToPath, URL } from 'node:url';
+import { defineConfig } from 'vite';
+
+let viteConfig = {
+  root: 'modules/farm_fd2/src/entrypoints',
+  publicDir: '../public',
+  base: '/fd2/',
+  plugins: [],
+  build: {
+    outDir: '../../dist/farmdata2',
+    emptyOutDir: true,
+    rollupOptions: {},
+  },
+  resolve: {
+    alias: {
+      '@': fileURLToPath(new URL('./src/', import.meta.url)),
+      '@comps': fileURLToPath(new URL('../../components/', import.meta.url)),
+      '@libs': fileURLToPath(new URL('../../library/', import.meta.url)),
+      '@css': fileURLToPath(new URL('../css/', import.meta.url)),
+    },
+  },
+};
+
+export default defineConfig(viteConfig);

--- a/modules/farm_fd2_examples/vite.config.e2e.js
+++ b/modules/farm_fd2_examples/vite.config.e2e.js
@@ -1,0 +1,24 @@
+import { fileURLToPath, URL } from 'node:url';
+import { defineConfig } from 'vite';
+
+let viteConfig = {
+  root: 'modules/farm_fd2_examples/src/entrypoints',
+  publicDir: '../public',
+  base: '/fd2_examples/',
+  plugins: [],
+  build: {
+    outDir: '../../dist/farmdata2',
+    emptyOutDir: true,
+    rollupOptions: {},
+  },
+  resolve: {
+    alias: {
+      '@': fileURLToPath(new URL('./src/', import.meta.url)),
+      '@comps': fileURLToPath(new URL('../../components/', import.meta.url)),
+      '@libs': fileURLToPath(new URL('../../library/', import.meta.url)),
+      '@css': fileURLToPath(new URL('../css/', import.meta.url)),
+    },
+  },
+};
+
+export default defineConfig(viteConfig);

--- a/modules/farm_fd2_school/vite.config.e2e.js
+++ b/modules/farm_fd2_school/vite.config.e2e.js
@@ -1,0 +1,24 @@
+import { fileURLToPath, URL } from 'node:url';
+import { defineConfig } from 'vite';
+
+let viteConfig = {
+  root: 'modules/farm_fd2_school/src/entrypoints',
+  publicDir: '../public',
+  base: '/fd2_school/',
+  plugins: [],
+  build: {
+    outDir: '../../dist/farmdata2',
+    emptyOutDir: true,
+    rollupOptions: {},
+  },
+  resolve: {
+    alias: {
+      '@': fileURLToPath(new URL('./src/', import.meta.url)),
+      '@comps': fileURLToPath(new URL('../../components/', import.meta.url)),
+      '@libs': fileURLToPath(new URL('../../library/', import.meta.url)),
+      '@css': fileURLToPath(new URL('../css/', import.meta.url)),
+    },
+  },
+};
+
+export default defineConfig(viteConfig);

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,7 +31,8 @@
         "@vue/eslint-config-prettier": "^7.1.0",
         "conventional-changelog-conventionalcommits": "^7.0.1",
         "cspell": "^6.31.2",
-        "cypress": "^12.17.4",
+        "cypress": "12.17.4",
+        "cypress-vite": "^1.5.0",
         "docdash": "^2.0.2",
         "eslint": "^8.39.0",
         "eslint-plugin-cypress": "^2.13.3",
@@ -8512,6 +8513,19 @@
       },
       "engines": {
         "node": "^14.0.0 || ^16.0.0 || >=18.0.0"
+      }
+    },
+    "node_modules/cypress-vite": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/cypress-vite/-/cypress-vite-1.5.0.tgz",
+      "integrity": "sha512-vvTMqJZgI3sN2ylQTi4OQh8LRRjSrfrIdkQD5fOj+EC/e9oHkxS96lif1SyDF1PwailG1tnpJE+VpN6+AwO/rg==",
+      "dev": true,
+      "dependencies": {
+        "chokidar": "^3.5.3",
+        "debug": "^4.3.4"
+      },
+      "peerDependencies": {
+        "vite": "^2.9.0 || ^3.0.0 || ^4.0.0 || ^5.0.0"
       }
     },
     "node_modules/cypress/node_modules/commander": {

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "conventional-changelog-conventionalcommits": "^7.0.1",
     "cspell": "^6.31.2",
     "cypress": "12.17.4",
+    "cypress-vite": "^1.5.0",
     "docdash": "^2.0.2",
     "eslint": "^8.39.0",
     "eslint-plugin-cypress": "^2.13.3",


### PR DESCRIPTION
**Pull Request Description**

Modifies the cypress and vite configurations so that e2e tests are built using Vite instead of webpack.  This allows the e2e test files to use the aliases (e.g. `@libs/farmosUtil/farmosUtil`) to import libraries.

Closes #267

---

**Licensing Certification**

FarmData2 is a [Free Cultural Work](https://freedomdefined.org/Definition) and all accepted contributions are licensed as described in the LICENSE.md file. This requires that the contributor holds the rights to do so. By submitting this pull request **I certify that I satisfy the terms of the [Developer Certificate of Origin](https://developercertificate.org/)** for its contents.
