### PR TITLE
Handles null for plantAsset parameter in farmosUtil.js: createSoilDisturbance

### DIFF
--- a/library/farmosUtil/farmosUtil.js
+++ b/library/farmosUtil/farmosUtil.js
@@ -2065,7 +2065,7 @@ export async function createSoilDisturbanceActivityLog(
     },
     relationships: {
       location: locationArray,
-      asset: [{ type: 'asset--plant', id: plantAsset.id }],
+      asset: plantAsset ? [{ type: 'asset--plant', id: plantAsset.id }] : [],
       category: logCategoriesArray,
       quantity: quantitiesArray,
       equipment: equipmentArray,


### PR DESCRIPTION
**Pull Request Description**

This PR handles null for `plantAsset` parameter in `farmosUtil.js: createSoilDisturbance`. In addition, a test is added for creating a soil disturbance without a `plantAsset`.

Closes #233 
---

**Licensing Certification**

FarmData2 is a [Free Cultural Work](https://freedomdefined.org/Definition) and all accepted contributions are licensed as described in the LICENSE.md file. This requires that the contributor holds the rights to do so. By submitting this pull request **I certify that I satisfy the terms of the [Developer Certificate of Origin](https://developercertificate.org/)** for its contents.
