### PR TITLE
fix(comp): prevents duplicate equipment selection in EquipmentSelector

### DIFF
--- a/components/EquipmentSelector/EquipmentSelector.vue
+++ b/components/EquipmentSelector/EquipmentSelector.vue
@@ -8,6 +8,7 @@
       v-bind:showValidityStyling="showValidityStyling"
       v-bind:options="equipmentList"
       v-bind:selected="selected"
+      v-bind:noRepeat="true"
       v-on:update:selected="handleUpdateSelected()"
       v-on:add-clicked="handleAddClicked($event)"
       v-on:valid="handleValid($event)"

--- a/components/MultiSelectorBase/MultiSelectorBase.behavior.comp.cy.js
+++ b/components/MultiSelectorBase/MultiSelectorBase.behavior.comp.cy.js
@@ -192,4 +192,239 @@ describe('Test the MultiSelectorBase component behavior', () => {
         cy.get('[data-cy="selector-4"]').should('not.exist');
       });
   });
+
+  it('Selecting an option removes it from available options in subsequent selectors', () => {
+    const readySpy = cy.spy().as('readySpy');
+
+    cy.mount(MultiSelectorBase, {
+      props: {
+        onReady: readySpy,
+        options: ['one', 'two', 'three', 'four', 'five'],
+        noRepeat: true,
+      },
+    });
+
+    cy.get('@readySpy')
+      .should('have.been.calledOnce')
+      .then(() => {
+        // Select "one" in the first selector
+        cy.get('[data-cy="selector-1"]')
+          .find('[data-cy="selector-input"]')
+          .select('one');
+
+        // Verify that "one" is not available in the second selector
+        cy.get('[data-cy="selector-2"]')
+          .find('[data-cy="selector-input"]')
+          .children('option')
+          .should('not.contain', 'one');
+      });
+  });
+
+  it('Removing a selected option restores it to available options in subsequent selectors', () => {
+    const readySpy = cy.spy().as('readySpy');
+
+    cy.mount(MultiSelectorBase, {
+      props: {
+        onReady: readySpy,
+        selected: ['one', 'two'],
+        options: ['one', 'two', 'three', 'four', 'five'],
+        noRepeat: true,
+      },
+    });
+
+    cy.get('@readySpy')
+      .should('have.been.calledOnce')
+      .then(() => {
+        // Verify initial selections
+        cy.get('[data-cy="selector-1"]')
+          .find('[data-cy="selector-input"]')
+          .should('have.value', 'one');
+        cy.get('[data-cy="selector-2"]')
+          .find('[data-cy="selector-input"]')
+          .should('have.value', 'two');
+
+        // Delete the first selection
+        cy.get('[data-cy="selector-1"]')
+          .find('[data-cy="selector-delete-button"]')
+          .click();
+
+        // Verify that "one" is now available in the second selector
+        cy.get('[data-cy="selector-2"]')
+          .find('[data-cy="selector-input"]')
+          .children('option')
+          .should('contain', 'one');
+      });
+  });
+
+  it('Selecting multiple options reduces available options incrementally', () => {
+    const readySpy = cy.spy().as('readySpy');
+
+    cy.mount(MultiSelectorBase, {
+      props: {
+        onReady: readySpy,
+        options: ['one', 'two', 'three', 'four', 'five'],
+        noRepeat: true,
+      },
+    });
+
+    cy.get('@readySpy')
+      .should('have.been.calledOnce')
+      .then(() => {
+        // Select "one" in the first selector
+        cy.get('[data-cy="selector-1"]')
+          .find('[data-cy="selector-input"]')
+          .select('one');
+
+        // Select "two" in the second selector
+        cy.get('[data-cy="selector-2"]')
+          .find('[data-cy="selector-input"]')
+          .select('two');
+
+        // Verify that "one" and "two" are not available in the third selector
+        cy.get('[data-cy="selector-3"]')
+          .find('[data-cy="selector-input"]')
+          .children('option')
+          .should('not.contain', 'one')
+          .and('not.contain', 'two');
+      });
+  });
+
+  it('Deleting a middle selection restores it in subsequent selectors', () => {
+    const readySpy = cy.spy().as('readySpy');
+
+    cy.mount(MultiSelectorBase, {
+      props: {
+        onReady: readySpy,
+        selected: ['one', 'two', 'three'],
+        options: ['one', 'two', 'three', 'four', 'five'],
+        noRepeat: true,
+      },
+    });
+
+    cy.get('@readySpy')
+      .should('have.been.calledOnce')
+      .then(() => {
+        // Delete the middle selection ("two")
+        cy.get('[data-cy="selector-2"]')
+          .find('[data-cy="selector-delete-button"]')
+          .click();
+
+        // Verify that "two" is now available in the third selector
+        cy.get('[data-cy="selector-3"]')
+          .find('[data-cy="selector-input"]')
+          .children('option')
+          .should('contain', 'two');
+      });
+  });
+
+  it('Adding a new selection removes it from subsequent selectors when noRepeat is true', () => {
+    const readySpy = cy.spy().as('readySpy');
+
+    cy.mount(MultiSelectorBase, {
+      props: {
+        onReady: readySpy,
+        selected: [],
+        options: ['one', 'two', 'three', 'four', 'five'],
+        noRepeat: true, // Enable noRepeat
+      },
+    });
+
+    cy.get('@readySpy')
+      .should('have.been.calledOnce')
+      .then(() => {
+        // Initially select "one" in the first selector
+        cy.get('[data-cy="selector-1"]')
+          .find('[data-cy="selector-input"]')
+          .select('one');
+
+        // Verify that "one" is not available in the second selector
+        cy.get('[data-cy="selector-2"]')
+          .find('[data-cy="selector-input"]')
+          .children('option')
+          .should('not.contain', 'one');
+
+        // Select "two" in the second selector
+        cy.get('[data-cy="selector-2"]')
+          .find('[data-cy="selector-input"]')
+          .select('two');
+
+        // Verify that "one" and "two" are not available in the third selector
+        cy.get('[data-cy="selector-3"]')
+          .find('[data-cy="selector-input"]')
+          .children('option')
+          .should('not.contain', 'one')
+          .and('not.contain', 'two');
+      });
+  });
+
+  it('Selecting all options until none are left, then removing all to restore full options list', () => {
+    const readySpy = cy.spy().as('readySpy');
+
+    cy.mount(MultiSelectorBase, {
+      props: {
+        onReady: readySpy,
+        options: ['one', 'two', 'three', 'four', 'five'],
+        noRepeat: true,
+      },
+    });
+
+    cy.get('@readySpy')
+      .should('have.been.calledOnce')
+      .then(() => {
+        // Select all options one by one until no options are left
+        cy.get('[data-cy="selector-1"]')
+          .find('[data-cy="selector-input"]')
+          .select('one');
+
+        cy.get('[data-cy="selector-2"]')
+          .find('[data-cy="selector-input"]')
+          .select('two');
+
+        cy.get('[data-cy="selector-3"]')
+          .find('[data-cy="selector-input"]')
+          .select('three');
+
+        cy.get('[data-cy="selector-4"]')
+          .find('[data-cy="selector-input"]')
+          .select('four');
+
+        cy.get('[data-cy="selector-5"]')
+          .find('[data-cy="selector-input"]')
+          .select('five');
+
+        // Verify no new selector is added because all options are selected
+        cy.get('[data-cy="selector-6"]').should('not.exist');
+
+        // Remove all selections one by one
+        cy.get('[data-cy="selector-5"]')
+          .find('[data-cy="selector-delete-button"]')
+          .click();
+
+        cy.get('[data-cy="selector-4"]')
+          .find('[data-cy="selector-delete-button"]')
+          .click();
+
+        cy.get('[data-cy="selector-3"]')
+          .find('[data-cy="selector-delete-button"]')
+          .click();
+
+        cy.get('[data-cy="selector-2"]')
+          .find('[data-cy="selector-delete-button"]')
+          .click();
+
+        cy.get('[data-cy="selector-1"]')
+          .find('[data-cy="selector-delete-button"]')
+          .click();
+
+        // Verify that all options are restored and available in the first selector
+        cy.get('[data-cy="selector-1"]')
+          .find('[data-cy="selector-input"]')
+          .children('option')
+          .should('contain', 'one')
+          .and('contain', 'two')
+          .and('contain', 'three')
+          .and('contain', 'four')
+          .and('contain', 'five');
+      });
+  });
 });

--- a/components/MultiSelectorBase/MultiSelectorBase.vue
+++ b/components/MultiSelectorBase/MultiSelectorBase.vue
@@ -44,6 +44,7 @@ import SelectorBase from '@comps/SelectorBase/SelectorBase.vue';
     v-bind:selected="form.selected"
     v-bind:options="options"
     v-bind:popupUrl="popupUrl"
+    b-bind:noRepeat="noRepeat"
     v-on:valid="
       (valid) => {
         validity.selected = valid;

--- a/components/MultiSelectorBase/MultiSelectorBase.vue
+++ b/components/MultiSelectorBase/MultiSelectorBase.vue
@@ -7,7 +7,7 @@
       v-bind:data-cy="'selector-' + (i + 1)"
       v-bind:invalidFeedbackText="invalidFeedbackText"
       v-bind:label="String(i + 1)"
-      v-bind:options="options"
+      v-bind:options="getFilteredOptions(i)"
       v-bind:required="isRequired(i)"
       v-bind:selected="selected[i]"
       v-bind:showValidityStyling="showValidityStyling"
@@ -116,6 +116,13 @@ export default {
       type: String,
       default: null,
     },
+    /**
+     * Whether duplicate selections are allowed.
+     */
+    noRepeat: {
+      type: Boolean,
+      default: false,
+    },
   },
   data() {
     return {
@@ -135,6 +142,17 @@ export default {
     },
     isRequired(i) {
       return this.required && i === 0 && this.selectedItems.length < 2;
+    },
+    getFilteredOptions(index) {
+      // Filter options if noRepeat is true
+      if (this.noRepeat) {
+        return this.options.filter(
+          (item) =>
+            !this.selectedItems.includes(item) ||
+            this.selectedItems[index] === item
+        );
+      }
+      return this.options;
     },
     handleAddClicked(event) {
       /**

--- a/modules/farm_fd2_examples/src/entrypoints/multi_selector_base/App.vue
+++ b/modules/farm_fd2_examples/src/entrypoints/multi_selector_base/App.vue
@@ -15,6 +15,7 @@
     v-bind:selected="form.selected"
     v-bind:options="options"
     v-bind:popupUrl="popupUrl"
+    v-bind:noRepeat="noRepeat"
     v-on:valid="
       (valid) => {
         validity.selected = valid;
@@ -53,6 +54,17 @@
             data-cy="styling-checkbox"
             switch
             v-model="validity.showStyling"
+          />
+        </td>
+      </tr>
+      <tr>
+        <td>noRepeat</td>
+        <td>
+          <BFormCheckbox
+            id="no-repeat-checkbox"
+            data-cy="no-repeat-checkbox"
+            switch
+            v-model="noRepeat"
           />
         </td>
       </tr>
@@ -158,6 +170,7 @@ export default {
   data() {
     return {
       required: true,
+      noRepeat: false,
       form: {
         selected: [],
       },


### PR DESCRIPTION
### Pull Request Description

This pull request fixes issue #164 by preventing duplicate selections in the `EquipmentSelector` component. Rather than directly modifying `EquipmentSelector`, I updated the `MultiSelectorBase` component, which manages the dropdown behavior for multiple selections within `EquipmentSelector`.

#### Changes Made
1. **Added a `noRepeat` Prop**:
   - I added a `noRepeat` prop to `MultiSelectorBase`, set to `false` by default so it doesn’t interfere with other components using `MultiSelectorBase`. When `noRepeat` is set to `true`, the dropdowns automatically filter out any items that have already been selected, ensuring each item can only be chosen once.
   - In `EquipmentSelector`, I enabled this feature by setting `v-bind:noRepeat="true"`, with no further changes needed in `EquipmentSelector`.

2. **Updated the Dropdown Filtering Logic**:
   - I created a new method, `getFilteredOptions`, in `MultiSelectorBase` to handle filtering when `noRepeat` is enabled. This method updates each dropdown to hide items already selected, allowing only unique selections across dropdowns.

3. **Added Behavior Tests in `MultiSelectorBase.behaviour.comp.cy.js`**:
   - I added new behavior tests to `MultiSelectorBase.behaviour.comp.cy.js` to verify that `noRepeat` works as expected. These tests check that selected items are removed from the available options in subsequent dropdowns and reappear when deselected, confirming that the `noRepeat` functionality works smoothly.

#### Why I Updated `MultiSelectorBase`
The issue #164 suggested modifying `EquipmentSelector`, but since `MultiSelectorBase` controls the dropdowns, adding `noRepeat` there made the solution simpler and more flexible.

Closes #164 

---

**Licensing Certification**

FarmData2 is a [Free Cultural Work](https://freedomdefined.org/Definition) and all accepted contributions are licensed as described in the LICENSE.md file. This requires that the contributor holds the rights to do so. By submitting this pull request **I certify that I satisfy the terms of the [Developer Certificate of Origin](https://developercertificate.org/)** for its contents.
