### PR TITLE
Soil disturbance validity fix

### DIFF
--- a/components/SoilDisturbance/SoilDisturbance.events.comp.cy.js
+++ b/components/SoilDisturbance/SoilDisturbance.events.comp.cy.js
@@ -221,7 +221,9 @@ describe('Test the SoilDisturbance component events', () => {
 
     cy.mount(SoilDisturbance, {
       props: {
-        passes: 2,
+        required: true,
+        equipment: ['Tractor'],
+        passes: null,
         onReady: readySpy,
         onValid: validSpy,
       },

--- a/components/SoilDisturbance/SoilDisturbance.events.comp.cy.js
+++ b/components/SoilDisturbance/SoilDisturbance.events.comp.cy.js
@@ -155,6 +155,29 @@ describe('Test the SoilDisturbance component events', () => {
       });
   });
 
+  it('"valid" event ignores area if not included', () => {
+    const readySpy = cy.spy().as('readySpy');
+    const validSpy = cy.spy().as('validSpy');
+
+    cy.mount(SoilDisturbance, {
+      props: {
+        required: true,
+        area: null,
+        includeArea: false,
+        equipment: ['Tractor'],
+        onReady: readySpy,
+        onValid: validSpy,
+      },
+    });
+
+    cy.get('@readySpy')
+      .should('have.been.calledOnce')
+      .then(() => {
+        cy.get('@validSpy').should('have.been.calledOnce');
+        cy.get('@validSpy').should('have.been.calledWith', true);
+      });
+  });
+
   it('Changing area emits "valid" event correctly', () => {
     const readySpy = cy.spy().as('readySpy');
     const validSpy = cy.spy().as('validSpy');

--- a/components/SoilDisturbance/SoilDisturbance.vue
+++ b/components/SoilDisturbance/SoilDisturbance.vue
@@ -244,20 +244,13 @@ export default {
     isValid() {
       if (this.form.equipment.length === 0) {
         return this.validity.equipment;
-      } else if (!this.includePasses) {
-        return (
-          this.validity.equipment &&
-          this.validity.depth &&
-          this.validity.speed &&
-          this.validity.area
-        );
       } else {
         return (
           this.validity.equipment &&
           this.validity.depth &&
           this.validity.speed &&
-          this.validity.area &&
-          this.validity.passes
+          (!this.includeArea || this.validity.area) &&
+          (!this.includePasses || this.validity.passes)
         );
       }
     },


### PR DESCRIPTION
**Pull Request Description**

Changes the `isValid()` computed property of the SoilDisturbance component to correctly output the validity based on if area is or is not included. Also, adds a test to the `SoilDisturbance.events.comp.cy.js` file to check that `isValid()`  works accordingly.

Closes #276 
---

**Licensing Certification**

FarmData2 is a [Free Cultural Work](https://freedomdefined.org/Definition) and all accepted contributions are licensed as described in the LICENSE.md file. This requires that the contributor holds the rights to do so. By submitting this pull request **I certify that I satisfy the terms of the [Developer Certificate of Origin](https://developercertificate.org/)** for its contents.

Co-authored-by: Shahir Ahmed [98346408+Shahir-47@users.noreply.github.com](mailto:98346408+Shahir-47@users.noreply.github.com)