### PR TITLE
fix(test): validates form data in submission e2e test

### DIFF
--- a/modules/farm_fd2/src/entrypoints/tray_seeding/App.vue
+++ b/modules/farm_fd2/src/entrypoints/tray_seeding/App.vue
@@ -231,7 +231,7 @@ export default {
         );
 
         lib
-          .submitForm(this.form)
+          .submitForm({ ...this.form })
           .then(() => {
             uiUtil.hideToast();
             this.reset(true);
@@ -293,6 +293,13 @@ export default {
   },
   created() {
     this.createdCount++;
+
+    /*
+     * Make the lib containing the submitForm function accessible to the
+     * e2e tests so that the submission test can spy on the submitForm
+     * function to verify that it is receiving the correct information.
+     */
+    document.defaultView.lib = lib;
   },
 };
 </script>

--- a/modules/farm_fd2/src/entrypoints/tray_seeding/App.vue
+++ b/modules/farm_fd2/src/entrypoints/tray_seeding/App.vue
@@ -162,7 +162,7 @@ import TextDisplay from '@comps/TextDisplay/TextDisplay.vue';
 import CommentBox from '@comps/CommentBox/CommentBox.vue';
 import SubmitResetButtons from '@comps/SubmitResetButtons/SubmitResetButtons.vue';
 import * as uiUtil from '@libs/uiUtil/uiUtil.js';
-import * as lib from './lib.js';
+import { lib } from './lib.js';
 
 export default {
   components: {

--- a/modules/farm_fd2/src/entrypoints/tray_seeding/lib.js
+++ b/modules/farm_fd2/src/entrypoints/tray_seeding/lib.js
@@ -19,7 +19,7 @@ import * as farmosUtil from '@libs/farmosUtil/farmosUtil';
  * ```
  * @throws {Error} if an error occurs while creating the farmOS records.
  */
-export async function submitForm(formData) {
+async function submitForm(formData) {
   try {
     const plantAsset = {
       name: 'plantAsset',
@@ -139,3 +139,7 @@ export async function submitForm(formData) {
     throw Error(errorMsg, error);
   }
 }
+
+export const lib = {
+  submitForm,
+};

--- a/modules/farm_fd2/src/entrypoints/tray_seeding/lib.submit.unit.cy.js
+++ b/modules/farm_fd2/src/entrypoints/tray_seeding/lib.submit.unit.cy.js
@@ -1,4 +1,4 @@
-import * as lib from './lib';
+import { lib } from './lib';
 import * as farmosUtil from '@libs/farmosUtil/farmosUtil';
 
 describe('Test the tray seeding lib', () => {

--- a/modules/farm_fd2/src/entrypoints/tray_seeding/lib.submitError.unit.cy.js
+++ b/modules/farm_fd2/src/entrypoints/tray_seeding/lib.submitError.unit.cy.js
@@ -1,4 +1,4 @@
-import * as lib from './lib';
+import { lib } from './lib';
 
 describe('Test error when submitting tray seeding lib', () => {
   let form = {

--- a/modules/farm_fd2/src/entrypoints/tray_seeding/tray_seeding.submission.e2e.cy.js
+++ b/modules/farm_fd2/src/entrypoints/tray_seeding/tray_seeding.submission.e2e.cy.js
@@ -1,4 +1,8 @@
+//import { lib } from './lib.js';
+
 describe('Tray Seeding: Submission tests', () => {
+  before(() => {});
+
   beforeEach(() => {
     cy.restoreLocalStorage();
     cy.restoreSessionStorage();
@@ -53,6 +57,11 @@ describe('Tray Seeding: Submission tests', () => {
      */
     cy.intercept('POST', '**/api/log/seeding', cy.spy().as('submitSpy'));
 
+    cy.window().then((win) => {
+      console.log(win);
+      cy.spy(win, 'libForm').as('submitFuncSpy');
+    });
+
     /*
      * Fill in the form and click the "Submit" button.
      */
@@ -75,6 +84,8 @@ describe('Tray Seeding: Submission tests', () => {
      * already do that.
      */
     cy.get('@submitSpy').should('be.called');
+
+    cy.get('@submitFuncSpy').should('be.called');
 
     // Check that the "sticky" parts of the form are not reset...
     cy.get('[data-cy="date-input"]').should('have.value', '1950-01-02');

--- a/modules/farm_fd2/src/entrypoints/tray_seeding/tray_seeding.submission.e2e.cy.js
+++ b/modules/farm_fd2/src/entrypoints/tray_seeding/tray_seeding.submission.e2e.cy.js
@@ -1,6 +1,4 @@
 describe('Tray Seeding: Submission tests', () => {
-  before(() => {});
-
   beforeEach(() => {
     cy.restoreLocalStorage();
     cy.restoreSessionStorage();

--- a/modules/farm_fd2/src/entrypoints/tray_seeding/tray_seeding.submission.e2e.cy.js
+++ b/modules/farm_fd2/src/entrypoints/tray_seeding/tray_seeding.submission.e2e.cy.js
@@ -1,5 +1,3 @@
-//import { lib } from './lib.js';
-
 describe('Tray Seeding: Submission tests', () => {
   before(() => {});
 
@@ -51,15 +49,17 @@ describe('Tray Seeding: Submission tests', () => {
 
   it('Test successful submission', () => {
     /*
-     * Create a spy to watch for the seeding log, which is the
-     * last thing created by the lib.submitForm function that is
-     * called when the "Submit" button is clicked.
+     * Setup a spy on the submitForm function in lib.js.  This is
+     * the function that is called when the submit button is clicked.
+     * The spy will be used to check that the argument passed to the
+     * submitForm function contains the expected data from the form.
+     *
+     * The lib.submit.unit.cy.js function checks that if submitForm
+     * is given the correct data that the correct assets, logs and
+     * quantities are created, so we do not need to do that here.
      */
-    cy.intercept('POST', '**/api/log/seeding', cy.spy().as('submitSpy'));
-
     cy.window().then((win) => {
-      console.log(win);
-      cy.spy(win, 'libForm').as('submitFuncSpy');
+      cy.spy(win.lib, 'submitForm').as('submitFuncSpy');
     });
 
     /*
@@ -79,13 +79,20 @@ describe('Tray Seeding: Submission tests', () => {
     );
 
     /*
-     * Ensure that the lib.submitForm function was called.
-     * No need to check the db for the records as the lib unit tests
-     * already do that.
+     * Check that the submitForm function was called with the
+     * expected form data.
      */
-    cy.get('@submitSpy').should('be.called');
+    cy.get('@submitFuncSpy').then((spy) => {
+      let data = spy.getCall(0).args[0];
 
-    cy.get('@submitFuncSpy').should('be.called');
+      expect(data.seedingDate).to.equal('1950-01-02');
+      expect(data.cropName).to.equal('ARUGULA');
+      expect(data.locationName).to.equal('CHUAU');
+      expect(data.trays).to.equal(10);
+      expect(data.traySize).to.equal('50');
+      expect(data.seedsPerCell).to.equal(3);
+      expect(data.comment).to.equal('test comment');
+    });
 
     // Check that the "sticky" parts of the form are not reset...
     cy.get('[data-cy="date-input"]').should('have.value', '1950-01-02');


### PR DESCRIPTION
**Pull Request Description**

Uses a `spy` to validate the data that is passed to `lib.submitForm` when the Submit button is clicked.  This includes a number of other changes that were needed to make that `spy` work. The details are documented in #170.

Partially addresses #170 

---

**Licensing Certification**

FarmData2 is a [Free Cultural Work](https://freedomdefined.org/Definition) and all accepted contributions are licensed as described in the LICENSE.md file. This requires that the contributor holds the rights to do so. By submitting this pull request **I certify that I satisfy the terms of the [Developer Certificate of Origin](https://developercertificate.org/)** for its contents.
