### PR TITLE
fix(dev): enhances the `runAlltests.bash` script

### DIFF
--- a/bin/runAllTests.bash
+++ b/bin/runAllTests.bash
@@ -1,10 +1,21 @@
 #!/bin/bash
 
-test.bash --comp
+TEST_COMMANDS=(
+  "test.bash --comp"
+  "test.bash --e2e --fd2 --live --glob=components/**/*.e2e.cy.js"
+  "test.bash --unit --lib"
+  "test.bash --unit --fd2"
+  "test.bash --e2e --fd2 --live"
+)
 
-# Temporary hack until test.bash is updated for these tests.
-test.bash --e2e --fd2 --live --glob=components/**/*.e2e.cy.js
+SED_SCRIPT="/Spec.*Tests/,/Tests Complete/p;/Running:/,/$/p;/failing/,/Results/p;"
+GREP_SCRIPT="^\s*$"
 
-test.bash --unit --lib
-test.bash --unit --fd2
-test.bash --e2e --fd2 --live
+for cmd in "${TEST_COMMANDS[@]}"; do
+  echo ""
+  echo "Running: $cmd"
+  echo ""
+  script -f -e -q -c "$cmd" /dev/null |
+    sed -u -n "$SED_SCRIPT" |
+    grep --line-buffered -v "$GREP_SCRIPT"
+done

--- a/bin/test.bash
+++ b/bin/test.bash
@@ -340,7 +340,8 @@ if [ -n "$CYPRESS_GUI" ]; then
   EXIT_CODE=$?
 else
   echo "Running tests headless."
-  npx cypress run --env "$CYPRESS_ENV" --"$CYPRESS_TEST_TYPE" --config-file "$CYPRESS_CONFIG_FILE"
+  #script -feqc "npx cypress run --env $CYPRESS_ENV --$CYPRESS_TEST_TYPE --config-file $CYPRESS_CONFIG_FILE" /dev/null
+  npx cypress run --env $CYPRESS_ENV --$CYPRESS_TEST_TYPE --config-file $CYPRESS_CONFIG_FILE
   EXIT_CODE=$?
 fi
 

--- a/bin/test.bash
+++ b/bin/test.bash
@@ -340,8 +340,7 @@ if [ -n "$CYPRESS_GUI" ]; then
   EXIT_CODE=$?
 else
   echo "Running tests headless."
-  #script -feqc "npx cypress run --env $CYPRESS_ENV --$CYPRESS_TEST_TYPE --config-file $CYPRESS_CONFIG_FILE" /dev/null
-  npx cypress run --env $CYPRESS_ENV --$CYPRESS_TEST_TYPE --config-file $CYPRESS_CONFIG_FILE
+  npx cypress run --env "$CYPRESS_ENV" --"$CYPRESS_TEST_TYPE" --config-file "$CYPRESS_CONFIG_FILE"
   EXIT_CODE=$?
 fi
 


### PR DESCRIPTION
**Pull Request Description**

Causes the script to only print:
- Each "Running ... (x of y)" line as it goes for status updates.
- Any failed test output.
- The results table at the end of each collection of tests.

Closes #108 

---

**Licensing Certification**

FarmData2 is a [Free Cultural Work](https://freedomdefined.org/Definition) and all accepted contributions are licensed as described in the LICENSE.md file. This requires that the contributor holds the rights to do so. By submitting this pull request **I certify that I satisfy the terms of the [Developer Certificate of Origin](https://developercertificate.org/)** for its contents.
