### PR TITLE
refactor(fd2): updates transplanting to match new templates

### DIFF
--- a/modules/farm_fd2/src/entrypoints/direct_seeding/App.vue
+++ b/modules/farm_fd2/src/entrypoints/direct_seeding/App.vue
@@ -295,7 +295,7 @@ export default {
               });
           })
           .catch(() => {
-            if (!this.errorShown) {
+            if (!this.errorShowing) {
               uiUtil.hideToast();
               this.errorShowing = true;
               uiUtil

--- a/modules/farm_fd2/src/entrypoints/transplanting/transplanting.submission.e2e.cy.js
+++ b/modules/farm_fd2/src/entrypoints/transplanting/transplanting.submission.e2e.cy.js
@@ -93,16 +93,19 @@ describe('Transplanting: Submission tests', () => {
      */
     submitForm();
 
+    // Check that Submit and Reset are disabled while submitting.
+    cy.get('[data-cy="submit-button"]').should('be.disabled');
+    cy.get('[data-cy="reset-button"]').should('be.disabled');
+
     // Check for the status toast while the form is submitting.
     cy.get('.toast')
       .should('be.visible')
       .should('contain.text', 'Submitting transplanting...');
 
     // Give time for all the records to be created.
-    cy.get('.toast', { timeout: 10000 }).should(
-      'contain.text',
-      'Transplanting created.'
-    );
+    cy.get('.toast', { timeout: 10000 })
+      .should('be.visible')
+      .should('contain.text', 'Transplanting created.');
 
     /*
      * Check that the submitForm function was called with the
@@ -168,8 +171,12 @@ describe('Transplanting: Submission tests', () => {
       .should('have.value', '100');
     cy.get('[data-cy="comment-input"]').should('have.value', '');
 
-    // Finally check that the toast is hidden.
+    // Check that the toast is hidden.
     cy.get('.toast').should('not.exist');
+
+    // Check that Submit button is re-enabled after submitting.
+    cy.get('[data-cy="submit-button"]').should('be.enabled');
+    cy.get('[data-cy="reset-button"]').should('be.enabled');
   });
 
   it('Test submission with network error', () => {
@@ -177,6 +184,8 @@ describe('Transplanting: Submission tests', () => {
       statusCode: 401,
     });
     submitForm();
+    cy.get('[data-cy="submit-button"]').should('be.disabled');
+    cy.get('[data-cy="reset-button"]').should('be.disabled');
     cy.get('.toast')
       .should('be.visible')
       .should('contain.text', 'Submitting transplanting...');
@@ -184,5 +193,7 @@ describe('Transplanting: Submission tests', () => {
       .should('be.visible')
       .should('contain.text', 'Error creating transplanting.');
     cy.get('.toast', { timeout: 7000 }).should('not.exist');
+    cy.get('[data-cy="submit-button"]').should('be.enabled');
+    cy.get('[data-cy="reset-button"]').should('be.enabled');
   });
 });

--- a/modules/farm_fd2/src/entrypoints/tray_seeding/App.vue
+++ b/modules/farm_fd2/src/entrypoints/tray_seeding/App.vue
@@ -256,7 +256,7 @@ export default {
               });
           })
           .catch(() => {
-            if (!this.errorShown) {
+            if (!this.errorShowing) {
               uiUtil.hideToast();
               this.errorShowing = true;
               uiUtil

--- a/modules/farm_fd2/src/entrypoints/tray_seeding/tray_seeding.submission.e2e.cy.js
+++ b/modules/farm_fd2/src/entrypoints/tray_seeding/tray_seeding.submission.e2e.cy.js
@@ -75,10 +75,9 @@ describe('Tray Seeding: Submission tests', () => {
       .should('contain.text', 'Submitting tray seeding...');
 
     // Give time for all the records to be created.
-    cy.get('.toast', { timeout: 10000 }).should(
-      'contain.text',
-      'Tray seeding created.'
-    );
+    cy.get('.toast', { timeout: 10000 })
+      .should('be.visible')
+      .should('contain.text', 'Tray seeding created.');
 
     /*
      * Check that the submitForm function was called with the


### PR DESCRIPTION
**Pull Request Description**

Updates the transplanting entry point and tests to match the new entry point templates.  This simplifies the code and fixes an issue with enabling / disabling the submit and reset button.  Also touches up a few things in the tray seeding and direct seeding entry points that were missed when refactoring them.

Closes #277 

---

**Licensing Certification**

FarmData2 is a [Free Cultural Work](https://freedomdefined.org/Definition) and all accepted contributions are licensed as described in the LICENSE.md file. This requires that the contributor holds the rights to do so. By submitting this pull request **I certify that I satisfy the terms of the [Developer Certificate of Origin](https://developercertificate.org/)** for its contents.
