### PR TITLE
adds soil disturbed and modifies test

### DIFF
--- a/modules/farm_fd2/src/entrypoints/direct_seeding/lib.js
+++ b/modules/farm_fd2/src/entrypoints/direct_seeding/lib.js
@@ -196,7 +196,11 @@ async function submitForm(formData) {
             formData.beds,
             ['tillage', 'seeding_direct'],
             results.plantAsset,
-            [results.depthQuantity, results.speedQuantity],
+            [
+              results.depthQuantity,
+              results.speedQuantity,
+              results.bedFeetQuantity,
+            ],
             equipmentAssets
           );
         },

--- a/modules/farm_fd2/src/entrypoints/direct_seeding/lib.submit.unit.cy.js
+++ b/modules/farm_fd2/src/entrypoints/direct_seeding/lib.submit.unit.cy.js
@@ -240,12 +240,15 @@ describe('Submission using the direct_seeding lib.', () => {
       categoryMap.get('seeding_direct').id
     );
 
-    expect(results.activityLog.relationships.quantity.length).to.equal(2);
+    expect(results.activityLog.relationships.quantity.length).to.equal(3);
     expect(results.activityLog.relationships.quantity[0].id).to.equal(
       results.depthQuantity.id
     );
     expect(results.activityLog.relationships.quantity[1].id).to.equal(
       results.speedQuantity.id
+    );
+    expect(results.activityLog.relationships.quantity[2].id).to.equal(
+      results.bedFeetQuantity.id
     );
 
     expect(results.activityLog.relationships.equipment.length).to.equal(1);


### PR DESCRIPTION
**Pull Request Description**

Adds the `bedFeetQuanitity` to the soil disturbance activity log for direct seeding and updates the `lib.submit.unit.cy.js` test to check that `bedFeetQuanitity` is referenced in the soil disturbance log.

closes #286 

---

**Licensing Certification**

FarmData2 is a [Free Cultural Work](https://freedomdefined.org/Definition) and all accepted contributions are licensed as described in the LICENSE.md file. This requires that the contributor holds the rights to do so. By submitting this pull request **I certify that I satisfy the terms of the [Developer Certificate of Origin](https://developercertificate.org/)** for its contents.
