### PR TITLE
fix(fd2): modifies LocationSelector "+" button

### DIFF
--- a/components/LocationSelector/LocationSelector.directSeeding.e2e.cy.js
+++ b/components/LocationSelector/LocationSelector.directSeeding.e2e.cy.js
@@ -1,0 +1,88 @@
+describe('LocationSelector popup test on direct_seeding page', () => {
+  beforeEach(() => {
+    cy.restoreLocalStorage();
+    cy.restoreSessionStorage();
+
+    cy.login('admin', 'admin');
+    cy.visit('/fd2/direct_seeding/');
+    cy.waitForPage();
+  });
+
+  afterEach(() => {
+    cy.saveLocalStorage();
+    cy.saveSessionStorage();
+  });
+
+  it('Form selects new location for Direct Seeding - Bed with Parent ALF', () => {
+    cy.get('[data-cy="direct-seeding-location"]')
+      .find('[data-cy="selector-add-button"]')
+      .click();
+
+    cy.get('[data-cy="selector-popupIframe"]', { timeout: 10000 })
+      .should('be.visible')
+      .its('0.contentDocument.body', { timeout: 10000 })
+      .should('not.be.empty')
+      .then(cy.wrap)
+      .as('iframeBody');
+
+    cy.get('@iframeBody')
+      .find('[id="edit-name-0-value"]', { timeout: 10000 })
+      .should('be.visible')
+      .type('NewLocationForDirectSeeding_Bed');
+
+    cy.get('@iframeBody').find('[id="edit-land-type-bed"]').check();
+
+    cy.get('@iframeBody')
+      .find('[id="edit-parent-0-target-id"]')
+      .should('be.visible')
+      .type('alf');
+
+    cy.get('@iframeBody')
+      .find('.ui-menu .ui-menu-item a')
+      .contains('ALF')
+      .click();
+
+    cy.get('@iframeBody')
+      .find('[id="edit-submit"]', { timeout: 10000 })
+      .should('be.visible') // Ensure the submit button is visible
+      .click();
+
+    cy.get('[data-cy="direct-seeding-location"]')
+      .find('[data-cy="selector-input"]')
+      .select('ALF');
+
+    cy.get('[data-cy="location-bed-picker"]')
+      .find('[data-cy="picker-options"]')
+      .contains('NewLocationForDirectSeeding_Bed')
+      .should('exist');
+  });
+
+  it('Form selects new location for Direct Seeding - Field', () => {
+    cy.get('[data-cy="direct-seeding-location"]')
+      .find('[data-cy="selector-add-button"]')
+      .click();
+
+    cy.get('[data-cy="selector-popupIframe"]', { timeout: 10000 })
+      .should('be.visible')
+      .its('0.contentDocument.body', { timeout: 10000 })
+      .should('not.be.empty')
+      .then(cy.wrap)
+      .as('iframeBody');
+
+    cy.get('@iframeBody')
+      .find('[id="edit-name-0-value"]', { timeout: 10000 })
+      .should('be.visible')
+      .type('NewLocationForDirectSeeding_Field');
+
+    cy.get('@iframeBody').find('[id="edit-land-type-field"]').check();
+
+    cy.get('@iframeBody')
+      .find('[id="edit-submit"]', { timeout: 10000 })
+      .should('be.visible')
+      .click();
+
+    cy.get('[data-cy="direct-seeding-location"]')
+      .find('[data-cy="selector-input"]', { timeout: 10000 })
+      .should('have.value', 'NewLocationForDirectSeeding_Field');
+  });
+});

--- a/components/LocationSelector/LocationSelector.traySeeding.e2e.cy.js
+++ b/components/LocationSelector/LocationSelector.traySeeding.e2e.cy.js
@@ -13,7 +13,7 @@ describe('LocationSelector popup test', () => {
     cy.saveSessionStorage();
   });
 
-  it('Form selects new location', () => {
+  it('Form selects new location for Tray Seeding', () => {
     cy.get('[data-cy="tray-seeding-location"]')
       .find('[data-cy="selector-add-button"]')
       .click();
@@ -27,14 +27,14 @@ describe('LocationSelector popup test', () => {
 
     cy.get('@iframeBody')
       .find('[id="edit-name-0-value"]', { timeout: 10000 })
-      .should('be.visible') // Ensure the input field is visible
+      .should('be.visible')
       .type('NewLocation');
 
     cy.get('@iframeBody').find('[id="edit-structure-type-greenhouse"]').check();
 
     cy.get('@iframeBody')
       .find('[id="edit-submit"]', { timeout: 10000 })
-      .should('be.visible') // Ensure the submit button is visible
+      .should('be.visible')
       .click();
 
     cy.get('[data-cy="tray-seeding-location"]')

--- a/components/LocationSelector/LocationSelector.vue
+++ b/components/LocationSelector/LocationSelector.vue
@@ -296,6 +296,19 @@ export default {
     },
   },
   methods: {
+    setPopupUrl() {
+      if (
+        (this.includeGreenhouses || this.includeGreenhousesWithBeds) &&
+        !this.includeFields &&
+        this.canCreateStructure
+      ) {
+        this.popupUrl = '/asset/add/structure';
+      } else if (this.includeFields && this.canCreateLand) {
+        this.popupUrl = '/asset/add/land';
+      } else {
+        this.popupUrl = null;
+      }
+    },
     handleUpdateBeds(event) {
       this.checkedBeds = event;
 
@@ -386,6 +399,9 @@ export default {
     },
   },
   watch: {
+    includeFields: 'setPopupUrl',
+    includeGreenhouses: 'setPopupUrl',
+    includeGreenhousesWithBeds: 'setPopupUrl',
     selectedBeds() {
       this.checkedBeds = this.selectedBeds;
     },
@@ -433,21 +449,7 @@ export default {
         this.bedObjs = beds;
         this.canCreateLand = createLand;
         this.canCreateStructure = createStructure;
-        if (
-          this.includeFields &&
-          (this.includeGreenhouses || this.includeGreenhousesWithBeds) &&
-          this.canCreateLand &&
-          this.canCreateStructure
-        ) {
-          this.popupUrl = '/asset/add';
-        } else if (this.includeFields && this.canCreateLand) {
-          this.popupUrl = '/asset/add/land';
-        } else if (
-          (this.includeGreenhouses || this.includeGreenhousesWithBeds) &&
-          this.canCreateStructure
-        ) {
-          this.popupUrl = '/asset/add/structure';
-        }
+        this.setPopupUrl();
 
         /**
          * The select has been populated with the list of locations and the component is ready to be used.

--- a/components/LocationSelector/LocationSelector.vue
+++ b/components/LocationSelector/LocationSelector.vue
@@ -113,15 +113,25 @@ export default {
     },
     /**
      * Whether to include all greenhouses in the list of locations.
+     * If set to `true`, all greenhouses will be added to the location options,
+     * regardless of whether they contain beds or not.
      */
     includeGreenhouses: {
       type: Boolean,
       default: false,
     },
     /**
-     * Whether to include only greenhouses with beds in the list of locations.
-     * If `includeGreenhouses` is also true, then all greenhouses will be included
-     * even if this property is true.
+     * Whether to include only greenhouses that contain beds in the list of locations.
+     * Note: If `includeGreenhouses` is also set to `true`, all greenhouses will be
+     * included, overriding this setting.
+     *
+     * For example:
+     * - If `includeGreenhouses` is `true` and `includeGreenhousesWithBeds` is `false`,
+     *   all greenhouses will be included.
+     * - If both `includeGreenhouses` and `includeGreenhousesWithBeds` are `true`,
+     *   all greenhouses (both with and without beds) will be included.
+     * - If `includeGreenhouses` is `false` and `includeGreenhousesWithBeds` is `true`,
+     *   only greenhouses that have beds will be included.
      */
     includeGreenhousesWithBeds: {
       type: Boolean,
@@ -207,10 +217,22 @@ export default {
       bedObjs: [],
       canCreateLand: false,
       canCreateStructure: false,
-      popupUrl: null,
     };
   },
   computed: {
+    popupUrl() {
+      if (
+        (this.includeGreenhouses || this.includeGreenhousesWithBeds) &&
+        !this.includeFields &&
+        this.canCreateStructure
+      ) {
+        return '/asset/add/structure';
+      } else if (this.includeFields && this.canCreateLand) {
+        return '/asset/add/land';
+      } else {
+        return null;
+      }
+    },
     canCreateLocation() {
       return (
         (this.includeFields && this.canCreateLand) ||
@@ -296,19 +318,6 @@ export default {
     },
   },
   methods: {
-    setPopupUrl() {
-      if (
-        (this.includeGreenhouses || this.includeGreenhousesWithBeds) &&
-        !this.includeFields &&
-        this.canCreateStructure
-      ) {
-        this.popupUrl = '/asset/add/structure';
-      } else if (this.includeFields && this.canCreateLand) {
-        this.popupUrl = '/asset/add/land';
-      } else {
-        this.popupUrl = null;
-      }
-    },
     handleUpdateBeds(event) {
       this.checkedBeds = event;
 
@@ -399,9 +408,6 @@ export default {
     },
   },
   watch: {
-    includeFields: 'setPopupUrl',
-    includeGreenhouses: 'setPopupUrl',
-    includeGreenhousesWithBeds: 'setPopupUrl',
     selectedBeds() {
       this.checkedBeds = this.selectedBeds;
     },
@@ -449,7 +455,6 @@ export default {
         this.bedObjs = beds;
         this.canCreateLand = createLand;
         this.canCreateStructure = createStructure;
-        this.setPopupUrl();
 
         /**
          * The select has been populated with the list of locations and the component is ready to be used.

--- a/components/LocationSelector/LocationSelector.vue
+++ b/components/LocationSelector/LocationSelector.vue
@@ -127,11 +127,11 @@ export default {
      *
      * For example:
      * - If `includeGreenhouses` is `true` and `includeGreenhousesWithBeds` is `false`,
-     *   all greenhouses will be included.
+     *   all greenhouses, (both with and without beds), will be included.
      * - If both `includeGreenhouses` and `includeGreenhousesWithBeds` are `true`,
      *   all greenhouses (both with and without beds) will be included.
      * - If `includeGreenhouses` is `false` and `includeGreenhousesWithBeds` is `true`,
-     *   only greenhouses that have beds will be included.
+     *   only greenhouses with beds will be included.
      */
     includeGreenhousesWithBeds: {
       type: Boolean,


### PR DESCRIPTION
**Pull Request Description**

This PR updates the `LocationSelector` component by improving the "+" button logic, expanding documentation, and adding e2e tests. The button’s URL is now a computed property, adapting based on props and user permissions for asset creation. Here’s what’s changed:

- **Updated "+" Button Logic**:
  - When fields are included and land creation is allowed, the button links to the land asset form.
  - If only greenhouses are included and structure creation is permitted, it links to the structure asset form.

- **Clearer Documentation**: Expanded documentation now better explains the `includeGreenhouses` and `includeGreenhousesWithBeds` props, outlining how each affects dropdown options and URL behavior.

- **End-to-End Tests**: Added tests validate that the `LocationSelector` works as expected across pages:
  - Confirming that the "+" button links to the correct asset form depending on the page context.
  - Allowing fields, greenhouses, or beds to be added based on the scenario, such as adding a field or bed in direct seeding and adding greenhouses in tray seeding.

Closes #376 

---

**Licensing Certification**

FarmData2 is a [Free Cultural Work](https://freedomdefined.org/Definition) and all accepted contributions are licensed as described in the LICENSE.md file. This requires that the contributor holds the rights to do so. By submitting this pull request **I certify that I satisfy the terms of the [Developer Certificate of Origin](https://developercertificate.org/)** for its contents.
