### PR TITLE
refactor(fd2): modifies direct seeding App.vue to match new templates

### DIFF
--- a/modules/farm_fd2/src/entrypoints/direct_seeding/App.vue
+++ b/modules/farm_fd2/src/entrypoints/direct_seeding/App.vue
@@ -144,7 +144,7 @@
               v-bind:equipment="form.equipment"
               v-bind:depth="form.depth"
               v-bind:speed="form.speed"
-              v-bind:includeArea="includeArea"
+              v-bind:includeArea="false"
               v-on:valid="validity.soilDisturbance = $event"
               v-on:update:equipment="form.equipment = $event"
               v-on:update:depth="form.depth = $event"
@@ -170,8 +170,8 @@
         <SubmitResetButtons
           id="direct-seeding-submit-reset"
           data-cy="direct-seeding-submit-reset"
-          v-bind:enableSubmit="enableSubmit"
-          v-bind:enableReset="enableReset"
+          v-bind:enableSubmit="submitEnabled"
+          v-bind:enableReset="resetEnabled"
           v-on:ready="createdCount++"
           v-on:submit="submit()"
           v-on:reset="reset()"
@@ -240,24 +240,36 @@ export default {
         soilDisturbance: false,
         comment: false,
       },
-      includeArea: false,
-      enableSubmit: true,
-      enableReset: true,
-      errorShown: false,
+      submitting: false,
+      errorShowing: false,
       createdCount: 0,
     };
+  },
+  computed: {
+    pageDoneLoading() {
+      return this.createdCount == 10;
+    },
+    submitEnabled() {
+      return !this.validity.show || (this.validToSubmit && !this.submitting);
+    },
+    resetEnabled() {
+      return !this.submitting;
+    },
+    validToSubmit() {
+      return Object.entries(this.validity)
+        .filter(([key]) => key !== 'show')
+        .every((item) => item[1] === true);
+    },
   },
   methods: {
     handleBedsUpdate(checkedBeds) {
       this.form.beds = checkedBeds;
     },
     submit() {
+      this.submitting = true;
       this.validity.show = true;
 
-      if (this.canSubmit) {
-        this.disableSubmit = true;
-        this.disableReset = true;
-
+      if (this.validToSubmit) {
         uiUtil.showToast(
           'Submitting direct seeding...',
           '',
@@ -269,25 +281,39 @@ export default {
           .submitForm({ ...this.form })
           .then(() => {
             uiUtil.hideToast();
-            this.reset(true); // keep sticky parts.
-            uiUtil.showToast(
-              'Direct seeding created.',
-              '',
-              'top-center',
-              'success',
-              2
-            );
+            uiUtil
+              .showToast(
+                'Direct seeding created.',
+                '',
+                'top-center',
+                'success',
+                2
+              )
+              .then(() => {
+                this.reset(true);
+                this.submitting = false;
+              });
           })
           .catch(() => {
-            uiUtil.hideToast();
-            this.showErrorToast(
-              'Error creating direct seeding.',
-              'Check your network connection and try again.'
-            );
-            this.enableSubmit = true;
+            if (!this.errorShown) {
+              uiUtil.hideToast();
+              this.errorShowing = true;
+              uiUtil
+                .showToast(
+                  'Error creating direct seeding.',
+                  'Check your network connection and try again.',
+                  'top-center',
+                  'danger',
+                  5
+                )
+                .then(() => {
+                  this.submitting = false;
+                  this.errorShowing = false;
+                });
+            }
           });
       } else {
-        this.enableSubmit = false;
+        this.submitting = false;
       }
     },
     reset(sticky = false) {
@@ -307,53 +333,13 @@ export default {
       this.form.beds = [];
       this.form.bedFeet = 100;
       this.form.comment = null;
-      this.enableSubmit = true;
-    },
-    showErrorToast(title, message) {
-      if (!this.errorShown) {
-        this.errorShown = true;
-        this.enableSubmit = false;
-        this.enableReset = false;
-
-        uiUtil.showToast(title, message, 'top-center', 'danger', 5);
-      }
     },
   },
-  computed: {
-    canSubmit() {
-      const required =
-        this.validity.seedingDate &&
-        this.validity.cropName &&
-        this.validity.location &&
-        this.validity.bedFeet &&
-        this.validity.bedWidth &&
-        this.validity.rowsPerBed &&
-        this.validity.soilDisturbance;
-
-      return required;
-    },
-    pageDoneLoading() {
-      return this.createdCount == 10;
-    },
-  },
-  watch: {
-    validity: {
-      handler() {
-        if (this.canSubmit) {
-          this.enableSubmit = true;
-        }
-      },
-      deep: true,
-    },
-  },
+  watch: {},
   created() {
     this.createdCount++;
+
     if (window.Cypress) {
-      /*
-       * Make the lib containing the submitForm function accessible to the
-       * e2e tests so that the submission test can spy on the submitForm
-       * function to verify that it is receiving the correct information.
-       */
       document.defaultView.lib = lib;
     }
   },

--- a/modules/farm_fd2/src/entrypoints/direct_seeding/direct_seeding.submission.e2e.cy.js
+++ b/modules/farm_fd2/src/entrypoints/direct_seeding/direct_seeding.submission.e2e.cy.js
@@ -91,16 +91,19 @@ describe('Direct Seeding: Submission tests', () => {
      */
     submitForm();
 
+    // Check that Submit and Reset are disabled while submitting.
+    cy.get('[data-cy="submit-button"]').should('be.disabled');
+    cy.get('[data-cy="reset-button"]').should('be.disabled');
+
     // Check for the status toast while the form is submitting.
     cy.get('.toast')
       .should('be.visible')
       .should('contain.text', 'Submitting direct seeding...');
 
     // Give time for all the records to be created.
-    cy.get('.toast', { timeout: 10000 }).should(
-      'contain.text',
-      'Direct seeding created.'
-    );
+    cy.get('.toast', { timeout: 10000 })
+      .should('be.visible')
+      .should('contain.text', 'Direct seeding created.');
 
     /*
      * Check that the submitForm function was called with the
@@ -166,8 +169,12 @@ describe('Direct Seeding: Submission tests', () => {
       .should('have.value', '100');
     cy.get('[data-cy="comment-input"]').should('have.value', '');
 
-    // Finally check that the toast is hidden.
+    // Check that the toast is hidden.
     cy.get('.toast').should('not.exist');
+
+    // Check that Submit button is re-enabled after submitting.
+    cy.get('[data-cy="submit-button"]').should('be.enabled');
+    cy.get('[data-cy="reset-button"]').should('be.enabled');
   });
 
   it('Test submission with network error', () => {
@@ -175,6 +182,8 @@ describe('Direct Seeding: Submission tests', () => {
       statusCode: 401,
     });
     submitForm();
+    cy.get('[data-cy="submit-button"]').should('be.disabled');
+    cy.get('[data-cy="reset-button"]').should('be.disabled');
     cy.get('.toast')
       .should('be.visible')
       .should('contain.text', 'Submitting direct seeding...');
@@ -182,5 +191,7 @@ describe('Direct Seeding: Submission tests', () => {
       .should('be.visible')
       .should('contain.text', 'Error creating direct seeding.');
     cy.get('.toast', { timeout: 7000 }).should('not.exist');
+    cy.get('[data-cy="submit-button"]').should('be.enabled');
+    cy.get('[data-cy="reset-button"]').should('be.enabled');
   });
 });

--- a/modules/farm_fd2/src/entrypoints/direct_seeding/direct_seeding.submitReset.e2e.cy.js
+++ b/modules/farm_fd2/src/entrypoints/direct_seeding/direct_seeding.submitReset.e2e.cy.js
@@ -75,22 +75,39 @@ describe('Direct Seeding: Submit/Reset Buttons component', () => {
     populateForm();
     cy.get('[data-cy="submit-button"]').should('be.enabled');
     cy.get('[data-cy="date-input"]').clear();
+
     cy.get('[data-cy="submit-button"]').click();
     cy.get('[data-cy="submit-button"]').should('be.disabled');
+
+    cy.get('[data-cy="date-input"]').type('2020-01-01');
+    cy.get('[data-cy="date-input"]').blur();
+    cy.get('[data-cy="submit-button"]').should('be.enabled');
   });
 
   it('Invalid crop disables submit', () => {
     populateForm({ skipCrop: true });
     cy.get('[data-cy="submit-button"]').should('be.enabled');
     cy.get('[data-cy="submit-button"]').click();
+
     cy.get('[data-cy="submit-button"]').should('be.disabled');
+
+    cy.get('[data-cy="direct-seeding-crop"]')
+      .find('[data-cy="selector-input"]')
+      .select('ARUGULA');
+    cy.get('[data-cy="submit-button"]').should('be.enabled');
   });
 
   it('Invalid location disables submit', () => {
     populateForm({ skipLocation: true });
     cy.get('[data-cy="submit-button"]').should('be.enabled');
     cy.get('[data-cy="submit-button"]').click();
+
     cy.get('[data-cy="submit-button"]').should('be.disabled');
+
+    cy.get('[data-cy="direct-seeding-location"]')
+      .find('[data-cy="selector-input"]')
+      .select('A');
+    cy.get('[data-cy="submit-button"]').should('be.enabled');
   });
 
   it('Invalid bed feet disables submit', () => {
@@ -105,6 +122,14 @@ describe('Direct Seeding: Submit/Reset Buttons component', () => {
 
     cy.get('[data-cy="submit-button"]').click();
     cy.get('[data-cy="submit-button"]').should('be.disabled');
+
+    cy.get('[data-cy="direct-seeding-bed-feet"]')
+      .find('[data-cy="numeric-input"]')
+      .type('22');
+    cy.get('[data-cy="direct-seeding-bed-feet"]')
+      .find('[data-cy="numeric-input"]')
+      .blur();
+    cy.get('[data-cy="submit-button"]').should('be.enabled');
   });
 
   it('Invalid bed width disables submit', () => {
@@ -119,6 +144,14 @@ describe('Direct Seeding: Submit/Reset Buttons component', () => {
 
     cy.get('[data-cy="submit-button"]').click();
     cy.get('[data-cy="submit-button"]').should('be.disabled');
+
+    cy.get('[data-cy="direct-seeding-bed-width"]')
+      .find('[data-cy="numeric-input"]')
+      .type('33');
+    cy.get('[data-cy="direct-seeding-bed-width"]')
+      .find('[data-cy="numeric-input"]')
+      .blur();
+    cy.get('[data-cy="submit-button"]').should('be.enabled');
   });
 
   // Note: There is no way to make Rows/Bed invalid.


### PR DESCRIPTION
**Pull Request Description**

Refactors the Direct Seeding endpoint to follow the template pattern in `/bin/templates/endpoint`.  Also enhances some of the Direct Seeding e2e tests.

Addresses part of #27

---

**Licensing Certification**

FarmData2 is a [Free Cultural Work](https://freedomdefined.org/Definition) and all accepted contributions are licensed as described in the LICENSE.md file. This requires that the contributor holds the rights to do so. By submitting this pull request **I certify that I satisfy the terms of the [Developer Certificate of Origin](https://developercertificate.org/)** for its contents.
