### PR TITLE
 refactor(test): simplifies the direct seeding unit tests

### DIFF
--- a/modules/farm_fd2/src/entrypoints/direct_seeding/lib.submit.unit.cy.js
+++ b/modules/farm_fd2/src/entrypoints/direct_seeding/lib.submit.unit.cy.js
@@ -2,12 +2,6 @@ import { lib } from './lib.js';
 import * as farmosUtil from '@libs/farmosUtil/farmosUtil';
 
 describe('Submission using the direct_seeding lib.', () => {
-  /*
-   * Create a form object that has the same format as the data.form
-   * object used in the tray_seeding entry point.  This will be passed
-   * to the lib functions as if it is coming from the tray seeding
-   * entry point as a submission.
-   */
   let form = {
     seedingDate: '1950-01-02',
     cropName: 'BROCCOLI',
@@ -22,24 +16,44 @@ describe('Submission using the direct_seeding lib.', () => {
     comment: 'A comment',
   };
 
-  let fieldMap = null;
+  let bedMap = null;
   let categoryMap = null;
-  let result = null;
+  let cropMap = null;
+  let equipmentMap = null;
+  let fieldMap = null;
+  let unitMap = null;
+  let results = null;
 
   before(() => {
     cy.restoreLocalStorage();
     cy.restoreSessionStorage();
 
-    cy.wrap(farmosUtil.getFieldNameToAssetMap()).then((map) => {
-      fieldMap = map;
+    cy.wrap(farmosUtil.getBedNameToAssetMap()).then((map) => {
+      bedMap = map;
     });
 
     cy.wrap(farmosUtil.getLogCategoryToTermMap()).then((map) => {
       categoryMap = map;
     });
 
+    cy.wrap(farmosUtil.getCropNameToTermMap()).then((map) => {
+      cropMap = map;
+    });
+
+    cy.wrap(farmosUtil.getEquipmentNameToAssetMap()).then((map) => {
+      equipmentMap = map;
+    });
+
+    cy.wrap(farmosUtil.getFieldNameToAssetMap()).then((map) => {
+      fieldMap = map;
+    });
+
+    cy.wrap(farmosUtil.getUnitToTermMap()).then((map) => {
+      unitMap = map;
+    });
+
     cy.wrap(lib.submitForm(form), { timeout: 10000 }).then((res) => {
-      result = res;
+      results = res;
     });
   });
 
@@ -54,286 +68,189 @@ describe('Submission using the direct_seeding lib.', () => {
   });
 
   it('Check the asset--plant', () => {
-    // Check the plant asset.
-    cy.wrap(farmosUtil.getPlantAsset(result.plantAsset.id)).then(
-      (plantAsset) => {
-        expect(plantAsset.type).to.equal('asset--plant');
-        expect(plantAsset.attributes.name).to.equal('1950-01-02_BROCCOLI');
-        expect(plantAsset.attributes.status).to.equal('active');
-        expect(plantAsset.attributes.notes.value).to.equal(form.comment);
-
-        expect(plantAsset.relationships.plant_type[0].type).to.equal(
-          'taxonomy_term--plant_type'
-        );
-        expect(plantAsset.relationships.plant_type[0].id).to.equal(
-          result.plantAsset.relationships.plant_type[0].id
-        );
-
-        expect(plantAsset.relationships.location[0].type).to.equal(
-          'asset--land'
-        );
-        expect(plantAsset.relationships.location[0].id).to.equal(
-          fieldMap.get(form.locationName).id
-        );
-
-        expect(plantAsset.attributes.inventory[0].measure).to.equal('length');
-        expect(plantAsset.attributes.inventory[0].value).to.equal('300');
-        expect(plantAsset.attributes.inventory[0].units).to.equal('FEET');
-      }
+    expect(results.plantAsset.type).to.equal('asset--plant');
+    expect(results.plantAsset.attributes.name).to.equal(
+      form.seedingDate + '_' + form.cropName
     );
+    expect(results.plantAsset.attributes.notes.value).to.equal(form.comment);
+    expect(results.plantAsset.relationships.plant_type[0].id).to.equal(
+      cropMap.get(form.cropName).id
+    );
+    expect(results.plantAsset.relationships.parent).to.have.length(0);
   });
 
   it('Check the bed feet quantity--standard', () => {
-    cy.wrap(farmosUtil.getStandardQuantity(result.bedFeetQuantity.id)).then(
-      (bedFeetQuantity) => {
-        expect(bedFeetQuantity.type).to.equal('quantity--standard');
-        expect(bedFeetQuantity.attributes.measure).to.equal('length');
-        expect(bedFeetQuantity.attributes.value.decimal).to.equal(
-          form.bedFeet.toString()
-        );
-        expect(bedFeetQuantity.attributes.label).to.equal('Bed Feet');
-
-        expect(bedFeetQuantity.attributes.inventory_adjustment).to.be.null;
-
-        expect(bedFeetQuantity.relationships.units.type).to.equal(
-          'taxonomy_term--unit'
-        );
-        expect(bedFeetQuantity.relationships.units.id).to.equal(
-          result.bedFeetQuantity.relationships.units.id
-        );
-
-        expect(bedFeetQuantity.relationships.inventory_asset).to.be.null;
-      }
+    expect(results.bedFeetQuantity.type).to.equal('quantity--standard');
+    expect(results.bedFeetQuantity.attributes.measure).to.equal('length');
+    expect(results.bedFeetQuantity.attributes.value.decimal).to.equal(
+      form.bedFeet
     );
+    expect(results.bedFeetQuantity.attributes.label).to.equal('Bed Feet');
+    expect(results.bedFeetQuantity.relationships.units.id).to.equal(
+      unitMap.get('FEET').id
+    );
+    expect(results.bedFeetQuantity.attributes.inventory_adjustment).to.be.null;
+    expect(results.bedFeetQuantity.relationships.inventory_asset).to.be.null;
   });
 
   it('Check the rows/bed quantity--standard', () => {
-    cy.wrap(farmosUtil.getStandardQuantity(result.rowsPerBedQuantity.id)).then(
-      (rowsPerBedQuantity) => {
-        expect(rowsPerBedQuantity.type).to.equal('quantity--standard');
-        expect(rowsPerBedQuantity.attributes.measure).to.equal('ratio');
-        expect(rowsPerBedQuantity.attributes.value.decimal).to.equal(
-          form.rowsPerBed.toString()
-        );
-        expect(rowsPerBedQuantity.attributes.label).to.equal('Rows/Bed');
-
-        expect(rowsPerBedQuantity.attributes.inventory_adjustment).to.be.null;
-
-        expect(rowsPerBedQuantity.relationships.units.type).to.equal(
-          'taxonomy_term--unit'
-        );
-        expect(rowsPerBedQuantity.relationships.units.id).to.equal(
-          result.rowsPerBedQuantity.relationships.units.id
-        );
-
-        expect(rowsPerBedQuantity.relationships.inventory_asset).to.be.null;
-      }
+    expect(results.rowsPerBedQuantity.type).to.equal('quantity--standard');
+    expect(results.rowsPerBedQuantity.attributes.measure).to.equal('ratio');
+    expect(results.rowsPerBedQuantity.attributes.value.decimal).to.equal(
+      form.rowsPerBed
     );
+    expect(results.rowsPerBedQuantity.attributes.label).to.equal('Rows/Bed');
+    expect(results.rowsPerBedQuantity.relationships.units.id).to.equal(
+      unitMap.get('ROWS/BED').id
+    );
+    expect(results.rowsPerBedQuantity.attributes.inventory_adjustment).to.be
+      .null;
+    expect(results.rowsPerBedQuantity.relationships.inventory_asset).to.be.null;
   });
 
   it('Check the row feet quantity--standard', () => {
-    cy.wrap(farmosUtil.getStandardQuantity(result.rowFeetQuantity.id)).then(
-      (rowFeetQuantity) => {
-        expect(rowFeetQuantity.type).to.equal('quantity--standard');
-        expect(rowFeetQuantity.attributes.measure).to.equal('length');
-        expect(rowFeetQuantity.attributes.value.decimal).to.equal(
-          (form.bedFeet * form.rowsPerBed).toString()
-        );
-        expect(rowFeetQuantity.attributes.label).to.equal('Row Feet');
+    expect(results.rowFeetQuantity.type).to.equal('quantity--standard');
+    expect(results.rowFeetQuantity.attributes.measure).to.equal('length');
+    expect(results.rowFeetQuantity.attributes.label).to.equal('Row Feet');
+    expect(results.rowFeetQuantity.attributes.value.decimal).to.equal(
+      form.bedFeet * form.rowsPerBed
+    );
+    expect(results.rowFeetQuantity.relationships.units.id).to.equal(
+      unitMap.get('FEET').id
+    );
 
-        expect(rowFeetQuantity.attributes.inventory_adjustment).to.equal(
-          'increment'
-        );
-
-        expect(rowFeetQuantity.relationships.units.type).to.equal(
-          'taxonomy_term--unit'
-        );
-        expect(rowFeetQuantity.relationships.units.id).to.equal(
-          result.rowFeetQuantity.relationships.units.id
-        );
-
-        expect(rowFeetQuantity.relationships.inventory_asset.type).to.equal(
-          'asset--plant'
-        );
-        expect(rowFeetQuantity.relationships.inventory_asset.id).to.equal(
-          result.rowFeetQuantity.relationships.inventory_asset.id
-        );
-      }
+    expect(results.rowFeetQuantity.relationships.inventory_asset.id).to.equal(
+      results.plantAsset.id
+    );
+    expect(results.rowFeetQuantity.attributes.inventory_adjustment).to.equal(
+      'increment'
     );
   });
 
   it('Check the bed width quantity--standard', () => {
-    cy.wrap(farmosUtil.getStandardQuantity(result.bedWidthQuantity.id)).then(
-      (bedWidthQuantity) => {
-        expect(bedWidthQuantity.type).to.equal('quantity--standard');
-        expect(bedWidthQuantity.attributes.measure).to.equal('length');
-        expect(bedWidthQuantity.attributes.value.decimal).to.equal(
-          form.bedWidth.toString()
-        );
-        expect(bedWidthQuantity.attributes.label).to.equal('Bed Width');
-
-        expect(bedWidthQuantity.attributes.inventory_adjustment).to.be.null;
-
-        expect(bedWidthQuantity.relationships.units.type).to.equal(
-          'taxonomy_term--unit'
-        );
-        expect(bedWidthQuantity.relationships.units.id).to.equal(
-          result.bedWidthQuantity.relationships.units.id
-        );
-
-        expect(bedWidthQuantity.relationships.inventory_asset).to.be.null;
-      }
+    expect(results.bedWidthQuantity.type).to.equal('quantity--standard');
+    expect(results.bedWidthQuantity.attributes.measure).to.equal('length');
+    expect(results.bedWidthQuantity.attributes.value.decimal).to.equal(
+      form.bedWidth
     );
+    expect(results.bedWidthQuantity.attributes.label).to.equal('Bed Width');
+    expect(results.bedWidthQuantity.relationships.units.id).to.equal(
+      unitMap.get('INCHES').id
+    );
+    expect(results.bedWidthQuantity.attributes.inventory_adjustment).to.be.null;
+    expect(results.bedWidthQuantity.relationships.inventory_asset).to.be.null;
   });
 
   it('Check the log--seeding', () => {
-    cy.wrap(farmosUtil.getSeedingLog(result.seedingLog.id)).then(
-      (seedingLog) => {
-        expect(seedingLog.type).to.equal('log--seeding');
-        expect(seedingLog.attributes.name).to.equal('1950-01-02_ds_BROCCOLI');
-        expect(seedingLog.attributes.timestamp).to.contain('1950-01-02');
-        expect(seedingLog.attributes.status).to.equal('done');
-        expect(seedingLog.attributes.is_movement).to.be.true;
-        expect(seedingLog.attributes.purchase_date).to.contain('1950-01-02');
+    expect(results.seedingLog.type).to.equal('log--seeding');
+    expect(results.seedingLog.attributes.name).to.equal(
+      form.seedingDate + '_ds_' + form.cropName
+    );
+    expect(results.seedingLog.attributes.timestamp).to.contain('1950-01-02');
 
-        expect(seedingLog.relationships.location.length).to.equal(3);
-        expect(seedingLog.relationships.location[0].id).to.equal(
-          result.seedingLog.relationships.location[0].id
-        );
-        expect(seedingLog.relationships.location[1].id).to.equal(
-          result.seedingLog.relationships.location[1].id
-        );
-        expect(seedingLog.relationships.location[2].id).to.equal(
-          result.seedingLog.relationships.location[2].id
-        );
+    expect(results.seedingLog.relationships.location.length).to.equal(3);
+    expect(results.seedingLog.relationships.location[0].id).to.equal(
+      fieldMap.get(form.locationName).id
+    );
+    expect(results.seedingLog.relationships.location[1].id).to.equal(
+      bedMap.get(form.beds[0]).id
+    );
+    expect(results.seedingLog.relationships.location[2].id).to.equal(
+      bedMap.get(form.beds[1]).id
+    );
 
-        expect(seedingLog.relationships.asset[0].type).to.equal('asset--plant');
-        expect(seedingLog.relationships.asset[0].id).to.equal(
-          result.seedingLog.relationships.asset[0].id
-        );
+    expect(results.seedingLog.relationships.category.length).to.equal(2);
+    expect(results.seedingLog.relationships.category[0].id).to.equal(
+      categoryMap.get('seeding').id
+    );
+    expect(results.seedingLog.relationships.category[1].id).to.equal(
+      categoryMap.get('seeding_direct').id
+    );
 
-        expect(seedingLog.relationships.category.length).to.equal(2);
-        expect(seedingLog.relationships.category[0].type).to.equal(
-          'taxonomy_term--log_category'
-        );
-        expect(seedingLog.relationships.category[0].id).to.equal(
-          result.seedingLog.relationships.category[0].id
-        );
-        expect(seedingLog.relationships.category[1].type).to.equal(
-          'taxonomy_term--log_category'
-        );
-        expect(seedingLog.relationships.category[1].id).to.equal(
-          result.seedingLog.relationships.category[1].id
-        );
+    expect(results.seedingLog.relationships.asset[0].id).to.equal(
+      results.plantAsset.id
+    );
 
-        expect(seedingLog.relationships.quantity.length).to.equal(4);
-        expect(seedingLog.relationships.quantity[0].type).to.equal(
-          'quantity--standard'
-        );
-        for (let i = 1; i < 4; i++) {
-          expect(seedingLog.relationships.quantity[i].type).to.equal(
-            'quantity--standard'
-          );
-          expect(seedingLog.relationships.quantity[i].id).to.equal(
-            result.seedingLog.relationships.quantity[i].id
-          );
-        }
-      }
+    expect(results.seedingLog.relationships.quantity.length).to.equal(4);
+    expect(results.seedingLog.relationships.quantity[0].id).to.equal(
+      results.bedFeetQuantity.id
+    );
+    expect(results.seedingLog.relationships.quantity[1].id).to.equal(
+      results.rowsPerBedQuantity.id
+    );
+    expect(results.seedingLog.relationships.quantity[2].id).to.equal(
+      results.rowFeetQuantity.id
+    );
+    expect(results.seedingLog.relationships.quantity[3].id).to.equal(
+      results.bedWidthQuantity.id
     );
   });
 
   it('Check the depth quantity--standard', () => {
-    cy.wrap(farmosUtil.getStandardQuantity(result.depthQuantity.id)).then(
-      (depthQuantity) => {
-        expect(depthQuantity.type).to.equal('quantity--standard');
-        expect(depthQuantity.attributes.measure).to.equal('length');
-        expect(depthQuantity.attributes.value.decimal).to.equal(
-          form.depth.toString()
-        );
-        expect(depthQuantity.attributes.label).to.equal('Depth');
-
-        expect(depthQuantity.attributes.inventory_adjustment).to.be.null;
-
-        expect(depthQuantity.relationships.units.type).to.equal(
-          'taxonomy_term--unit'
-        );
-        expect(depthQuantity.relationships.units.id).to.equal(
-          result.bedWidthQuantity.relationships.units.id
-        );
-
-        expect(depthQuantity.relationships.inventory_asset).to.be.null;
-      }
+    expect(results.depthQuantity.type).to.equal('quantity--standard');
+    expect(results.depthQuantity.attributes.measure).to.equal('length');
+    expect(results.depthQuantity.attributes.value.decimal).to.equal(form.depth);
+    expect(results.depthQuantity.attributes.label).to.equal('Depth');
+    expect(results.depthQuantity.relationships.units.id).to.equal(
+      unitMap.get('INCHES').id
     );
+    expect(results.depthQuantity.relationships.inventory_asset).to.be.null;
+    expect(results.depthQuantity.attributes.inventory_adjustment).to.be.null;
   });
 
   it('Check the speed quantity--standard', () => {
-    cy.wrap(farmosUtil.getStandardQuantity(result.speedQuantity.id)).then(
-      (speedQuantity) => {
-        expect(speedQuantity.type).to.equal('quantity--standard');
-        expect(speedQuantity.attributes.measure).to.equal('rate');
-        expect(speedQuantity.attributes.value.decimal).to.equal(
-          form.speed.toString()
-        );
-        expect(speedQuantity.attributes.label).to.equal('Speed');
-
-        expect(speedQuantity.attributes.inventory_adjustment).to.be.null;
-
-        expect(speedQuantity.relationships.units.type).to.equal(
-          'taxonomy_term--unit'
-        );
-        expect(speedQuantity.relationships.units.id).to.equal(
-          result.speedQuantity.relationships.units.id
-        );
-
-        expect(speedQuantity.relationships.inventory_asset).to.be.null;
-      }
+    expect(results.speedQuantity.type).to.equal('quantity--standard');
+    expect(results.speedQuantity.attributes.measure).to.equal('rate');
+    expect(results.speedQuantity.attributes.value.decimal).to.equal(form.speed);
+    expect(results.speedQuantity.attributes.label).to.equal('Speed');
+    expect(results.speedQuantity.relationships.units.id).to.equal(
+      unitMap.get('MPH').id
     );
+    expect(results.speedQuantity.relationships.inventory_asset).to.be.null;
+    expect(results.speedQuantity.attributes.inventory_adjustment).to.be.null;
   });
 
   it('Check the soil disturbance log--activity', () => {
-    cy.wrap(
-      farmosUtil.getSoilDisturbanceActivityLog(result.activityLog.id)
-    ).then((activityLog) => {
-      expect(activityLog.type).to.equal('log--activity');
-      expect(activityLog.attributes.name).to.equal('1950-01-02_sd_ALF');
-      expect(activityLog.attributes.timestamp).to.contain('1950-01-02');
-      expect(activityLog.attributes.status).to.equal('done');
-      expect(activityLog.attributes.is_movement).to.equal(false);
+    expect(results.activityLog.type).to.equal('log--activity');
+    expect(results.activityLog.attributes.name).to.equal(
+      form.seedingDate + '_sd_' + form.locationName
+    );
+    expect(results.activityLog.attributes.timestamp).to.contain('1950-01-02');
 
-      expect(activityLog.relationships.location.length).to.equal(3);
-      expect(activityLog.relationships.location[0].id).to.equal(
-        result.activityLog.relationships.location[0].id
-      );
-      expect(activityLog.relationships.location[1].id).to.equal(
-        result.activityLog.relationships.location[1].id
-      );
-      expect(activityLog.relationships.location[2].id).to.equal(
-        result.activityLog.relationships.location[2].id
-      );
+    expect(results.seedingLog.relationships.location.length).to.equal(3);
+    expect(results.seedingLog.relationships.location[0].id).to.equal(
+      fieldMap.get(form.locationName).id
+    );
+    expect(results.seedingLog.relationships.location[1].id).to.equal(
+      bedMap.get(form.beds[0]).id
+    );
+    expect(results.seedingLog.relationships.location[2].id).to.equal(
+      bedMap.get(form.beds[1]).id
+    );
 
-      expect(activityLog.relationships.asset[0].id).to.equal(
-        result.plantAsset.id
-      );
+    expect(results.activityLog.relationships.asset[0].id).to.equal(
+      results.plantAsset.id
+    );
 
-      expect(activityLog.relationships.category.length).to.equal(2);
-      expect(activityLog.relationships.category[0].id).to.equal(
-        categoryMap.get('tillage').id
-      );
-      expect(activityLog.relationships.category[1].id).to.equal(
-        categoryMap.get('seeding_direct').id
-      );
+    expect(results.activityLog.relationships.category.length).to.equal(2);
+    expect(results.activityLog.relationships.category[0].id).to.equal(
+      categoryMap.get('tillage').id
+    );
+    expect(results.activityLog.relationships.category[1].id).to.equal(
+      categoryMap.get('seeding_direct').id
+    );
 
-      expect(activityLog.relationships.quantity.length).to.equal(2);
-      expect(activityLog.relationships.quantity[0].id).to.equal(
-        result.depthQuantity.id
-      );
-      expect(activityLog.relationships.quantity[1].id).to.equal(
-        result.speedQuantity.id
-      );
-      expect(activityLog.relationships.equipment.length).to.equal(1);
-      expect(activityLog.relationships.equipment[0].id).to.equal(
-        result.equipment[0].id
-      );
-    });
+    expect(results.activityLog.relationships.quantity.length).to.equal(2);
+    expect(results.activityLog.relationships.quantity[0].id).to.equal(
+      results.depthQuantity.id
+    );
+    expect(results.activityLog.relationships.quantity[1].id).to.equal(
+      results.speedQuantity.id
+    );
+
+    expect(results.activityLog.relationships.equipment.length).to.equal(1);
+    expect(results.activityLog.relationships.equipment[0].id).to.equal(
+      equipmentMap.get(form.equipment[0]).id
+    );
   });
 });

--- a/modules/farm_fd2/src/entrypoints/direct_seeding/lib.submitNoEquipment.unit.cy.js
+++ b/modules/farm_fd2/src/entrypoints/direct_seeding/lib.submitNoEquipment.unit.cy.js
@@ -23,19 +23,34 @@ describe('Submit w/o equipment using the direct_seeding lib.', () => {
     comment: 'A comment',
   };
 
+  let categoryMap = null;
+  let cropMap = null;
   let fieldMap = null;
-  let result = null;
+  let unitMap = null;
+  let results = null;
 
   before(() => {
     cy.restoreLocalStorage();
     cy.restoreSessionStorage();
 
+    cy.wrap(farmosUtil.getLogCategoryToTermMap()).then((map) => {
+      categoryMap = map;
+    });
+
+    cy.wrap(farmosUtil.getCropNameToTermMap()).then((map) => {
+      cropMap = map;
+    });
+
     cy.wrap(farmosUtil.getFieldNameToAssetMap()).then((map) => {
       fieldMap = map;
     });
 
+    cy.wrap(farmosUtil.getUnitToTermMap()).then((map) => {
+      unitMap = map;
+    });
+
     cy.wrap(lib.submitForm(form), { timeout: 10000 }).then((res) => {
-      result = res;
+      results = res;
     });
   });
 
@@ -50,195 +65,121 @@ describe('Submit w/o equipment using the direct_seeding lib.', () => {
   });
 
   it('Check the asset--plant', () => {
-    // Check the plant asset.
-    cy.wrap(farmosUtil.getPlantAsset(result.plantAsset.id)).then(
-      (plantAsset) => {
-        expect(plantAsset.type).to.equal('asset--plant');
-        expect(plantAsset.attributes.name).to.equal(
-          result.plantAsset.attributes.name
-        );
-        expect(plantAsset.attributes.status).to.equal('active');
-        expect(plantAsset.attributes.notes.value).to.equal(form.comment);
-
-        expect(plantAsset.relationships.plant_type[0].type).to.equal(
-          'taxonomy_term--plant_type'
-        );
-        expect(plantAsset.relationships.plant_type[0].id).to.equal(
-          result.plantAsset.relationships.plant_type[0].id
-        );
-
-        expect(plantAsset.relationships.location[0].type).to.equal(
-          'asset--land'
-        );
-        expect(plantAsset.relationships.location[0].id).to.equal(
-          fieldMap.get(form.locationName).id
-        );
-
-        expect(plantAsset.attributes.inventory[0].measure).to.equal('length');
-        expect(plantAsset.attributes.inventory[0].value).to.equal('300');
-        expect(plantAsset.attributes.inventory[0].units).to.equal('FEET');
-      }
+    expect(results.plantAsset.type).to.equal('asset--plant');
+    expect(results.plantAsset.attributes.name).to.equal(
+      form.seedingDate + '_' + form.cropName
     );
+    expect(results.plantAsset.attributes.notes.value).to.equal(form.comment);
+    expect(results.plantAsset.relationships.plant_type[0].id).to.equal(
+      cropMap.get(form.cropName).id
+    );
+    expect(results.plantAsset.relationships.parent).to.have.length(0);
   });
 
   it('Check the bed feet quantity--standard', () => {
-    cy.wrap(farmosUtil.getStandardQuantity(result.bedFeetQuantity.id)).then(
-      (bedFeetQuantity) => {
-        expect(bedFeetQuantity.type).to.equal('quantity--standard');
-        expect(bedFeetQuantity.attributes.measure).to.equal('length');
-        expect(bedFeetQuantity.attributes.value.decimal).to.equal(
-          form.bedFeet.toString()
-        );
-        expect(bedFeetQuantity.attributes.label).to.equal('Bed Feet');
-
-        expect(bedFeetQuantity.attributes.inventory_adjustment).to.be.null;
-
-        expect(bedFeetQuantity.relationships.units.type).to.equal(
-          'taxonomy_term--unit'
-        );
-        expect(bedFeetQuantity.relationships.units.id).to.equal(
-          result.bedFeetQuantity.relationships.units.id
-        );
-
-        expect(bedFeetQuantity.relationships.inventory_asset).to.be.null;
-      }
+    expect(results.bedFeetQuantity.type).to.equal('quantity--standard');
+    expect(results.bedFeetQuantity.attributes.measure).to.equal('length');
+    expect(results.bedFeetQuantity.attributes.value.decimal).to.equal(
+      form.bedFeet
     );
+    expect(results.bedFeetQuantity.attributes.label).to.equal('Bed Feet');
+    expect(results.bedFeetQuantity.relationships.units.id).to.equal(
+      unitMap.get('FEET').id
+    );
+    expect(results.bedFeetQuantity.attributes.inventory_adjustment).to.be.null;
+    expect(results.bedFeetQuantity.relationships.inventory_asset).to.be.null;
   });
 
   it('Check the rows/bed quantity--standard', () => {
-    cy.wrap(farmosUtil.getStandardQuantity(result.rowsPerBedQuantity.id)).then(
-      (rowsPerBedQuantity) => {
-        expect(rowsPerBedQuantity.type).to.equal('quantity--standard');
-        expect(rowsPerBedQuantity.attributes.measure).to.equal('ratio');
-        expect(rowsPerBedQuantity.attributes.value.decimal).to.equal(
-          form.rowsPerBed.toString()
-        );
-        expect(rowsPerBedQuantity.attributes.label).to.equal('Rows/Bed');
-
-        expect(rowsPerBedQuantity.attributes.inventory_adjustment).to.be.null;
-
-        expect(rowsPerBedQuantity.relationships.units.type).to.equal(
-          'taxonomy_term--unit'
-        );
-        expect(rowsPerBedQuantity.relationships.units.id).to.equal(
-          result.rowsPerBedQuantity.relationships.units.id
-        );
-
-        expect(rowsPerBedQuantity.relationships.inventory_asset).to.be.null;
-      }
+    expect(results.rowsPerBedQuantity.type).to.equal('quantity--standard');
+    expect(results.rowsPerBedQuantity.attributes.measure).to.equal('ratio');
+    expect(results.rowsPerBedQuantity.attributes.value.decimal).to.equal(
+      form.rowsPerBed
     );
+    expect(results.rowsPerBedQuantity.attributes.label).to.equal('Rows/Bed');
+    expect(results.rowsPerBedQuantity.relationships.units.id).to.equal(
+      unitMap.get('ROWS/BED').id
+    );
+    expect(results.rowsPerBedQuantity.attributes.inventory_adjustment).to.be
+      .null;
+    expect(results.rowsPerBedQuantity.relationships.inventory_asset).to.be.null;
   });
 
   it('Check the row feet quantity--standard', () => {
-    cy.wrap(farmosUtil.getStandardQuantity(result.rowFeetQuantity.id)).then(
-      (rowFeetQuantity) => {
-        expect(rowFeetQuantity.type).to.equal('quantity--standard');
-        expect(rowFeetQuantity.attributes.measure).to.equal('length');
-        expect(rowFeetQuantity.attributes.value.decimal).to.equal(
-          (form.bedFeet * form.rowsPerBed).toString()
-        );
-        expect(rowFeetQuantity.attributes.label).to.equal('Row Feet');
+    expect(results.rowFeetQuantity.type).to.equal('quantity--standard');
+    expect(results.rowFeetQuantity.attributes.measure).to.equal('length');
+    expect(results.rowFeetQuantity.attributes.label).to.equal('Row Feet');
+    expect(results.rowFeetQuantity.attributes.value.decimal).to.equal(
+      form.bedFeet * form.rowsPerBed
+    );
+    expect(results.rowFeetQuantity.relationships.units.id).to.equal(
+      unitMap.get('FEET').id
+    );
 
-        expect(rowFeetQuantity.attributes.inventory_adjustment).to.equal(
-          'increment'
-        );
-
-        expect(rowFeetQuantity.relationships.units.type).to.equal(
-          'taxonomy_term--unit'
-        );
-        expect(rowFeetQuantity.relationships.units.id).to.equal(
-          result.rowFeetQuantity.relationships.units.id
-        );
-
-        expect(rowFeetQuantity.relationships.inventory_asset.type).to.equal(
-          'asset--plant'
-        );
-        expect(rowFeetQuantity.relationships.inventory_asset.id).to.equal(
-          result.rowFeetQuantity.relationships.inventory_asset.id
-        );
-      }
+    expect(results.rowFeetQuantity.relationships.inventory_asset.id).to.equal(
+      results.plantAsset.id
+    );
+    expect(results.rowFeetQuantity.attributes.inventory_adjustment).to.equal(
+      'increment'
     );
   });
 
   it('Check the bed width quantity--standard', () => {
-    cy.wrap(farmosUtil.getStandardQuantity(result.bedWidthQuantity.id)).then(
-      (bedWidthQuantity) => {
-        expect(bedWidthQuantity.type).to.equal('quantity--standard');
-        expect(bedWidthQuantity.attributes.measure).to.equal('length');
-        expect(bedWidthQuantity.attributes.value.decimal).to.equal(
-          form.bedWidth.toString()
-        );
-        expect(bedWidthQuantity.attributes.label).to.equal('Bed Width');
-
-        expect(bedWidthQuantity.attributes.inventory_adjustment).to.be.null;
-
-        expect(bedWidthQuantity.relationships.units.type).to.equal(
-          'taxonomy_term--unit'
-        );
-        expect(bedWidthQuantity.relationships.units.id).to.equal(
-          result.bedWidthQuantity.relationships.units.id
-        );
-
-        expect(bedWidthQuantity.relationships.inventory_asset).to.be.null;
-      }
+    expect(results.bedWidthQuantity.type).to.equal('quantity--standard');
+    expect(results.bedWidthQuantity.attributes.measure).to.equal('length');
+    expect(results.bedWidthQuantity.attributes.value.decimal).to.equal(
+      form.bedWidth
     );
+    expect(results.bedWidthQuantity.attributes.label).to.equal('Bed Width');
+    expect(results.bedWidthQuantity.relationships.units.id).to.equal(
+      unitMap.get('INCHES').id
+    );
+    expect(results.bedWidthQuantity.attributes.inventory_adjustment).to.be.null;
+    expect(results.bedWidthQuantity.relationships.inventory_asset).to.be.null;
   });
 
   it('Check the log--seeding', () => {
-    cy.wrap(farmosUtil.getSeedingLog(result.seedingLog.id)).then(
-      (seedingLog) => {
-        expect(seedingLog.type).to.equal('log--seeding');
-        expect(seedingLog.attributes.name).to.equal(
-          result.seedingLog.attributes.name
-        );
-        expect(seedingLog.attributes.timestamp).to.contain('1950-01-02');
-        expect(seedingLog.attributes.status).to.equal('done');
-        expect(seedingLog.attributes.is_movement).to.be.true;
-        expect(seedingLog.attributes.purchase_date).to.contain('1950-01-02');
+    expect(results.seedingLog.type).to.equal('log--seeding');
+    expect(results.seedingLog.attributes.name).to.equal(
+      form.seedingDate + '_ds_' + form.cropName
+    );
+    expect(results.seedingLog.attributes.timestamp).to.contain('1950-01-02');
 
-        expect(seedingLog.relationships.location.length).to.equal(1);
-        expect(seedingLog.relationships.location[0].type).to.equal(
-          'asset--land'
-        );
-        expect(seedingLog.relationships.location[0].id).to.equal(
-          result.seedingLog.relationships.location[0].id
-        );
+    expect(results.seedingLog.relationships.location.length).to.equal(1);
+    expect(results.seedingLog.relationships.location[0].id).to.equal(
+      fieldMap.get(form.locationName).id
+    );
 
-        expect(seedingLog.relationships.asset[0].type).to.equal('asset--plant');
-        expect(seedingLog.relationships.asset[0].id).to.equal(
-          result.seedingLog.relationships.asset[0].id
-        );
+    expect(results.seedingLog.relationships.category.length).to.equal(2);
+    expect(results.seedingLog.relationships.category[0].id).to.equal(
+      categoryMap.get('seeding').id
+    );
+    expect(results.seedingLog.relationships.category[1].id).to.equal(
+      categoryMap.get('seeding_direct').id
+    );
 
-        expect(seedingLog.relationships.category.length).to.equal(2);
-        expect(seedingLog.relationships.category[0].type).to.equal(
-          'taxonomy_term--log_category'
-        );
-        expect(seedingLog.relationships.category[0].id).to.equal(
-          result.seedingLog.relationships.category[0].id
-        );
-        expect(seedingLog.relationships.category[1].type).to.equal(
-          'taxonomy_term--log_category'
-        );
-        expect(seedingLog.relationships.category[1].id).to.equal(
-          result.seedingLog.relationships.category[1].id
-        );
+    expect(results.seedingLog.relationships.asset[0].id).to.equal(
+      results.plantAsset.id
+    );
 
-        expect(seedingLog.relationships.quantity.length).to.equal(4);
-        for (let i = 0; i < 4; i++) {
-          expect(seedingLog.relationships.quantity[i].type).to.equal(
-            'quantity--standard'
-          );
-          expect(seedingLog.relationships.quantity[i].id).to.equal(
-            result.seedingLog.relationships.quantity[i].id
-          );
-        }
-      }
+    expect(results.seedingLog.relationships.quantity.length).to.equal(4);
+    expect(results.seedingLog.relationships.quantity[0].id).to.equal(
+      results.bedFeetQuantity.id
+    );
+    expect(results.seedingLog.relationships.quantity[1].id).to.equal(
+      results.rowsPerBedQuantity.id
+    );
+    expect(results.seedingLog.relationships.quantity[2].id).to.equal(
+      results.rowFeetQuantity.id
+    );
+    expect(results.seedingLog.relationships.quantity[3].id).to.equal(
+      results.bedWidthQuantity.id
     );
   });
 
   it('Check soil disturbance activity log not created', () => {
-    expect(result.depthQuantity).to.be.null;
-    expect(result.speedQuantity).to.be.null;
-    expect(result.activityLog).to.be.null;
+    expect(results.depthQuantity).to.be.null;
+    expect(results.speedQuantity).to.be.null;
+    expect(results.activityLog).to.be.null;
   });
 });


### PR DESCRIPTION
**Pull Request Description**

Simplifies the tests in `lib.submit.unit.cy.js` by just checking that the proper values have been passed to the `farmosUtil.js` library functions used by Direct Seeding's `lib.submtForm`.

---

**Licensing Certification**

FarmData2 is a [Free Cultural Work](https://freedomdefined.org/Definition) and all accepted contributions are licensed as described in the LICENSE.md file. This requires that the contributor holds the rights to do so. By submitting this pull request **I certify that I satisfy the terms of the [Developer Certificate of Origin](https://developercertificate.org/)** for its contents.
