### PR TITLE
Fixes the equipment selector component test after the new db release

### DIFF
--- a/components/EquipmentSelector/EquipmentSelector.content.comp.cy.js
+++ b/components/EquipmentSelector/EquipmentSelector.content.comp.cy.js
@@ -131,7 +131,7 @@ describe('Test the default EquipmentSelector content', () => {
       .then(() => {
         cy.get('[data-cy="selector-input"]')
           .find('option')
-          .should('have.length', 7);
+          .should('have.length', 9);
 
         cy.get('[data-cy="equipment-selector-1"]')
           .find('[data-cy="selector-option-1"]')


### PR DESCRIPTION
**Pull Request Description**

Fixes the equipment selector content component test after the new v3.3.5. db release

---

**Licensing Certification**

FarmData2 is a [Free Cultural Work](https://freedomdefined.org/Definition) and all accepted contributions are licensed as described in the LICENSE.md file. This requires that the contributor holds the rights to do so. By submitting this pull request **I certify that I satisfy the terms of the [Developer Certificate of Origin](https://developercertificate.org/)** for its contents.
