### PR TITLE
fix(examples): fixes indentation error in .yml file

### DIFF
--- a/modules/farm_fd2_examples/src/module/farm_fd2_examples.routing.yml
+++ b/modules/farm_fd2_examples/src/module/farm_fd2_examples.routing.yml
@@ -94,7 +94,7 @@ farm.fd2_examples_text_display.content:
   defaults:
     _controller: '\Drupal\farm_fd2_examples\Controller\FD2_Controller::content'
     _title: 'TextDisplay Example'
-   requirements:
+  requirements:
     _permission: 'access content'
 farm.fd2_examples_equipment_selector.content:
   path: '/fd2_examples/equipment_selector'


### PR DESCRIPTION
**Pull Request Description**

Fixes an indentation error in the examples `routing` yml file that was introduced when resolving merge conflicts.

---

**Licensing Certification**

FarmData2 is a [Free Cultural Work](https://freedomdefined.org/Definition) and all accepted contributions are licensed as described in the LICENSE.md file. This requires that the contributor holds the rights to do so. By submitting this pull request **I certify that I satisfy the terms of the [Developer Certificate of Origin](https://developercertificate.org/)** for its contents.
