### PR TITLE
 Fix: Winterkill Component - Validity

### DIFF
--- a/components/WinterKill/WinterKill.vue
+++ b/components/WinterKill/WinterKill.vue
@@ -5,6 +5,7 @@
     label-for="winter-kill-checkbox"
     label-cols="auto"
     label-align="end"
+    :state="componentIsValid"
   >
     <template v-slot:label>
       <span data-cy="winter-kill-label">Winter kill:</span>
@@ -212,6 +213,9 @@ export default {
         );
         this.chosenDate = defaultDate;
         this.$emit('update:date', defaultDate);
+      } else if (!isChecked) {
+        this.chosenDate = '';
+        this.$emit('update:date', '');
       }
       this.emitValidState();
     },


### PR DESCRIPTION
**Pull Request Description**

This pull request addresses issue #335, which involves two main issues with the Winterkill component:
1. The validity becomes false when the checkbox is unchecked.
2. The component does not assign 'is-valid' or 'is-invalid' classes based on Vue's state attributes.

Closes #335
---

**Licensing Certification**

FarmData2 is a [Free Cultural Work](https://freedomdefined.org/Definition) and all accepted contributions are licensed as described in the LICENSE.md file. This requires that the contributor holds the rights to do so. By submitting this pull request **I certify that I satisfy the terms of the [Developer Certificate of Origin](https://developercertificate.org/)** for its contents.
