### PR TITLE
fix(test): patches winterkill test for added log type

### DIFF
--- a/modules/farm_fd2/src/entrypoints/cover_crop_seeding/lib.submit.unit.cy.js
+++ b/modules/farm_fd2/src/entrypoints/cover_crop_seeding/lib.submit.unit.cy.js
@@ -164,9 +164,12 @@ describe('Submission using the cover_crop lib.', () => {
       results.plantAsset.id
     );
 
-    expect(results.winterKillLog.relationships.category.length).to.equal(1);
+    expect(results.winterKillLog.relationships.category.length).to.equal(2);
     expect(results.winterKillLog.relationships.category[0].id).to.equal(
       categoryMap.get('termination').id
+    );
+    expect(results.winterKillLog.relationships.category[1].id).to.equal(
+      categoryMap.get('seeding_cover_crop').id
     );
 
     expect(results.winterKillLog.relationships.quantity).to.be.empty;


### PR DESCRIPTION
**Pull Request Description**

Patches this test to account for the addition of the `seeding_cover_crop` log type being added to the log.

---

**Licensing Certification**

FarmData2 is a [Free Cultural Work](https://freedomdefined.org/Definition) and all accepted contributions are licensed as described in the LICENSE.md file. This requires that the contributor holds the rights to do so. By submitting this pull request **I certify that I satisfy the terms of the [Developer Certificate of Origin](https://developercertificate.org/)** for its contents.
