### PR TITLE
fix(examples): fixes mixed type sorting in PickListBase

### DIFF
--- a/components/PicklistBase/PicklistBase.behavior.comp.cy.js
+++ b/components/PicklistBase/PicklistBase.behavior.comp.cy.js
@@ -61,7 +61,98 @@ describe('Test the PicklistBase component behavior', () => {
     cy.get('[data-cy="picklist-quantity-1"]').should('have.value', '0');
   });
 
-  it('sorts rows correctly and updates picked rows and quantities', () => {
+  it('sorts alphabetical data correctly', () => {
+    cy.mount(PicklistBase, {
+      props: {
+        rows: [
+          { name: 'Item B', quantity: 2, location: 'GHANA' },
+          { name: 'Item A', quantity: 4, location: 'GHANA' },
+          { name: 'Item C', quantity: 6, location: 'GHANA' },
+        ],
+        columns: ['name', 'quantity', 'location'],
+        labels: { name: 'Name', quantity: 'Quantity', location: 'Location' },
+      },
+    });
+
+    cy.get('[data-cy="picklist-sort-button-name"]').click();
+    cy.get('[data-cy="picklist-name-0"]').should('have.text', 'Item A');
+    cy.get('[data-cy="picklist-name-1"]').should('have.text', 'Item B');
+    cy.get('[data-cy="picklist-name-2"]').should('have.text', 'Item C');
+
+    cy.get('[data-cy="picklist-sort-button-name"]').click();
+    cy.get('[data-cy="picklist-name-0"]').should('have.text', 'Item C');
+    cy.get('[data-cy="picklist-name-1"]').should('have.text', 'Item B');
+    cy.get('[data-cy="picklist-name-2"]').should('have.text', 'Item A');
+
+    cy.get('[data-cy="picklist-sort-button-name"]').click();
+    cy.get('[data-cy="picklist-name-0"]').should('have.text', 'Item A');
+    cy.get('[data-cy="picklist-name-1"]').should('have.text', 'Item B');
+    cy.get('[data-cy="picklist-name-2"]').should('have.text', 'Item C');
+  });
+
+  it('sorts numeric data correctly', () => {
+    cy.mount(PicklistBase, {
+      props: {
+        rows: [
+          { name: 'Item B', quantity: 2, location: 'GHANA' },
+          { name: 'Item A', quantity: 10, location: 'GHANA' },
+          { name: 'Item C', quantity: 3, location: 'GHANA' },
+        ],
+        columns: ['name', 'quantity', 'location'],
+        labels: { name: 'Name', quantity: 'Quantity', location: 'Location' },
+      },
+    });
+
+    cy.get('[data-cy="picklist-sort-button-quantity"]').click();
+    cy.get('[data-cy="picklist-quantity-0"]').should('have.text', '2');
+    cy.get('[data-cy="picklist-quantity-1"]').should('have.text', '3');
+    cy.get('[data-cy="picklist-quantity-2"]').should('have.text', '10');
+
+    cy.get('[data-cy="picklist-sort-button-quantity"]').click();
+    cy.get('[data-cy="picklist-quantity-0"]').should('have.text', '10');
+    cy.get('[data-cy="picklist-quantity-1"]').should('have.text', '3');
+    cy.get('[data-cy="picklist-quantity-2"]').should('have.text', '2');
+
+    cy.get('[data-cy="picklist-sort-button-quantity"]').click();
+    cy.get('[data-cy="picklist-quantity-0"]').should('have.text', '2');
+    cy.get('[data-cy="picklist-quantity-1"]').should('have.text', '3');
+    cy.get('[data-cy="picklist-quantity-2"]').should('have.text', '10');
+  });
+
+  it('sorts mixed type data correctly', () => {
+    cy.mount(PicklistBase, {
+      props: {
+        rows: [
+          { name: 'Item B', quantity: 2, location: 'A' },
+          { name: 'Item A', quantity: 10, location: 2 },
+          { name: 'Item C', quantity: 3, location: 'B' },
+          { name: 'Item C', quantity: 3, location: 10 },
+        ],
+        columns: ['name', 'quantity', 'location'],
+        labels: { name: 'Name', quantity: 'Quantity', location: 'Location' },
+      },
+    });
+
+    cy.get('[data-cy="picklist-sort-button-location"]').click();
+    cy.get('[data-cy="picklist-location-0"]').should('have.text', '2');
+    cy.get('[data-cy="picklist-location-1"]').should('have.text', '10');
+    cy.get('[data-cy="picklist-location-2"]').should('have.text', 'A');
+    cy.get('[data-cy="picklist-location-3"]').should('have.text', 'B');
+
+    cy.get('[data-cy="picklist-sort-button-location"]').click();
+    cy.get('[data-cy="picklist-location-0"]').should('have.text', 'B');
+    cy.get('[data-cy="picklist-location-1"]').should('have.text', 'A');
+    cy.get('[data-cy="picklist-location-2"]').should('have.text', '10');
+    cy.get('[data-cy="picklist-location-3"]').should('have.text', '2');
+
+    cy.get('[data-cy="picklist-sort-button-location"]').click();
+    cy.get('[data-cy="picklist-location-0"]').should('have.text', '2');
+    cy.get('[data-cy="picklist-location-1"]').should('have.text', '10');
+    cy.get('[data-cy="picklist-location-2"]').should('have.text', 'A');
+    cy.get('[data-cy="picklist-location-3"]').should('have.text', 'B');
+  });
+
+  it('selected quantities move with sorted data', () => {
     cy.mount(PicklistBase, {
       props: {
         rows: [
@@ -80,20 +171,14 @@ describe('Test the PicklistBase component behavior', () => {
     });
 
     cy.get('[data-cy="picklist-sort-button-name"]').click();
-    cy.get('[data-cy="picklist-row-0"]').contains('Item A');
-    cy.get('[data-cy="picklist-row-1"]').contains('Item B');
     cy.get('[data-cy="picklist-quantity-0"]').should('have.value', '3');
     cy.get('[data-cy="picklist-quantity-1"]').should('have.value', '2');
 
     cy.get('[data-cy="picklist-sort-button-name"]').click();
-    cy.get('[data-cy="picklist-row-0"]').contains('Item B');
-    cy.get('[data-cy="picklist-row-1"]').contains('Item A');
     cy.get('[data-cy="picklist-quantity-0"]').should('have.value', '2');
     cy.get('[data-cy="picklist-quantity-1"]').should('have.value', '3');
 
     cy.get('[data-cy="picklist-sort-button-name"]').click();
-    cy.get('[data-cy="picklist-row-0"]').contains('Item A');
-    cy.get('[data-cy="picklist-row-1"]').contains('Item B');
     cy.get('[data-cy="picklist-quantity-0"]').should('have.value', '3');
     cy.get('[data-cy="picklist-quantity-1"]').should('have.value', '2');
   });

--- a/components/PicklistBase/PicklistBase.vue
+++ b/components/PicklistBase/PicklistBase.vue
@@ -536,42 +536,40 @@ export default {
       }
     },
     handleSort({ label, sortOrder }) {
-      // Previous state of rows before sorting
-      const oldRowOrder = [...this.sortedRows];
-
-      // Update the sort state
       this.sortColumn = this.columns.find(
         (column) => this.getLabel(column) === label
       );
       this.sortOrder = sortOrder;
 
-      // Perform the sort operation
       const sorted = [...this.sortedRows].sort((a, b) => {
         if (a[this.sortColumn] < b[this.sortColumn]) {
           return this.sortOrder === 'asc' ? -1 : 1;
         } else if (a[this.sortColumn] > b[this.sortColumn]) {
           return this.sortOrder === 'asc' ? 1 : -1;
-        } else {
-          return 0;
+        }
+        return 0;
+      });
+
+      const newPickedRows = new Array(this.rows.length).fill(0);
+      const newQuantityOptionsMap = new Map();
+      
+      sorted.forEach((sortedRow, index) => {
+        const originalIndex = this.rows.indexOf(sortedRow);
+        if (this.picked.has(originalIndex)) {
+          newPickedRows[index] = this.picked.get(originalIndex).picked;
+        }
+        if (this.quantityAttribute) {
+          newQuantityOptionsMap.set(
+            index,
+            Array.from(
+              { length: sortedRow[this.quantityAttribute] + 1 },
+              (_, i) => i
+            )
+          );
         }
       });
 
-      // Update the sorted rows
       this.sortedRows = sorted;
-
-      // Map old pickedRows to the new sorted order
-      const newPickedRows = new Array(this.rows.length);
-      const newQuantityOptionsMap = new Map();
-      sorted.forEach((sortedRow, index) => {
-        const originalIndex = oldRowOrder.findIndex((row) => row === sortedRow);
-        newPickedRows[index] = this.pickedRows[originalIndex];
-        newQuantityOptionsMap.set(
-          index,
-          this.quantityOptionsMap.get(originalIndex)
-        );
-      });
-
-      // Update pickedRows and quantityOptionsMap to reflect the new order
       this.pickedRows = newPickedRows;
       this.quantityOptionsMap = newQuantityOptionsMap;
     },

--- a/components/PicklistBase/PicklistBase.vue
+++ b/components/PicklistBase/PicklistBase.vue
@@ -542,17 +542,26 @@ export default {
       this.sortOrder = sortOrder;
 
       const sorted = [...this.sortedRows].sort((a, b) => {
-        if (a[this.sortColumn] < b[this.sortColumn]) {
-          return this.sortOrder === 'asc' ? -1 : 1;
-        } else if (a[this.sortColumn] > b[this.sortColumn]) {
-          return this.sortOrder === 'asc' ? 1 : -1;
+        let aVal = a[this.sortColumn];
+        let bVal = b[this.sortColumn];
+
+        if (isNaN(aVal) || isNaN(bVal)) {
+          aVal = aVal.toString().toLowerCase();
+          bVal = bVal.toString().toLowerCase();
         }
-        return 0;
+
+        if (aVal < bVal) {
+          return this.sortOrder === 'asc' ? -1 : 1;
+        } else if (aVal > bVal) {
+          return this.sortOrder === 'asc' ? 1 : -1;
+        } else {
+          return 0;
+        }
       });
 
       const newPickedRows = new Array(this.rows.length).fill(0);
       const newQuantityOptionsMap = new Map();
-      
+
       sorted.forEach((sortedRow, index) => {
         const originalIndex = this.rows.indexOf(sortedRow);
         if (this.picked.has(originalIndex)) {

--- a/modules/farm_fd2_examples/src/entrypoints/picklist_base/App.vue
+++ b/modules/farm_fd2_examples/src/entrypoints/picklist_base/App.vue
@@ -271,12 +271,18 @@ export default {
     toggleFirstRow() {
       const firstRow = this.rows[0];
       const firstRowIndex = this.rows.indexOf(firstRow);
-      const newPicked = new Map(this.form.picked);
-      if (newPicked.has(firstRowIndex)) {
-        newPicked.delete(firstRowIndex);
-      } else {
+      const newPicked = new Map();
+      
+      for (const [key, value] of this.form.picked) {
+        if (key !== firstRowIndex) {
+          newPicked.set(key, value);
+        }
+      }
+      
+      if (!this.form.picked.has(firstRowIndex)) {
         newPicked.set(firstRowIndex, firstRow);
       }
+      
       this.form.picked = newPicked;
     },
   },

--- a/modules/farm_fd2_examples/src/entrypoints/picklist_base/App.vue
+++ b/modules/farm_fd2_examples/src/entrypoints/picklist_base/App.vue
@@ -271,20 +271,12 @@ export default {
     toggleFirstRow() {
       const firstRow = this.rows[0];
       const firstRowIndex = this.rows.indexOf(firstRow);
-      const newPicked = new Map();
-      
-      for (const [key, value] of this.form.picked) {
-        if (key !== firstRowIndex) {
-          newPicked.set(key, value);
-        }
+
+      if (this.form.picked.has(firstRowIndex)) {
+        this.form.picked.delete(firstRowIndex);
+      } else {
+        this.form.picked.set(firstRowIndex, firstRow);
       }
-      
-      if (!this.form.picked.has(firstRowIndex)) {
-        newPicked.set(firstRowIndex, firstRow);
-      }
-      
-      this.form.picked = newPicked;
-    },
   },
   created() {
     this.createdCount++;

--- a/modules/farm_fd2_examples/src/entrypoints/picklist_base/App.vue
+++ b/modules/farm_fd2_examples/src/entrypoints/picklist_base/App.vue
@@ -271,13 +271,18 @@ export default {
     toggleFirstRow() {
       const firstRow = this.rows[0];
       const firstRowIndex = this.rows.indexOf(firstRow);
-
-      if (this.form.picked.has(firstRowIndex)) {
-        this.form.picked.delete(firstRowIndex);
+      const newPicked = new Map(this.form.picked);
+      
+      if (newPicked.has(firstRowIndex)) {
+        newPicked.delete(firstRowIndex);
       } else {
-        this.form.picked.set(firstRowIndex, firstRow);
+        newPicked.set(firstRowIndex, {
+          row: firstRow,
+          picked: 1  
+        });
       }
-    },
+      this.form.picked = newPicked;
+    }
   },
   created() {
     this.createdCount++;

--- a/modules/farm_fd2_examples/src/entrypoints/picklist_base/App.vue
+++ b/modules/farm_fd2_examples/src/entrypoints/picklist_base/App.vue
@@ -271,12 +271,13 @@ export default {
     toggleFirstRow() {
       const firstRow = this.rows[0];
       const firstRowIndex = this.rows.indexOf(firstRow);
-
-      if (this.form.picked.has(firstRowIndex)) {
-        this.form.picked.delete(firstRowIndex);
+      const newPicked = new Map(this.form.picked);
+      if (newPicked.has(firstRowIndex)) {
+        newPicked.delete(firstRowIndex);
       } else {
-        this.form.picked.set(firstRowIndex, firstRow);
+        newPicked.set(firstRowIndex, firstRow);
       }
+      this.form.picked = newPicked;
     },
   },
   created() {

--- a/modules/farm_fd2_examples/src/entrypoints/picklist_base/App.vue
+++ b/modules/farm_fd2_examples/src/entrypoints/picklist_base/App.vue
@@ -277,6 +277,7 @@ export default {
       } else {
         this.form.picked.set(firstRowIndex, firstRow);
       }
+    },
   },
   created() {
     this.createdCount++;

--- a/modules/farm_fd2_examples/src/entrypoints/picklist_base/App.vue
+++ b/modules/farm_fd2_examples/src/entrypoints/picklist_base/App.vue
@@ -210,16 +210,16 @@ export default {
         },
         {
           c1: 'A',
-          c2: 2,
+          c2: 25,
           c3: 'X',
-          stuff: 'A, 2, X',
+          stuff: 'A, 25, X',
           quantity: 2,
         },
         {
           c1: 'D',
           c2: 7,
-          c3: 'Z',
-          stuff: 'D, 7, Z',
+          c3: 5,
+          stuff: 'D, 7, 5',
           quantity: 3,
         },
         {
@@ -272,17 +272,17 @@ export default {
       const firstRow = this.rows[0];
       const firstRowIndex = this.rows.indexOf(firstRow);
       const newPicked = new Map(this.form.picked);
-      
+
       if (newPicked.has(firstRowIndex)) {
         newPicked.delete(firstRowIndex);
       } else {
         newPicked.set(firstRowIndex, {
           row: firstRow,
-          picked: 1  
+          picked: 1,
         });
       }
       this.form.picked = newPicked;
-    }
+    },
   },
   created() {
     this.createdCount++;


### PR DESCRIPTION
**Pull Request Description**

Fixes the sorting of mixed type columns (e.g.  numbers and strings).  

Also fixes example page issue related to `picked` prop not being properly updated due to non trigger of reactivity and refactors `handleSort`.

Closes #414 

---

**Licensing Certification**

FarmData2 is a [Free Cultural Work](https://freedomdefined.org/Definition) and all accepted contributions are licensed as described in the LICENSE.md file. This requires that the contributor holds the rights to do so. By submitting this pull request **I certify that I satisfy the terms of the [Developer Certificate of Origin](https://developercertificate.org/)** for its contents.
