### PR TITLE
Makes the categories all have a common parent 'Category'

### DIFF
--- a/library/farmosUtil/farmosUtil.equipment.unit.cy.js
+++ b/library/farmosUtil/farmosUtil.equipment.unit.cy.js
@@ -107,6 +107,23 @@ describe('Test the equipment utility functions', () => {
         expect(equipmentMap.get('Seeding Drill')).to.be.undefined;
       }
     );
+
+    cy.wrap(farmosUtil.getEquipmentNameToAssetMap(['Seeding'])).then(
+      (equipmentMap) => {
+        expect(equipmentMap).to.not.be.null;
+        expect(equipmentMap.size).to.equal(4);
+
+        expect(equipmentMap.get('Planter')).to.not.be.null;
+        expect(equipmentMap.get('Planter').type).to.equal('asset--equipment');
+
+        expect(equipmentMap.get('Portable Broadcaster')).to.not.be.null;
+        expect(equipmentMap.get('Portable Broadcaster').type).to.equal(
+          'asset--equipment'
+        );
+
+        expect(equipmentMap.get('Tractor')).to.be.undefined;
+      }
+    );
   });
 
   it('Get the EquipmentIdToAsset map for all equipment', () => {
@@ -156,6 +173,21 @@ describe('Test the equipment utility functions', () => {
             );
 
             const drillId = equipmentNameMap.get('Seeding Drill').id;
+            expect(equipmentIdMap.get(drillId)).to.be.undefined;
+          }
+        );
+        cy.wrap(farmosUtil.getEquipmentIdToAssetMap(['Seeding'])).then(
+          (equipmentIdMap) => {
+            expect(equipmentIdMap).to.not.be.null;
+            expect(equipmentIdMap.size).to.equal(4);
+
+            const tractorId = equipmentNameMap.get('Planter').id;
+            expect(equipmentIdMap.get(tractorId)).to.not.be.null;
+            expect(equipmentIdMap.get(tractorId).type).to.equal(
+              'asset--equipment'
+            );
+
+            const drillId = equipmentNameMap.get('Tractor').id;
             expect(equipmentIdMap.get(drillId)).to.be.undefined;
           }
         );

--- a/library/farmosUtil/farmosUtil.equipment.unit.cy.js
+++ b/library/farmosUtil/farmosUtil.equipment.unit.cy.js
@@ -14,21 +14,32 @@ describe('Test the equipment utility functions', () => {
   it('Get the equipment', () => {
     cy.wrap(farmosUtil.getEquipment()).then((equipment) => {
       expect(equipment).to.not.be.null;
-      expect(equipment.length).to.equal(8);
+      expect(equipment.length).to.equal(9);
 
-      expect(equipment[0].attributes.name).to.equal('General');
+      // Category
+      expect(equipment[0].attributes.name).to.equal('Category');
       expect(equipment[0].attributes.notes.value).to.equal(
-        'Equipment used for a variety of operations.'
+        ' Parent of all categories'
       );
       expect(equipment[0].type).to.equal('asset--equipment');
       expect(equipment[0].relationships.parent).to.have.length(0);
 
-      expect(equipment[7].attributes.name).to.equal('Tractor');
-      expect(equipment[7].attributes.notes.value).to.equal(
+      // General
+      expect(equipment[1].attributes.name).to.equal('General');
+      expect(equipment[1].attributes.notes.value).to.equal(
+        'Equipment used for a variety of operations.'
+      );
+      expect(equipment[1].type).to.equal('asset--equipment');
+      expect(equipment[1].relationships.parent).to.have.length(1);
+      expect(equipment[1].relationships.parent[0].id).to.equal(equipment[0].id);
+
+      // Tractor
+      expect(equipment[8].attributes.name).to.equal('Tractor');
+      expect(equipment[8].attributes.notes.value).to.equal(
         'A standard tractor.'
       );
-      expect(equipment[7].type).to.equal('asset--equipment');
-      expect(equipment[7].relationships.parent[0].id).to.equal(equipment[0].id);
+      expect(equipment[8].type).to.equal('asset--equipment');
+      expect(equipment[8].relationships.parent[0].id).to.equal(equipment[1].id);
     });
   });
 

--- a/library/farmosUtil/farmosUtil.equipment.unit.cy.js
+++ b/library/farmosUtil/farmosUtil.equipment.unit.cy.js
@@ -14,12 +14,24 @@ describe('Test the equipment utility functions', () => {
   it('Get the equipment', () => {
     cy.wrap(farmosUtil.getEquipment()).then((equipment) => {
       expect(equipment).to.not.be.null;
-      expect(equipment.length).to.equal(9);
+      expect(equipment.length).to.equal(11);
+
+      // Garden Rake
+      expect(equipment[4].attributes.name).to.equal('Rake');
+      expect(equipment[4].attributes.notes.value).to.equal('A garden rake.');
+      expect(equipment[4].type).to.equal('asset--equipment');
+      expect(equipment[4].relationships.parent).to.have.length(0);
+
+      // Shovel
+      expect(equipment[7].attributes.name).to.equal('Shovel');
+      expect(equipment[7].attributes.notes).to.be.null;
+      expect(equipment[7].type).to.equal('asset--equipment');
+      expect(equipment[7].relationships.parent).to.have.length(0);
 
       // Category
       expect(equipment[0].attributes.name).to.equal('Category');
       expect(equipment[0].attributes.notes.value).to.equal(
-        ' Parent of all categories'
+        'Parent of all categories'
       );
       expect(equipment[0].type).to.equal('asset--equipment');
       expect(equipment[0].relationships.parent).to.have.length(0);
@@ -34,12 +46,14 @@ describe('Test the equipment utility functions', () => {
       expect(equipment[1].relationships.parent[0].id).to.equal(equipment[0].id);
 
       // Tractor
-      expect(equipment[8].attributes.name).to.equal('Tractor');
-      expect(equipment[8].attributes.notes.value).to.equal(
+      expect(equipment[10].attributes.name).to.equal('Tractor');
+      expect(equipment[10].attributes.notes.value).to.equal(
         'A standard tractor.'
       );
-      expect(equipment[8].type).to.equal('asset--equipment');
-      expect(equipment[8].relationships.parent[0].id).to.equal(equipment[1].id);
+      expect(equipment[10].type).to.equal('asset--equipment');
+      expect(equipment[10].relationships.parent[0].id).to.equal(
+        equipment[1].id
+      );
     });
   });
 
@@ -76,52 +90,72 @@ describe('Test the equipment utility functions', () => {
   it('Get the equipmentNameToTerm map for all categories', () => {
     cy.wrap(farmosUtil.getEquipmentNameToAssetMap()).then((equipmentMap) => {
       expect(equipmentMap).to.not.be.null;
-      expect(equipmentMap.size).to.equal(6); // Note: Categories are excluded
+      expect(equipmentMap.size).to.equal(8); // Note: Categories are excluded
 
-      expect(equipmentMap.get('Tractor')).to.not.be.null;
+      expect(equipmentMap.get('Rake')).to.not.be.undefined;
+      expect(equipmentMap.get('Rake').type).to.equal('asset--equipment');
+
+      expect(equipmentMap.get('Shovel')).to.not.be.undefined;
+      expect(equipmentMap.get('Shovel').type).to.equal('asset--equipment');
+
+      expect(equipmentMap.get('Tractor')).to.not.be.undefined;
       expect(equipmentMap.get('Tractor').type).to.equal('asset--equipment');
 
-      expect(equipmentMap.get('Seeding Drill')).to.not.be.null;
+      expect(equipmentMap.get('Seeding Drill')).to.not.be.undefined;
       expect(equipmentMap.get('Seeding Drill').type).to.equal(
         'asset--equipment'
       );
 
+      expect(equipmentMap.get('Category')).to.be.undefined;
       expect(equipmentMap.get('General')).to.be.undefined;
     });
   });
 
-  it('Get the equipmentNameToTerm map for specific categories', () => {
+  it('Get the equipmentNameToTerm map for a specific category', () => {
     cy.wrap(farmosUtil.getEquipmentNameToAssetMap(['General'])).then(
       (equipmentMap) => {
         expect(equipmentMap).to.not.be.null;
         expect(equipmentMap.size).to.equal(2);
 
-        expect(equipmentMap.get('Tractor')).to.not.be.null;
+        expect(equipmentMap.get('Tractor')).to.not.be.undefined;
         expect(equipmentMap.get('Tractor').type).to.equal('asset--equipment');
 
-        expect(equipmentMap.get('Small Tractor')).to.not.be.null;
+        expect(equipmentMap.get('Small Tractor')).to.not.be.undefined;
         expect(equipmentMap.get('Small Tractor').type).to.equal(
           'asset--equipment'
         );
 
         expect(equipmentMap.get('Seeding Drill')).to.be.undefined;
+        expect(equipmentMap.get('Rake')).to.be.undefined;
+        expect(equipmentMap.get('Shovel')).to.be.undefined;
       }
     );
+  });
 
-    cy.wrap(farmosUtil.getEquipmentNameToAssetMap(['Seeding'])).then(
+  it('Get the equipmentNameToTerm map for a specific categories', () => {
+    cy.wrap(farmosUtil.getEquipmentNameToAssetMap(['General', 'Seeding'])).then(
       (equipmentMap) => {
         expect(equipmentMap).to.not.be.null;
-        expect(equipmentMap.size).to.equal(4);
+        expect(equipmentMap.size).to.equal(6);
 
-        expect(equipmentMap.get('Planter')).to.not.be.null;
-        expect(equipmentMap.get('Planter').type).to.equal('asset--equipment');
+        expect(equipmentMap.get('Tractor')).to.not.be.undefined;
+        expect(equipmentMap.get('Tractor').type).to.equal('asset--equipment');
 
-        expect(equipmentMap.get('Portable Broadcaster')).to.not.be.null;
-        expect(equipmentMap.get('Portable Broadcaster').type).to.equal(
+        expect(equipmentMap.get('Small Tractor')).to.not.be.undefined;
+        expect(equipmentMap.get('Small Tractor').type).to.equal(
           'asset--equipment'
         );
 
-        expect(equipmentMap.get('Tractor')).to.be.undefined;
+        expect(equipmentMap.get('Seeding Drill')).to.not.be.undefined;
+        expect(equipmentMap.get('Seeding Drill').type).to.equal(
+          'asset--equipment'
+        );
+
+        expect(equipmentMap.get('Planter')).to.not.be.undefined;
+        expect(equipmentMap.get('Planter').type).to.equal('asset--equipment');
+
+        expect(equipmentMap.get('Rake')).to.be.undefined;
+        expect(equipmentMap.get('Shovel')).to.be.undefined;
       }
     );
   });
@@ -130,7 +164,7 @@ describe('Test the equipment utility functions', () => {
     cy.wrap(farmosUtil.getEquipmentNameToAssetMap()).then(
       (equipmentNameMap) => {
         expect(equipmentNameMap).to.not.be.null;
-        expect(equipmentNameMap.size).to.equal(6);
+        expect(equipmentNameMap.size).to.equal(8);
 
         cy.wrap(farmosUtil.getEquipmentIdToAssetMap()).then(
           (equipmentIdMap) => {
@@ -149,17 +183,34 @@ describe('Test the equipment utility functions', () => {
             expect(equipmentIdMap.get(drillId).type).to.equal(
               'asset--equipment'
             );
+
+            const rakeId = equipmentNameMap.get('Rake').id;
+            expect(equipmentIdMap.get(rakeId).attributes.name).to.equal('Rake');
+            expect(equipmentIdMap.get(rakeId).type).to.equal(
+              'asset--equipment'
+            );
+
+            const shovelId = equipmentNameMap.get('Shovel').id;
+            expect(equipmentIdMap.get(shovelId).attributes.name).to.equal(
+              'Shovel'
+            );
+            expect(equipmentIdMap.get(shovelId).type).to.equal(
+              'asset--equipment'
+            );
+
+            expect(equipmentNameMap.get('Category')).to.be.undefined;
+            expect(equipmentNameMap.get('Seeding')).to.be.undefined;
           }
         );
       }
     );
   });
 
-  it('Get the EquipmentIdToAsset map for specific categories', () => {
+  it('Get the EquipmentIdToAsset map for a specific category', () => {
     cy.wrap(farmosUtil.getEquipmentNameToAssetMap()).then(
       (equipmentNameMap) => {
         expect(equipmentNameMap).to.not.be.null;
-        expect(equipmentNameMap.size).to.equal(6);
+        expect(equipmentNameMap.size).to.equal(8);
 
         cy.wrap(farmosUtil.getEquipmentIdToAssetMap(['General'])).then(
           (equipmentIdMap) => {
@@ -172,25 +223,45 @@ describe('Test the equipment utility functions', () => {
               'asset--equipment'
             );
 
-            const drillId = equipmentNameMap.get('Seeding Drill').id;
-            expect(equipmentIdMap.get(drillId)).to.be.undefined;
+            expect(equipmentIdMap.get(equipmentNameMap.get('Seeding Drill'))).to
+              .be.undefined;
+            expect(equipmentIdMap.get(equipmentNameMap.get('Rake'))).to.be
+              .undefined;
+            expect(equipmentIdMap.get(equipmentNameMap.get('Shovel'))).to.be
+              .undefined;
           }
         );
-        cy.wrap(farmosUtil.getEquipmentIdToAssetMap(['Seeding'])).then(
-          (equipmentIdMap) => {
-            expect(equipmentIdMap).to.not.be.null;
-            expect(equipmentIdMap.size).to.equal(4);
+      }
+    );
+  });
 
-            const tractorId = equipmentNameMap.get('Planter').id;
-            expect(equipmentIdMap.get(tractorId)).to.not.be.null;
-            expect(equipmentIdMap.get(tractorId).type).to.equal(
-              'asset--equipment'
-            );
+  it('Get the EquipmentIdToAsset map for a specific categories', () => {
+    cy.wrap(farmosUtil.getEquipmentNameToAssetMap()).then(
+      (equipmentNameMap) => {
+        expect(equipmentNameMap).to.not.be.null;
+        expect(equipmentNameMap.size).to.equal(8);
 
-            const drillId = equipmentNameMap.get('Tractor').id;
-            expect(equipmentIdMap.get(drillId)).to.be.undefined;
-          }
-        );
+        cy.wrap(
+          farmosUtil.getEquipmentIdToAssetMap(['General', 'Seeding'])
+        ).then((equipmentIdMap) => {
+          expect(equipmentIdMap).to.not.be.null;
+          expect(equipmentIdMap.size).to.equal(6);
+
+          const tractorId = equipmentNameMap.get('Tractor').id;
+          expect(equipmentIdMap.get(tractorId)).to.not.be.null;
+          expect(equipmentIdMap.get(tractorId).type).to.equal(
+            'asset--equipment'
+          );
+
+          const drillId = equipmentNameMap.get('Seeding Drill').id;
+          expect(equipmentIdMap.get(drillId)).to.not.be.null;
+          expect(equipmentIdMap.get(drillId).type).to.equal('asset--equipment');
+
+          expect(equipmentIdMap.get(equipmentNameMap.get('Rake'))).to.be
+            .undefined;
+          expect(equipmentIdMap.get(equipmentNameMap.get('Shovel'))).to.be
+            .undefined;
+        });
       }
     );
   });

--- a/library/farmosUtil/farmosUtil.js
+++ b/library/farmosUtil/farmosUtil.js
@@ -1430,14 +1430,19 @@ export async function getEquipmentNameToAssetMap(categories = []) {
     equipment.map((eq) => [eq.id, eq.attributes.name])
   );
 
+  const categoryParentName = 'Category';
+
   function filter(filtered, eq) {
+    const hasParent = eq.relationships.parent.length != 0;
+    const parentName = hasParent
+      ? parentIdToName.get(eq.relationships.parent[0].id)
+      : null;
+
     if (
-      // If the equipment has a parent
-      // and either the categories list is empty or
-      // the category name of the parent is in the list of categories
-      eq.relationships.parent.length != 0 &&
-      (categories.length == 0 ||
-        categories.includes(parentIdToName.get(eq.relationships.parent[0].id)))
+      eq.attributes.name !== categoryParentName &&
+      parentName !== categoryParentName &&
+      (categories.length === 0 ||
+        (hasParent && categories.includes(parentName)))
     ) {
       filtered.set(eq.attributes.name, eq);
     }
@@ -1473,14 +1478,19 @@ export async function getEquipmentIdToAssetMap(categories = []) {
     equipment.map((eq) => [eq.id, eq.attributes.name])
   );
 
+  const categoryParentName = 'Category';
+
   function filter(filtered, eq) {
+    const hasParent = eq.relationships.parent.length != 0;
+    const parentName = hasParent
+      ? parentIdToName.get(eq.relationships.parent[0].id)
+      : null;
+
     if (
-      // If the equipment has a parent
-      // and either the categories list is empty or
-      // the category name of the parent is in the list of categories
-      eq.relationships.parent.length != 0 &&
-      (categories.length == 0 ||
-        categories.includes(parentIdToName.get(eq.relationships.parent[0].id)))
+      eq.attributes.name !== categoryParentName &&
+      parentName !== categoryParentName &&
+      (categories.length === 0 ||
+        (hasParent && categories.includes(parentName)))
     ) {
       filtered.set(eq.id, eq);
     }


### PR DESCRIPTION
**Pull Request Description**

This makes the equipment categories all have a common parent 'Category'.  This makes it possible to include equipment without a category because we can omit any assets with this parent rather than omitting any assets that do not have a parent. 

Closes #298 

---

**Licensing Certification**

FarmData2 is a [Free Cultural Work](https://freedomdefined.org/Definition) and all accepted contributions are licensed as described in the LICENSE.md file. This requires that the contributor holds the rights to do so. By submitting this pull request **I certify that I satisfy the terms of the [Developer Certificate of Origin](https://developercertificate.org/)** for its contents.
