### PR TITLE
fix(dev):  does not require `--unit` flag when running `test.bash --lib` command

### DIFF
--- a/bin/test.bash
+++ b/bin/test.bash
@@ -11,6 +11,7 @@ function usage {
   echo "    -e|--e2e  : Run end-to-end tests."
   echo "    -c|--comp : Run component tests."
   echo "    -u|--unit : Run unit tests."
+  echo "    -b|--lib  : Run all unit tests in the library directory."
   echo ""
   echo "  -i|--gui  : Include to run tests within the Cypress GUI test runner."
   echo "              NOTE: if -i|--gui is used with -p|--prev or -l|--live then"

--- a/bin/test.bash
+++ b/bin/test.bash
@@ -126,6 +126,7 @@ while true; do
     ;;
   -b | --lib)
     TEST_LIB=1
+    UNIT_TESTS=1
     shift 2
     ;;
   -g | --glob)


### PR DESCRIPTION
**Pull Request Description**

The `test.bash` is modified so that `test.bash --lib` is a valid command that run all of the unit tests in the `library` directory (as `test.bash --lib --unit` does now`.

Closes #375 
---

**Licensing Certification**

FarmData2 is a [Free Cultural Work](https://freedomdefined.org/Definition) and all accepted contributions are licensed as described in the LICENSE.md file. This requires that the contributor holds the rights to do so. By submitting this pull request **I certify that I satisfy the terms of the [Developer Certificate of Origin](https://developercertificate.org/)** for its contents.
