### PR TITLE
adds soil disturbed for transplanting and modifies test 

### DIFF
--- a/modules/farm_fd2/src/entrypoints/transplanting/lib.js
+++ b/modules/farm_fd2/src/entrypoints/transplanting/lib.js
@@ -276,7 +276,11 @@ export async function submitForm(formData) {
             formData.beds,
             ['tillage', 'transplanting'],
             results.transplantingPlantAsset,
-            [results.depthQuantity, results.speedQuantity],
+            [
+              results.depthQuantity,
+              results.speedQuantity,
+              results.transplantingBedFeetQuantity,
+            ],
             results.equipmentAssets
           );
         },

--- a/modules/farm_fd2/src/entrypoints/transplanting/lib.submit.unit.cy.js
+++ b/modules/farm_fd2/src/entrypoints/transplanting/lib.submit.unit.cy.js
@@ -355,12 +355,15 @@ describe('Submission using the transplanting lib.', () => {
       categoryMap.get('transplanting').id
     );
 
-    expect(result.activityLog.relationships.quantity.length).to.equal(2);
+    expect(result.activityLog.relationships.quantity.length).to.equal(3);
     expect(result.activityLog.relationships.quantity[0].id).to.equal(
       result.depthQuantity.id
     );
     expect(result.activityLog.relationships.quantity[1].id).to.equal(
       result.speedQuantity.id
+    );
+    expect(result.activityLog.relationships.quantity[2].id).to.equal(
+      result.transplantingBedFeetQuantity.id
     );
   });
 });


### PR DESCRIPTION
**Pull Request Description**

Adds the `transplantingBedFeetQuanitity` to the soil disturbance activity log for transplanting and updates the `lib.submit.unit.cy.js` test to check that `transplantingBedFeetQuanitity ` is referenced in the soil disturbance log.

closes #287  

**Licensing Certification**

FarmData2 is a [Free Cultural Work](https://freedomdefined.org/Definition) and all accepted contributions are licensed as described in the LICENSE.md file. This requires that the contributor holds the rights to do so. By submitting this pull request **I certify that I satisfy the terms of the [Developer Certificate of Origin](https://developercertificate.org/)** for its contents.
