### PR TITLE
Changes the styling of the submit/reset buttons

### DIFF
--- a/components/SubmitResetButtons/SubmitResetButtons.vue
+++ b/components/SubmitResetButtons/SubmitResetButtons.vue
@@ -3,8 +3,9 @@
     <BRow
       id="submit-reset"
       data-cy="submit-reset"
+      class="grid-container"
     >
-      <BCol cols="auto">
+      <BCol class="submit-button-col d-flex justify-content-start">
         <BButton
           id="submit-button"
           data-cy="submit-button"
@@ -16,14 +17,13 @@
           >Submit</BButton
         >
       </BCol>
-      <BCol
-        cols="auto"
-        alignSelf="center"
-      >
+      <BCol class="reset-button-col d-flex justify-content-end p-0">
         <BButton
           id="reset-button"
           data-cy="reset-button"
           variant="warning"
+          size="lg"
+          class="fd2-reset"
           v-on:click="reset()"
           v-bind:disabled="!resetEnabled"
           >Reset</BButton
@@ -117,15 +117,34 @@ export default {
 </script>
 
 <style scoped>
+.grid-container {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  gap: 10px;
+  align-items: center;
+  width: 100%;
+  margin-left: 0 !important;
+}
+
+.submit-button-col {
+  padding-left: 0 !important;
+}
+
 .fd2-submit {
-  width: 245px !important;
-  min-width: 245px;
-  max-width: 245px;
+  width: 100%;
 }
 
 .fd2-reset {
-  width: 50px !important;
-  min-width: 50px;
-  max-width: 50px;
+  width: 100%;
+  max-width: 120px;
+}
+
+@media (max-width: 576px) {
+  .fd2-submit {
+    font-size: 14px;
+  }
+  .fd2-reset {
+    font-size: 14px;
+  }
 }
 </style>

--- a/components/SubmitResetButtons/SubmitResetButtons.vue
+++ b/components/SubmitResetButtons/SubmitResetButtons.vue
@@ -138,13 +138,4 @@ export default {
   width: 100%;
   max-width: 120px;
 }
-
-@media (max-width: 576px) {
-  .fd2-submit {
-    font-size: 14px;
-  }
-  .fd2-reset {
-    font-size: 14px;
-  }
-}
 </style>


### PR DESCRIPTION
**Pull Request Description**

Styles the buttons so that the reset button is a fixed size and goes all the way to the right of the page. The Submit button should then expand to fill the remainder of the space.

Closes #219 

---

**Licensing Certification**

FarmData2 is a [Free Cultural Work](https://freedomdefined.org/Definition) and all accepted contributions are licensed as described in the LICENSE.md file. This requires that the contributor holds the rights to do so. By submitting this pull request **I certify that I satisfy the terms of the [Developer Certificate of Origin](https://developercertificate.org/)** for its contents.
