### PR TITLE
fix(fd2): patches the equipment selector

### DIFF
--- a/components/EquipmentSelector/EquipmentSelector.events.comp.cy.js
+++ b/components/EquipmentSelector/EquipmentSelector.events.comp.cy.js
@@ -94,6 +94,57 @@ describe('Test the EquipmentSelector component events', () => {
       });
   });
 
+  it('Emits valid false when required and prop changed to contain no selections', () => {
+    const readySpy = cy.spy().as('readySpy');
+    const validSpy = cy.spy().as('validSpy');
+
+    cy.mount(EquipmentSelector, {
+      props: {
+        required: true,
+        onReady: readySpy,
+        onValid: validSpy,
+        selected: ['Tractor', 'Planter'],
+      },
+    }).then(({ wrapper }) => {
+      cy.get('@readySpy')
+        .should('have.been.calledOnce')
+        .then(() => {
+          cy.get('@validSpy').should('have.been.calledOnce');
+          cy.get('@validSpy').should('have.been.calledWith', true);
+        })
+        .then(() => {
+          wrapper.setProps({ selected: [] });
+          cy.get('@validSpy').should('have.been.calledTwice');
+          cy.get('@validSpy').should('have.been.calledWith', false);
+        });
+    });
+  });
+
+  it('Emits valid true when not required and prop changed to contain no selections', () => {
+    const readySpy = cy.spy().as('readySpy');
+    const validSpy = cy.spy().as('validSpy');
+
+    cy.mount(EquipmentSelector, {
+      props: {
+        required: false,
+        onReady: readySpy,
+        onValid: validSpy,
+        selected: ['Tractor', 'Planter'],
+      },
+    }).then(({ wrapper }) => {
+      cy.get('@readySpy')
+        .should('have.been.calledOnce')
+        .then(() => {
+          cy.get('@validSpy').should('have.been.calledOnce');
+          cy.get('@validSpy').should('have.been.calledWith', true);
+        })
+        .then(() => {
+          wrapper.setProps({ selected: [] });
+          cy.get('@validSpy').should('have.been.called');
+        });
+    });
+  });
+
   it('Emits "update:selected" when first selection is changed', () => {
     const readySpy = cy.spy().as('readySpy');
     const updateSpy = cy.spy().as('updateSpy');

--- a/components/EquipmentSelector/EquipmentSelector.vue
+++ b/components/EquipmentSelector/EquipmentSelector.vue
@@ -146,6 +146,10 @@ export default {
         this.selectedEquipment[i] = event;
       }
 
+      if (this.selectedEquipment.length == 0) {
+        this.valid[0] = !this.required;
+      }
+
       /**
        * The selected equipment has changed.
        * @property {Array<String>} event the names of the newly selected equipment.


### PR DESCRIPTION
**Pull Request Description**

Patches the EquipmentSelector and adds a test for the case when the component is required and the last piece of equipment is removed via a change to the prop.  The component now emits `valid` with a `false` payload in this circumstance.

Closes #328 

---

**Licensing Certification**

FarmData2 is a [Free Cultural Work](https://freedomdefined.org/Definition) and all accepted contributions are licensed as described in the LICENSE.md file. This requires that the contributor holds the rights to do so. By submitting this pull request **I certify that I satisfy the terms of the [Developer Certificate of Origin](https://developercertificate.org/)** for its contents.
