### PR TITLE
fix(examples): moves example entry point to examples main menu

### DIFF
--- a/modules/farm_fd2_examples/src/module/farm_fd2_examples.links.menu.yml
+++ b/modules/farm_fd2_examples/src/module/farm_fd2_examples.links.menu.yml
@@ -55,6 +55,6 @@ farm.fd2_examples_soil_disturbance:
 farm.fd2_examples_example_entry_point:
   title: 'Example Entry Point'
   description: 'An example of a new entry point created by addEntrypoint.bash.'
-  parent: farm.fd2_examples_component_examples
+  parent: farm.fd2_examples_main
   route_name: farm.fd2_examples_example_entry_point.content
   weight: 100


### PR DESCRIPTION
**Pull Request Description**

The Example Entry Point example was appearing on the FD2 Examples -> Components menu.  This PR moves it to the FD2 Examples menu instead.

---

**Licensing Certification**

FarmData2 is a [Free Cultural Work](https://freedomdefined.org/Definition) and all accepted contributions are licensed as described in the LICENSE.md file. This requires that the contributor holds the rights to do so. By submitting this pull request **I certify that I satisfy the terms of the [Developer Certificate of Origin](https://developercertificate.org/)** for its contents.
