### PR TITLE
feat(fd2): adds Soil menu

### DIFF
--- a/modules/farm_fd2/src/entrypoints/soil/App.vue
+++ b/modules/farm_fd2/src/entrypoints/soil/App.vue
@@ -1,0 +1,39 @@
+<template>
+  <h1 data-cy="title">FarmData2 Soil Features</h1>
+  <p>This menu contains the collection of FarmData2 soil features including:</p>
+
+  <UL>
+    <LI>
+      Soil Disturbance: A form for recording activities that disturb the soil.
+    </LI>
+    <LI>
+      Soil Amendment: A form for recording amendments to the soil (e.g.
+      fertilizers).
+    </LI>
+  </UL>
+
+  <div
+    data-cy="page-loaded"
+    v-show="false"
+  >
+    {{ pageDoneLoading }}
+  </div>
+</template>
+
+<script>
+export default {
+  data() {
+    return {
+      createdCount: 0,
+    };
+  },
+  computed: {
+    pageDoneLoading() {
+      return this.createdCount == 1;
+    },
+  },
+  created() {
+    this.createdCount++;
+  },
+};
+</script>

--- a/modules/farm_fd2/src/entrypoints/soil/index.html
+++ b/modules/farm_fd2/src/entrypoints/soil/index.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1.0"
+    />
+    <title>Soil</title>
+  </head>
+  <body>
+    <div id="app"></div>
+    <script
+      type="module"
+      src="/soil/soil.js"
+    ></script>
+  </body>
+</html>

--- a/modules/farm_fd2/src/entrypoints/soil/soil.exists.e2e.cy.js
+++ b/modules/farm_fd2/src/entrypoints/soil/soil.exists.e2e.cy.js
@@ -1,0 +1,10 @@
+describe('Check that the soil entry point in farm_fd2 exists.', () => {
+  it('Check that the page loaded.', () => {
+    // Login if running in live farmOS.
+    cy.login('admin', 'admin');
+    // Go to the main page.
+    cy.visit('fd2/soil/');
+    // Check that the page loads.
+    cy.waitForPage();
+  });
+});

--- a/modules/farm_fd2/src/entrypoints/soil/soil.html
+++ b/modules/farm_fd2/src/entrypoints/soil/soil.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1.0"
+    />
+    <title>Soil</title>
+  </head>
+  <body>
+    <div id="app"></div>
+    <script
+      type="module"
+      src="/soil/soil.js"
+    ></script>
+  </body>
+</html>

--- a/modules/farm_fd2/src/entrypoints/soil/soil.js
+++ b/modules/farm_fd2/src/entrypoints/soil/soil.js
@@ -1,0 +1,13 @@
+// Imports for Bootstrap-Vue components.
+import 'bootstrap/dist/css/bootstrap.css';
+import 'bootstrap-vue-next/dist/bootstrap-vue-next.css';
+
+import { createApp } from 'vue';
+import { createPinia } from 'pinia';
+import App from './App.vue';
+
+const app = createApp(App);
+
+app.use(createPinia());
+
+app.mount('#app');

--- a/modules/farm_fd2/src/module/farm_fd2.libraries.yml
+++ b/modules/farm_fd2/src/module/farm_fd2.libraries.yml
@@ -47,3 +47,13 @@ transplanting:
   css:
     component:
       style/style.css: {}
+
+soil:
+  js:
+    soil/soil.js:
+      preprocess: false
+      minified: true
+      attributes: { type: 'module' }
+  css:
+    component:
+      style/style.css: {}

--- a/modules/farm_fd2/src/module/farm_fd2.links.menu.yml
+++ b/modules/farm_fd2/src/module/farm_fd2.links.menu.yml
@@ -21,7 +21,13 @@ farm.fd2_direct_seeding:
   description: 'Data entry form for recording a direct seeding.'
   parent: farm.fd2_seeding
   route_name: farm.fd2_direct_seeding.content
-  weight: 110
+  weight: 100
+farm.fd2_soil:
+  title: 'Soil'
+  description: 'FarmData2 features for soil.'
+  parent: farm.fd2_main
+  route_name: farm.fd2_soil.content
+  weight: 100
 farm.fd2_transplanting:
   title: 'Transplanting'
   description: 'Data entry form for recording transplantings.'

--- a/modules/farm_fd2/src/module/farm_fd2.routing.yml
+++ b/modules/farm_fd2/src/module/farm_fd2.routing.yml
@@ -34,6 +34,13 @@ farm.fd2_direct_seeding.content:
     _title: 'Direct Seeding'
   requirements:
     _permission: 'access content,create plant asset,create seeding log,create standard quantity,create activity log'
+farm.fd2_soil.content:
+  path: '/fd2/soil'
+  defaults:
+    _controller: '\Drupal\farm_fd2\Controller\FD2_Controller::content'
+    _title: 'Soil'
+  requirements:
+    _permission: 'access content'
 farm.fd2_transplanting.content:
   path: '/fd2/transplanting'
   defaults:


### PR DESCRIPTION
**Pull Request Description**

Adds the Soil menu as the parent menu for Soil Disturbances and Soil Amendments.

Closes #288

---

**Licensing Certification**

FarmData2 is a [Free Cultural Work](https://freedomdefined.org/Definition) and all accepted contributions are licensed as described in the LICENSE.md file. This requires that the contributor holds the rights to do so. By submitting this pull request **I certify that I satisfy the terms of the [Developer Certificate of Origin](https://developercertificate.org/)** for its contents.
