### PR TITLE
fix(examples): add missing li end tag

### DIFF
--- a/modules/farm_fd2_examples/src/entrypoints/component_examples/App.vue
+++ b/modules/farm_fd2_examples/src/entrypoints/component_examples/App.vue
@@ -26,6 +26,7 @@
     <li>
       <a href="numeric_input">NumericInput</a>: A component for inputting a
       numerical value.
+    </li>
     <li>
       <a href="picker_base">PickerBase</a>: Base component for picking multiple
       items via checkboxes.


### PR DESCRIPTION
**Pull Request Description**

Adds a missing `</li>` tag to the components list of examples page.

---

**Licensing Certification**

FarmData2 is a [Free Cultural Work](https://freedomdefined.org/Definition) and all accepted contributions are licensed as described in the LICENSE.md file. This requires that the contributor holds the rights to do so. By submitting this pull request **I certify that I satisfy the terms of the [Developer Certificate of Origin](https://developercertificate.org/)** for its contents.
