### PR TITLE
Clarifies invalid feedback text for Trays and Seeds/Cell

### DIFF
--- a/modules/farm_fd2/src/entrypoints/tray_seeding/App.vue
+++ b/modules/farm_fd2/src/entrypoints/tray_seeding/App.vue
@@ -72,7 +72,7 @@
           data-cy="tray-seeding-trays"
           required
           label="Trays"
-          invalidFeedbackText="Trays must be positive."
+          invalidFeedbackText="Trays must be a positive number."
           v-model:value="form.trays"
           v-bind:showValidityStyling="validity.show"
           v-bind:decimalPlaces="2"
@@ -100,7 +100,7 @@
           data-cy="tray-seeding-seeds"
           required
           label="Seeds/Cell"
-          invalidFeedbackText="Seeds must be positive."
+          invalidFeedbackText="Seeds/Cell must be a positive number."
           v-model:value="form.seedsPerCell"
           v-bind:showValidityStyling="validity.show"
           v-bind:decimalPlaces="0"


### PR DESCRIPTION
**Pull Request Description**

The invalid feedback text is modified to be

- "Trays must be a positive number."
- "Seeds/Cell must be a positive number."

Closes #102
---

**Licensing Certification**

FarmData2 is a [Free Cultural Work](https://freedomdefined.org/Definition) and all accepted contributions are licensed as described in the LICENSE.md file. This requires that the contributor holds the rights to do so. By submitting this pull request **I certify that I satisfy the terms of the [Developer Certificate of Origin](https://developercertificate.org/)** for its contents.
