### PR TITLE
Changes required indicator and delete button behavior for EquipmentSelector and MultiCropSelector

### DIFF
--- a/components/EquipmentSelector/EquipmentSelector.content.comp.cy.js
+++ b/components/EquipmentSelector/EquipmentSelector.content.comp.cy.js
@@ -99,6 +99,62 @@ describe('Test the default EquipmentSelector content', () => {
       });
   });
 
+  it('Check required prop', () => {
+    const readySpy = cy.spy().as('readySpy');
+
+    cy.mount(EquipmentSelector, {
+      props: {
+        required: true,
+        onReady: readySpy,
+        selected: [],
+      },
+    });
+
+    cy.get('@readySpy')
+      .should('have.been.calledOnce')
+      .then(() => {
+        // no items => required and no delete
+        cy.get('[data-cy="equipment-selector-1"]')
+          .find('[data-cy="selector-delete-button"]')
+          .should('not.exist');
+        cy.get('[data-cy="equipment-selector-1"]')
+          .find('[data-cy="selector-required"]')
+          .should('exist');
+        // one item => required and no delete
+        cy.get('[data-cy="equipment-selector-1"]')
+          .find('[data-cy="selector-input"]')
+          .select('Tractor');
+        cy.get('[data-cy="equipment-selector-1"]')
+          .find('[data-cy="selector-delete-button"]')
+          .should('not.exist');
+        cy.get('[data-cy="equipment-selector-1"]')
+          .find('[data-cy="selector-required"]')
+          .should('exist');
+        cy.get('[data-cy="equipment-selector-2"]')
+          .find('[data-cy="selector-delete-button"]')
+          .should('not.exist');
+        cy.get('[data-cy="equipment-selector-2"]')
+          .find('[data-cy="selector-required"]')
+          .should('not.exist');
+        // two items => not required and delete
+        cy.get('[data-cy="equipment-selector-2"]')
+          .find('[data-cy="selector-input"]')
+          .select('Tractor');
+        cy.get('[data-cy="equipment-selector-1"]')
+          .find('[data-cy="selector-delete-button"]')
+          .should('exist');
+        cy.get('[data-cy="equipment-selector-1"]')
+          .find('[data-cy="selector-required"]')
+          .should('not.exist');
+        cy.get('[data-cy="equipment-selector-2"]')
+          .find('[data-cy="selector-delete-button"]')
+          .should('exist');
+        cy.get('[data-cy="equipment-selector-2"]')
+          .find('[data-cy="selector-required"]')
+          .should('not.exist');
+      });
+  });
+
   it('Check showValidityStyling prop', () => {
     const readySpy = cy.spy().as('readySpy');
 

--- a/components/EquipmentSelector/EquipmentSelector.vue
+++ b/components/EquipmentSelector/EquipmentSelector.vue
@@ -135,7 +135,7 @@ export default {
       }
     },
     isRequired(i) {
-      return this.required && (i == 0 || i < this.selectedEquipment.length - 1);
+      return this.required && i == 0 && this.selectedEquipment.length < 2;
     },
     handleUpdateSelected(event, i) {
       if (event === '') {

--- a/components/MultiCropSelector/MultiCropSelector.content.comp.cy.js
+++ b/components/MultiCropSelector/MultiCropSelector.content.comp.cy.js
@@ -99,6 +99,62 @@ describe('Test the default MultiCropSelector content', () => {
       });
   });
 
+  it('Check required prop', () => {
+    const readySpy = cy.spy().as('readySpy');
+
+    cy.mount(MultiCropSelector, {
+      props: {
+        required: true,
+        onReady: readySpy,
+        selected: [],
+      },
+    });
+
+    cy.get('@readySpy')
+      .should('have.been.calledOnce')
+      .then(() => {
+        // no items => required and no delete
+        cy.get('[data-cy="crop-selector-1"]')
+          .find('[data-cy="selector-delete-button"]')
+          .should('not.exist');
+        cy.get('[data-cy="crop-selector-1"]')
+          .find('[data-cy="selector-required"]')
+          .should('exist');
+        // one item => required and no delete
+        cy.get('[data-cy="crop-selector-1"]')
+          .find('[data-cy="selector-input"]')
+          .select('BROCCOLI');
+        cy.get('[data-cy="crop-selector-1"]')
+          .find('[data-cy="selector-delete-button"]')
+          .should('not.exist');
+        cy.get('[data-cy="crop-selector-1"]')
+          .find('[data-cy="selector-required"]')
+          .should('exist');
+        cy.get('[data-cy="crop-selector-2"]')
+          .find('[data-cy="selector-delete-button"]')
+          .should('not.exist');
+        cy.get('[data-cy="crop-selector-2"]')
+          .find('[data-cy="selector-required"]')
+          .should('not.exist');
+        // two items => not required and delete
+        cy.get('[data-cy="crop-selector-2"]')
+          .find('[data-cy="selector-input"]')
+          .select('BROCCOLI');
+        cy.get('[data-cy="crop-selector-1"]')
+          .find('[data-cy="selector-delete-button"]')
+          .should('exist');
+        cy.get('[data-cy="crop-selector-1"]')
+          .find('[data-cy="selector-required"]')
+          .should('not.exist');
+        cy.get('[data-cy="crop-selector-2"]')
+          .find('[data-cy="selector-delete-button"]')
+          .should('exist');
+        cy.get('[data-cy="crop-selector-2"]')
+          .find('[data-cy="selector-required"]')
+          .should('not.exist');
+      });
+  });
+
   it('Check showValidityStyling prop', () => {
     const readySpy = cy.spy().as('readySpy');
 

--- a/components/MultiCropSelector/MultiCropSelector.vue
+++ b/components/MultiCropSelector/MultiCropSelector.vue
@@ -157,7 +157,7 @@ export default {
     },
 
     isRequired(i) {
-      return this.required && (i == 0 || i < this.selectedCrops.length - 1);
+      return this.required && i == 0 && this.selectedCrops.length < 2;
     },
     handleUpdateSelected(event, i) {
       if (event === '') {


### PR DESCRIPTION
**Pull Request Description**

Adds the `includeDeleteButton` prop to `SelectorBase` to handle including both a delete button and the required `*`. 

Updates `MultiCropSelector` and `EquipmentSelector` so that when multiple items are selected, only the top item has `*` and all items have the delete button. With only one selected item, the top item has `*` but no delete button.

Additional testing for the 3 components have been added as well as an updated `SelectorBase` example page. 

closes #320 #319 

---

**Licensing Certification**

FarmData2 is a [Free Cultural Work](https://freedomdefined.org/Definition) and all accepted contributions are licensed as described in the LICENSE.md file. This requires that the contributor holds the rights to do so. By submitting this pull request **I certify that I satisfy the terms of the [Developer Certificate of Origin](https://developercertificate.org/)** for its contents.
