### PR TITLE
NumericInput: Button Increment Rounding

### DIFF
--- a/components/NumericInput/NumericInput.behavior.comp.cy.js
+++ b/components/NumericInput/NumericInput.behavior.comp.cy.js
@@ -68,7 +68,7 @@ describe('Test the NumericInput component behavior', () => {
       props: {
         label: 'Test',
         invalidFeedbackText: 'Test feedback text',
-        value: 1,
+        value: 0,
         incDecValues: [1, 10, 100],
         onReady: readySpy,
       },
@@ -86,6 +86,138 @@ describe('Test the NumericInput component behavior', () => {
         cy.get('[data-cy="numeric-decrease-sm"]').should('not.be.disabled');
         cy.get('[data-cy="numeric-decrease-md"]').should('be.disabled');
         cy.get('[data-cy="numeric-decrease-lg"]').should('be.disabled');
+
+        cy.get('[data-cy="numeric-increase-md"]').click();
+
+        cy.get('[data-cy="numeric-decrease-sm"]').should('not.be.disabled');
+        cy.get('[data-cy="numeric-decrease-md"]').should('not.be.disabled');
+        cy.get('[data-cy="numeric-decrease-lg"]').should('be.disabled');
+
+        cy.get('[data-cy="numeric-increase-lg"]').click();
+
+        cy.get('[data-cy="numeric-decrease-sm"]').should('not.be.disabled');
+        cy.get('[data-cy="numeric-decrease-md"]').should('not.be.disabled');
+        cy.get('[data-cy="numeric-decrease-lg"]').should('not.be.disabled');
+      });
+  });
+
+  it('Test increase buttons are disabled', () => {
+    const readySpy = cy.spy().as('readySpy');
+
+    cy.mount(NumericInput, {
+      props: {
+        label: 'Test',
+        invalidFeedbackText: 'Test feedback text',
+        value: 1000,
+        incDecValues: [1, 10, 100],
+        onReady: readySpy,
+        maxValue: 1000,
+      },
+    });
+
+    cy.get('@readySpy')
+      .should('have.been.calledOnce')
+      .then(() => {
+        cy.get('[data-cy="numeric-increase-sm"]').should('be.disabled');
+        cy.get('[data-cy="numeric-increase-md"]').should('be.disabled');
+        cy.get('[data-cy="numeric-increase-lg"]').should('be.disabled');
+
+        cy.get('[data-cy="numeric-decrease-sm"]').click();
+
+        cy.get('[data-cy="numeric-increase-sm"]').should('not.be.disabled');
+        cy.get('[data-cy="numeric-increase-md"]').should('be.disabled');
+        cy.get('[data-cy="numeric-increase-lg"]').should('be.disabled');
+
+        cy.get('[data-cy="numeric-decrease-md"]').click();
+
+        cy.get('[data-cy="numeric-increase-sm"]').should('not.be.disabled');
+        cy.get('[data-cy="numeric-increase-md"]').should('not.be.disabled');
+        cy.get('[data-cy="numeric-increase-lg"]').should('be.disabled');
+
+        cy.get('[data-cy="numeric-decrease-lg"]').click();
+
+        cy.get('[data-cy="numeric-increase-sm"]').should('not.be.disabled');
+        cy.get('[data-cy="numeric-increase-md"]').should('not.be.disabled');
+        cy.get('[data-cy="numeric-increase-lg"]').should('not.be.disabled');
+      });
+  });
+
+  it('Input of a larger value replaces the initial value', () => {
+    const readySpy = cy.spy().as('readySpy');
+
+    cy.mount(NumericInput, {
+      props: {
+        label: 'Test',
+        invalidFeedbackText: 'Test feedback text',
+        value: 10,
+        incDecValues: [1, 10, 100],
+        onReady: readySpy,
+      },
+    });
+
+    cy.get('@readySpy')
+      .should('have.been.calledOnce')
+      .then(() => {
+        cy.get('[data-cy="numeric-increase-lg"]').click();
+        cy.get('[data-cy="numeric-input"]').should('have.value', '100');
+      });
+  });
+
+  it('Input of a larger value replaces the initial value', () => {
+    const readySpy = cy.spy().as('readySpy');
+
+    cy.mount(NumericInput, {
+      props: {
+        label: 'Test',
+        invalidFeedbackText: 'Test feedback text',
+        value: 10,
+        incDecValues: [1, 10, 100],
+        onReady: readySpy,
+      },
+    });
+
+    cy.get('@readySpy')
+      .should('have.been.calledOnce')
+      .then(() => {
+        cy.get('[data-cy="numeric-increase-sm"]').click();
+        cy.get('[data-cy="numeric-input"]').should('have.value', '11');
+      });
+  });
+
+  it('User type input disables buttons', () => {
+    const readySpy = cy.spy().as('readySpy');
+
+    cy.mount(NumericInput, {
+      props: {
+        label: 'Test',
+        invalidFeedbackText: 'Test feedback text',
+        value: 0,
+        incDecValues: [1, 10, 100],
+        onReady: readySpy,
+        maxValue: 100,
+      },
+    });
+
+    cy.get('@readySpy')
+      .should('have.been.calledOnce')
+      .then(() => {
+        cy.get('[data-cy="numeric-decrease-sm"]').should('be.disabled');
+        cy.get('[data-cy="numeric-decrease-md"]').should('be.disabled');
+        cy.get('[data-cy="numeric-decrease-lg"]').should('be.disabled');
+        cy.get('[data-cy="numeric-increase-sm"]').should('not.be.disabled');
+        cy.get('[data-cy="numeric-increase-md"]').should('not.be.disabled');
+        cy.get('[data-cy="numeric-increase-lg"]').should('not.be.disabled');
+
+        cy.get('[data-cy="numeric-input"]').clear();
+        cy.get('[data-cy="numeric-input"]').type('100');
+        cy.get('[data-cy="numeric-input"]').blur();
+
+        cy.get('[data-cy="numeric-decrease-sm"]').should('not.be.disabled');
+        cy.get('[data-cy="numeric-decrease-md"]').should('not.be.disabled');
+        cy.get('[data-cy="numeric-decrease-lg"]').should('not.be.disabled');
+        cy.get('[data-cy="numeric-increase-sm"]').should('be.disabled');
+        cy.get('[data-cy="numeric-increase-md"]').should('be.disabled');
+        cy.get('[data-cy="numeric-increase-lg"]').should('be.disabled');
       });
   });
 

--- a/components/NumericInput/NumericInput.behavior.comp.cy.js
+++ b/components/NumericInput/NumericInput.behavior.comp.cy.js
@@ -27,12 +27,12 @@ describe('Test the NumericInput component behavior', () => {
     cy.get('@readySpy')
       .should('have.been.calledOnce')
       .then(() => {
-        cy.get('[data-cy="numeric-increase-sm"]').click();
-        cy.get('[data-cy="numeric-input"]').should('have.value', '8');
-        cy.get('[data-cy="numeric-increase-md"]').click();
-        cy.get('[data-cy="numeric-input"]').should('have.value', '13');
         cy.get('[data-cy="numeric-increase-lg"]').click();
-        cy.get('[data-cy="numeric-input"]').should('have.value', '33');
+        cy.get('[data-cy="numeric-input"]').should('have.value', '20');
+        cy.get('[data-cy="numeric-increase-md"]').click();
+        cy.get('[data-cy="numeric-input"]').should('have.value', '25');
+        cy.get('[data-cy="numeric-increase-sm"]').click();
+        cy.get('[data-cy="numeric-input"]').should('have.value', '26');
       });
   });
 
@@ -58,6 +58,36 @@ describe('Test the NumericInput component behavior', () => {
         cy.get('[data-cy="numeric-input"]').should('have.value', '44');
         cy.get('[data-cy="numeric-decrease-lg"]').click();
         cy.get('[data-cy="numeric-input"]').should('have.value', '24');
+      });
+  });
+
+  it('Test decrease buttons are disabled', () => {
+    const readySpy = cy.spy().as('readySpy');
+
+    cy.mount(NumericInput, {
+      props: {
+        label: 'Test',
+        invalidFeedbackText: 'Test feedback text',
+        value: 1,
+        incDecValues: [1, 10, 100],
+        onReady: readySpy,
+      },
+    });
+
+    cy.get('@readySpy')
+      .should('have.been.calledOnce')
+      .then(() => {
+        cy.get('[data-cy="numeric-decrease-sm"]').should('be.disabled');
+        cy.get('[data-cy="numeric-decrease-md"]').should('be.disabled');
+        cy.get('[data-cy="numeric-decrease-lg"]').should('be.disabled');
+
+        cy.get('[data-cy="numeric-increase-sm"]').click();
+        cy.get('[data-cy="numeric-decrease-sm"]').should(
+          'have.class',
+          'disabled'
+        );
+        cy.get('[data-cy="numeric-decrease-md"]').should('be.disabled');
+        cy.get('[data-cy="numeric-decrease-lg"]').should('be.disabled');
       });
   });
 

--- a/components/NumericInput/NumericInput.behavior.comp.cy.js
+++ b/components/NumericInput/NumericInput.behavior.comp.cy.js
@@ -142,7 +142,7 @@ describe('Test the NumericInput component behavior', () => {
       });
   });
 
-  it('Input of a larger value replaces the initial value', () => {
+  it('Input of value larger than initial value replaces initial value', () => {
     const readySpy = cy.spy().as('readySpy');
 
     cy.mount(NumericInput, {
@@ -150,7 +150,7 @@ describe('Test the NumericInput component behavior', () => {
         label: 'Test',
         invalidFeedbackText: 'Test feedback text',
         value: 10,
-        incDecValues: [1, 10, 100],
+        incDecValues: [100],
         onReady: readySpy,
       },
     });
@@ -158,12 +158,12 @@ describe('Test the NumericInput component behavior', () => {
     cy.get('@readySpy')
       .should('have.been.calledOnce')
       .then(() => {
-        cy.get('[data-cy="numeric-increase-lg"]').click();
+        cy.get('[data-cy="numeric-increase-sm"]').click();
         cy.get('[data-cy="numeric-input"]').should('have.value', '100');
       });
   });
 
-  it('Input of a larger value replaces the initial value', () => {
+  it('Input of value smaller than initial value adds to initial value', () => {
     const readySpy = cy.spy().as('readySpy');
 
     cy.mount(NumericInput, {
@@ -171,7 +171,7 @@ describe('Test the NumericInput component behavior', () => {
         label: 'Test',
         invalidFeedbackText: 'Test feedback text',
         value: 10,
-        incDecValues: [1, 10, 100],
+        incDecValues: [1],
         onReady: readySpy,
       },
     });
@@ -184,7 +184,28 @@ describe('Test the NumericInput component behavior', () => {
       });
   });
 
-  it('User type input disables buttons', () => {
+  it('Input of value smaller than initial decimal value adds to initial value', () => {
+    const readySpy = cy.spy().as('readySpy');
+
+    cy.mount(NumericInput, {
+      props: {
+        label: 'Test',
+        invalidFeedbackText: 'Test feedback text',
+        value: 0.5,
+        incDecValues: [1],
+        onReady: readySpy,
+      },
+    });
+
+    cy.get('@readySpy')
+      .should('have.been.calledOnce')
+      .then(() => {
+        cy.get('[data-cy="numeric-increase-sm"]').click();
+        cy.get('[data-cy="numeric-input"]').should('have.value', '1');
+      });
+  });
+
+  it('User typed input disables buttons', () => {
     const readySpy = cy.spy().as('readySpy');
 
     cy.mount(NumericInput, {

--- a/components/NumericInput/NumericInput.behavior.comp.cy.js
+++ b/components/NumericInput/NumericInput.behavior.comp.cy.js
@@ -82,10 +82,8 @@ describe('Test the NumericInput component behavior', () => {
         cy.get('[data-cy="numeric-decrease-lg"]').should('be.disabled');
 
         cy.get('[data-cy="numeric-increase-sm"]').click();
-        cy.get('[data-cy="numeric-decrease-sm"]').should(
-          'have.class',
-          'disabled'
-        );
+
+        cy.get('[data-cy="numeric-decrease-sm"]').should('not.be.disabled');
         cy.get('[data-cy="numeric-decrease-md"]').should('be.disabled');
         cy.get('[data-cy="numeric-decrease-lg"]').should('be.disabled');
       });

--- a/components/NumericInput/NumericInput.vue
+++ b/components/NumericInput/NumericInput.vue
@@ -16,7 +16,7 @@
           >*</sup
         >
       </template>
-      <BInputGroup>
+      <BInputGroup class="has-validation">
         <BInputGroupPrepend>
           <BButton
             data-cy="numeric-decrease-lg"
@@ -69,7 +69,10 @@
           <BButton
             data-cy="numeric-increase-sm"
             v-if="showSmallIncDec"
-            variant="outline-success"
+            v-bind:variant="
+              disableLargeInc ? 'outline-secondary' : 'outline-success'
+            "
+            v-bind:disabled="disableLargeInc"
             size="sm"
             v-on:click="adjustValue(incDecValues[0])"
             >&#x203A;</BButton
@@ -77,7 +80,10 @@
           <BButton
             data-cy="numeric-increase-md"
             v-if="showMediumIncDec"
-            variant="outline-success"
+            v-bind:variant="
+              disableMediumInc ? 'outline-secondary' : 'outline-success'
+            "
+            v-bind:disabled="disableMediumInc"
             size="sm"
             v-on:click="adjustValue(incDecValues[1])"
             >&#x27E9;</BButton
@@ -85,7 +91,10 @@
           <BButton
             data-cy="numeric-increase-lg"
             v-if="showLargeIncDec"
-            variant="outline-success"
+            v-bind:variant="
+              disableSmallInc ? 'outline-secondary' : 'outline-success'
+            "
+            v-bind:disabled="disableSmallInc"
             size="sm"
             v-on:click="adjustValue(incDecValues[2])"
             >&#x27EB;</BButton
@@ -269,13 +278,22 @@ export default {
       return this.valueAsString == null || this.valueAsString.length == 0;
     },
     disableSmallDec() {
-      return this.numericValue - this.incDecValues[0] <= this.minValue;
+      return this.numericValue - this.incDecValues[0] < this.minValue;
     },
     disableMediumDec() {
-      return this.numericValue - this.incDecValues[1] <= this.minValue;
+      return this.numericValue - this.incDecValues[1] < this.minValue;
     },
     disableLargeDec() {
-      return this.numericValue - this.incDecValues[2] <= this.minValue;
+      return this.numericValue - this.incDecValues[2] < this.minValue;
+    },
+    disableSmallInc() {
+      return this.numericValue + this.incDecValues[2] > this.maxValue;
+    },
+    disableMediumInc() {
+      return this.numericValue + this.incDecValues[1] > this.maxValue;
+    },
+    disableLargeInc() {
+      return this.numericValue + this.incDecValues[0] > this.maxValue;
     },
     isValid() {
       if (!this.required) {
@@ -317,8 +335,6 @@ export default {
       } else {
         this.valueAsString = this.formatter(this.minValue);
       }
-
-      this.numericValue = parseFloat(this.valueAsString);
     },
     formatter(value) {
       let val = parseFloat(value);
@@ -372,6 +388,7 @@ export default {
        * @property {Number} value The new numeric value or NaN if the value is invalid.
        */
       this.$emit('update:value', parseFloat(this.valueAsString));
+      this.numericValue = parseFloat(this.valueAsString);
     },
   },
   created() {

--- a/components/NumericInput/NumericInput.vue
+++ b/components/NumericInput/NumericInput.vue
@@ -237,6 +237,7 @@ export default {
   data() {
     return {
       valueAsString: this.formatter(this.value.toString()),
+      numericValue: this.value,
       /*
        * Needed so when initial value is changed the updated value can be replaced or updated
        */
@@ -268,13 +269,13 @@ export default {
       return this.valueAsString == null || this.valueAsString.length == 0;
     },
     disableSmallDec() {
-      return this.value - this.incDecValues[0] <= this.minValue;
+      return this.numericValue - this.incDecValues[0] <= this.minValue;
     },
     disableMediumDec() {
-      return this.value - this.incDecValues[1] <= this.minValue;
+      return this.numericValue - this.incDecValues[1] <= this.minValue;
     },
     disableLargeDec() {
-      return this.value - this.incDecValues[2] <= this.minValue;
+      return this.numericValue - this.incDecValues[2] <= this.minValue;
     },
     isValid() {
       if (!this.required) {
@@ -316,6 +317,8 @@ export default {
       } else {
         this.valueAsString = this.formatter(this.minValue);
       }
+
+      this.numericValue = parseFloat(this.valueAsString);
     },
     formatter(value) {
       let val = parseFloat(value);

--- a/components/NumericInput/NumericInput.vue
+++ b/components/NumericInput/NumericInput.vue
@@ -16,7 +16,7 @@
           >*</sup
         >
       </template>
-      <BInputGroup class="has-validation">
+      <BInputGroup>
         <BInputGroupPrepend>
           <BButton
             data-cy="numeric-decrease-lg"

--- a/components/NumericInput/NumericInput.vue
+++ b/components/NumericInput/NumericInput.vue
@@ -63,6 +63,7 @@
           v-bind:state="validityStyling"
           v-bind:required="required"
           v-bind:formatter="formatter"
+          @update:model-value="valueChanged"
         />
         <BInputGroupAppend>
           <BButton
@@ -236,7 +237,10 @@ export default {
   data() {
     return {
       valueAsString: this.formatter(this.value.toString()),
-      defaultValueChanged: false,
+      /*
+       * Needed so when initial value is changed the updated value can be replaced or updated
+       */
+      initialValueChanged: false,
 
       /*
        * This value is used in the "Key-Changing Technique" to force the input to
@@ -300,18 +304,14 @@ export default {
   methods: {
     adjustValue(amount) {
       if (this.isValid) {
-        if (this.defaultValueChanged) {
-          this.valueAsString = this.formatter(
-            parseFloat(this.valueAsString) + amount
-          );
-        } else if (!this.defaultValueChanged && amount > this.value) {
+        if (!this.initialValueChanged && amount > this.value) {
           this.valueAsString = this.formatter(amount);
-          this.defaultValueChanged = true;
+          this.initialValueChanged = true;
         } else {
           this.valueAsString = this.formatter(
             parseFloat(this.valueAsString) + amount
           );
-          this.defaultValueChanged = true;
+          this.initialValueChanged = true;
         }
       } else {
         this.valueAsString = this.formatter(this.minValue);
@@ -342,6 +342,12 @@ export default {
       }, 5);
 
       return formattedVal;
+    },
+    valueChanged() {
+      /*
+       * Update the initialValueChanged data when the user manually enters a value.
+       */
+      this.initialValueChanged = true;
     },
   },
   watch: {

--- a/components/NumericInput/NumericInput.vue
+++ b/components/NumericInput/NumericInput.vue
@@ -323,7 +323,7 @@ export default {
   methods: {
     adjustValue(amount) {
       if (this.isValid) {
-        if (!this.initialValueChanged && amount > this.value) {
+        if (!this.initialValueChanged && amount > this.numericValue) {
           this.valueAsString = this.formatter(amount);
           this.initialValueChanged = true;
         } else {

--- a/components/NumericInput/NumericInput.vue
+++ b/components/NumericInput/NumericInput.vue
@@ -21,7 +21,10 @@
           <BButton
             data-cy="numeric-decrease-lg"
             v-if="showLargeIncDec"
-            variant="outline-success"
+            v-bind:variant="
+              disableLargeDec ? 'outline-secondary' : 'outline-success'
+            "
+            v-bind:disabled="disableLargeDec"
             size="sm"
             v-on:click="adjustValue(-incDecValues[2])"
             >&#x27EA;</BButton
@@ -29,7 +32,10 @@
           <BButton
             data-cy="numeric-decrease-md"
             v-if="showMediumIncDec"
-            variant="outline-success"
+            v-bind:variant="
+              disableMediumDec ? 'outline-secondary' : 'outline-success'
+            "
+            v-bind:disabled="disableMediumDec"
             size="sm"
             v-on:click="adjustValue(-incDecValues[1])"
             >&#x27E8;</BButton
@@ -37,7 +43,10 @@
           <BButton
             data-cy="numeric-decrease-sm"
             v-if="showSmallIncDec"
-            variant="outline-success"
+            v-bind:variant="
+              disableSmallDec ? 'outline-secondary' : 'outline-success'
+            "
+            v-bind:disabled="disableSmallDec"
             size="sm"
             v-on:click="adjustValue(-incDecValues[0])"
             >&#x2039;</BButton
@@ -227,6 +236,7 @@ export default {
   data() {
     return {
       valueAsString: this.formatter(this.value.toString()),
+      defaultValueChanged: false,
 
       /*
        * This value is used in the "Key-Changing Technique" to force the input to
@@ -252,6 +262,15 @@ export default {
     },
     isEmpty() {
       return this.valueAsString == null || this.valueAsString.length == 0;
+    },
+    disableSmallDec() {
+      return this.value - this.incDecValues[0] <= this.minValue;
+    },
+    disableMediumDec() {
+      return this.value - this.incDecValues[1] <= this.minValue;
+    },
+    disableLargeDec() {
+      return this.value - this.incDecValues[2] <= this.minValue;
     },
     isValid() {
       if (!this.required) {
@@ -281,9 +300,19 @@ export default {
   methods: {
     adjustValue(amount) {
       if (this.isValid) {
-        this.valueAsString = this.formatter(
-          parseFloat(this.valueAsString) + amount
-        );
+        if (this.defaultValueChanged) {
+          this.valueAsString = this.formatter(
+            parseFloat(this.valueAsString) + amount
+          );
+        } else if (!this.defaultValueChanged && amount > this.value) {
+          this.valueAsString = this.formatter(amount);
+          this.defaultValueChanged = true;
+        } else {
+          this.valueAsString = this.formatter(
+            parseFloat(this.valueAsString) + amount
+          );
+          this.defaultValueChanged = true;
+        }
       } else {
         this.valueAsString = this.formatter(this.minValue);
       }

--- a/components/NumericInput/NumericInput.vue
+++ b/components/NumericInput/NumericInput.vue
@@ -70,9 +70,9 @@
             data-cy="numeric-increase-sm"
             v-if="showSmallIncDec"
             v-bind:variant="
-              disableLargeInc ? 'outline-secondary' : 'outline-success'
+              disableSmallInc ? 'outline-secondary' : 'outline-success'
             "
-            v-bind:disabled="disableLargeInc"
+            v-bind:disabled="disableSmallInc"
             size="sm"
             v-on:click="adjustValue(incDecValues[0])"
             >&#x203A;</BButton
@@ -92,9 +92,9 @@
             data-cy="numeric-increase-lg"
             v-if="showLargeIncDec"
             v-bind:variant="
-              disableSmallInc ? 'outline-secondary' : 'outline-success'
+              disableLargeInc ? 'outline-secondary' : 'outline-success'
             "
-            v-bind:disabled="disableSmallInc"
+            v-bind:disabled="disableLargeInc"
             size="sm"
             v-on:click="adjustValue(incDecValues[2])"
             >&#x27EB;</BButton
@@ -287,13 +287,13 @@ export default {
       return this.numericValue - this.incDecValues[2] < this.minValue;
     },
     disableSmallInc() {
-      return this.numericValue + this.incDecValues[2] > this.maxValue;
+      return this.numericValue + this.incDecValues[0] > this.maxValue;
     },
     disableMediumInc() {
       return this.numericValue + this.incDecValues[1] > this.maxValue;
     },
     disableLargeInc() {
-      return this.numericValue + this.incDecValues[0] > this.maxValue;
+      return this.numericValue + this.incDecValues[2] > this.maxValue;
     },
     isValid() {
       if (!this.required) {

--- a/components/SoilDisturbance/SoilDisturbance.content.comp.cy.js
+++ b/components/SoilDisturbance/SoilDisturbance.content.comp.cy.js
@@ -278,10 +278,7 @@ describe('Test the default SoilDisturbance content', () => {
       .then(() => {
         cy.get('[data-cy="soil-disturbance-depth"]')
           .find('[data-cy="numeric-decrease-sm"]')
-          .click();
-        cy.get('[data-cy="soil-disturbance-depth"]')
-          .find('[data-cy="numeric-input"]')
-          .should('have.value', '0.0');
+          .should('be.disabled');
       });
   });
 
@@ -350,10 +347,7 @@ describe('Test the default SoilDisturbance content', () => {
       .then(() => {
         cy.get('[data-cy="soil-disturbance-speed"]')
           .find('[data-cy="numeric-decrease-sm"]')
-          .click();
-        cy.get('[data-cy="soil-disturbance-speed"]')
-          .find('[data-cy="numeric-input"]')
-          .should('have.value', '0.0');
+          .should('be.disabled');
       });
   });
 
@@ -427,10 +421,7 @@ describe('Test the default SoilDisturbance content', () => {
       .then(() => {
         cy.get('[data-cy="soil-disturbance-area"]')
           .find('[data-cy="numeric-increase-sm"]')
-          .click();
-        cy.get('[data-cy="soil-disturbance-area"]')
-          .find('[data-cy="numeric-input"]')
-          .should('have.value', '100');
+          .should('be.disabled');
 
         cy.get('[data-cy="soil-disturbance-area"]')
           .find('[data-cy="numeric-input"]')
@@ -441,10 +432,7 @@ describe('Test the default SoilDisturbance content', () => {
 
         cy.get('[data-cy="soil-disturbance-area"]')
           .find('[data-cy="numeric-decrease-sm"]')
-          .click();
-        cy.get('[data-cy="soil-disturbance-area"]')
-          .find('[data-cy="numeric-input"]')
-          .should('have.value', '1');
+          .should('be.disabled');
       });
   });
 
@@ -507,10 +495,7 @@ describe('Test the default SoilDisturbance content', () => {
       .then(() => {
         cy.get('[data-cy="soil-disturbance-passes"]')
           .find('[data-cy="numeric-decrease-sm"]')
-          .click();
-        cy.get('[data-cy="soil-disturbance-passes"]')
-          .find('[data-cy="numeric-input"]')
-          .should('have.value', '1');
+          .should('be.disabled');
       });
   });
 });

--- a/modules/farm_fd2/src/entrypoints/tray_seeding/tray_seeding.seeds.e2e.cy.js
+++ b/modules/farm_fd2/src/entrypoints/tray_seeding/tray_seeding.seeds.e2e.cy.js
@@ -65,10 +65,7 @@ describe('Tray Seeding: Seeds/Cell Component', () => {
   it('Seeds/Cell has correct minimum value.', () => {
     cy.get('[data-cy="tray-seeding-seeds"]')
       .find('[data-cy="numeric-decrease-sm"]')
-      .click();
-    cy.get('[data-cy="tray-seeding-seeds"]')
-      .find('[data-cy="numeric-input"]')
-      .should('have.value', '1');
+      .should('be.disabled');
   });
 
   it('Seeds/Cell validity styling works', () => {

--- a/modules/farm_fd2/src/entrypoints/tray_seeding/tray_seeding.trays.e2e.cy.js
+++ b/modules/farm_fd2/src/entrypoints/tray_seeding/tray_seeding.trays.e2e.cy.js
@@ -76,8 +76,14 @@ describe('Tray Seeding: Number of Trays Component', () => {
 
   it('Number of trays has correct minimum value.', () => {
     cy.get('[data-cy="tray-seeding-trays"]')
-      .find('[data-cy="numeric-decrease-sm"]')
-      .click();
+      .find('[data-cy="numeric-input"]')
+      .clear();
+    cy.get('[data-cy="tray-seeding-trays"]')
+      .find('[data-cy="numeric-input"]')
+      .type('0.005');
+    cy.get('[data-cy="tray-seeding-trays"]')
+      .find('[data-cy="numeric-input"]')
+      .blur();
     cy.get('[data-cy="tray-seeding-trays"]')
       .find('[data-cy="numeric-input"]')
       .should('have.value', '0.01');


### PR DESCRIPTION
**Pull Request Description**

Added:
- Form input now follows below rules to help users better understand the behavior:
```
If the component is in its initial state (i.e. has not been manually edited and no increment or decrement buttons have been clicked):
  If an increment button larger than the current value is clicked (e.g. value 60, click +100)
    The value is set to the next higher value of that increment (e.g. value -> 100).
  otherwise (e.g. value 60, click +10)
    The value is incremented based on the button that is clicked. (e.g. value -> 70)
otherwise
  The value is incremented or decremented based on the button clicked.
```
- Button disabling and styling when decrementing the input will drop it below the min value. 
- The input form now has `initialValueChanged` data, indicating when the user has first interacted with the form input.

Closes #204 

---

**Licensing Certification**

FarmData2 is a [Free Cultural Work](https://freedomdefined.org/Definition) and all accepted contributions are licensed as described in the LICENSE.md file. This requires that the contributor holds the rights to do so. By submitting this pull request **I certify
/ that I satisfy the terms of the [Developer Certificate of Origin](https://developercertificate.org/)** for its contents.
