### PR TITLE
Improve Reactivity in Picker Components and Add `selectAllBedsByDefault` to LocationSelector

### DIFF
--- a/components/BedPicker/BedPicker.events.comp.cy.js
+++ b/components/BedPicker/BedPicker.events.comp.cy.js
@@ -32,7 +32,7 @@ describe('Test the BedPicker component events', () => {
       });
   });
 
-  it('Test update:picked event propagated', () => {
+  it('Test update:picked event propagated from user interaction', () => {
     const readySpy = cy.spy().as('readySpy');
     const pickedSpy = cy.spy().as('pickedSpy');
 
@@ -51,6 +51,35 @@ describe('Test the BedPicker component events', () => {
         cy.get('@pickedSpy').should('have.been.calledOnce');
         cy.get('@pickedSpy').should('have.been.calledWith', ['ALF-1']);
       });
+  });
+
+  it('Emits update:picked when the picked prop changes', () => {
+    const readySpy = cy.spy().as('readySpy');
+    const pickedSpy = cy.spy().as('pickedSpy');
+
+    cy.mount(BedPicker, {
+      props: {
+        onReady: readySpy,
+        'onUpdate:picked': pickedSpy,
+        location: 'ALF',
+        picked: ['ALF-2'],
+      },
+    }).then(({ wrapper }) => {
+      cy.get('@readySpy')
+        .should('have.been.calledOnce')
+        .then(() => {
+          cy.get('@pickedSpy').should('have.been.calledOnce');
+          cy.get('@pickedSpy').should('have.been.calledWith', ['ALF-2']);
+
+          wrapper.setProps({ picked: ['ALF-3', 'ALF-4'] });
+
+          cy.get('@pickedSpy').should('have.been.calledTwice');
+          cy.get('@pickedSpy').should('have.been.calledWith', [
+            'ALF-3',
+            'ALF-4',
+          ]);
+        });
+    });
   });
 
   it('Error event if unable to fetch beds, fields or greenhouses', () => {

--- a/components/LocationSelector/LocationSelector.behavior.comp.cy.js
+++ b/components/LocationSelector/LocationSelector.behavior.comp.cy.js
@@ -154,4 +154,165 @@ describe('Test the LocationSelector component behavior', () => {
         });
     });
   });
+
+  it('1. Prop = true, when a location with beds is selected, all beds are checked', () => {
+    const readySpy = cy.spy().as('readySpy');
+
+    cy.mount(LocationSelector, {
+      props: {
+        includeGreenhouses: true,
+        includeFields: true,
+        onReady: readySpy,
+        selectAllBedsByDefault: true,
+      },
+    });
+
+    cy.get('@readySpy')
+      .should('have.been.calledOnce')
+      .then(() => {
+        cy.get('[data-cy="selector-input"]').select('CHUAU');
+        cy.get('[data-cy="location-beds-accordion"]').should('exist');
+        cy.get('[data-cy="picker-options"] input[type="checkbox"]').should(
+          'be.checked'
+        );
+      });
+  });
+
+  it('2. Prop = false, when a location with beds is selected, no beds are checked', () => {
+    const readySpy = cy.spy().as('readySpy');
+
+    cy.mount(LocationSelector, {
+      props: {
+        includeGreenhouses: true,
+        includeFields: true,
+        onReady: readySpy,
+        selectAllBedsByDefault: false,
+      },
+    });
+
+    cy.get('@readySpy')
+      .should('have.been.calledOnce')
+      .then(() => {
+        cy.get('[data-cy="selector-input"]').select('CHUAU');
+        cy.get('[data-cy="location-beds-accordion"]').should('exist');
+        cy.get('[data-cy="picker-options"] input[type="checkbox"]').should(
+          'not.be.checked'
+        );
+      });
+  });
+
+  it('3. Prop starts false, select a location (none checked), then change prop to true, select another location (all checked)', () => {
+    const readySpy = cy.spy().as('readySpy');
+
+    cy.mount(LocationSelector, {
+      props: {
+        includeGreenhouses: true,
+        includeFields: true,
+        onReady: readySpy,
+        selectAllBedsByDefault: false,
+      },
+    }).then(({ wrapper }) => {
+      cy.get('@readySpy')
+        .should('have.been.calledOnce')
+        .then(() => {
+          cy.then(() => {
+            cy.get('[data-cy="selector-input"]').select('CHUAU');
+            cy.get('[data-cy="picker-options"] input[type="checkbox"]').should(
+              'not.be.checked'
+            );
+          }).then(() => {
+            wrapper.setProps({ selectAllBedsByDefault: true });
+            cy.get('[data-cy="selector-input"]').select('ALF');
+            cy.get('[data-cy="picker-options"] input[type="checkbox"]').should(
+              'be.checked'
+            );
+          });
+        });
+    });
+  });
+
+  it('4. Prop starts true, select a location (all checked), then change prop to false, select another location (none checked)', () => {
+    const readySpy = cy.spy().as('readySpy');
+
+    cy.mount(LocationSelector, {
+      props: {
+        includeGreenhouses: true,
+        includeFields: true,
+        onReady: readySpy,
+        selectAllBedsByDefault: true,
+      },
+    }).then(({ wrapper }) => {
+      cy.get('@readySpy')
+        .should('have.been.calledOnce')
+        .then(() => {
+          cy.then(() => {
+            cy.get('[data-cy="selector-input"]').select('CHUAU');
+            cy.get('[data-cy="picker-options"] input[type="checkbox"]').should(
+              'be.checked'
+            );
+          }).then(() => {
+            wrapper.setProps({ selectAllBedsByDefault: false });
+
+            cy.get('[data-cy="selector-input"]').select('ALF');
+            cy.get('[data-cy="picker-options"] input[type="checkbox"]').should(
+              'not.be.checked'
+            );
+          });
+        });
+    });
+  });
+
+  it(`5. Prop = true, switch locations: ensure each newly selected location's beds are all checked`, () => {
+    const readySpy = cy.spy().as('readySpy');
+
+    cy.mount(LocationSelector, {
+      props: {
+        includeGreenhouses: true,
+        includeFields: true,
+        onReady: readySpy,
+        selectAllBedsByDefault: true,
+      },
+    });
+
+    cy.get('@readySpy')
+      .should('have.been.calledOnce')
+      .then(() => {
+        cy.get('[data-cy="selector-input"]').select('CHUAU');
+        cy.get('[data-cy="picker-options"] input[type="checkbox"]').should(
+          'be.checked'
+        );
+
+        cy.get('[data-cy="selector-input"]').select('ALF');
+        cy.get('[data-cy="picker-options"] input[type="checkbox"]').should(
+          'be.checked'
+        );
+      });
+  });
+
+  it(`6. Prop = false, switch locations: ensure each newly selected location's beds are all unchecked`, () => {
+    const readySpy = cy.spy().as('readySpy');
+
+    cy.mount(LocationSelector, {
+      props: {
+        includeGreenhouses: true,
+        includeFields: true,
+        onReady: readySpy,
+        selectAllBedsByDefault: false,
+      },
+    });
+
+    cy.get('@readySpy')
+      .should('have.been.calledOnce')
+      .then(() => {
+        cy.get('[data-cy="selector-input"]').select('CHUAU');
+        cy.get('[data-cy="picker-options"] input[type="checkbox"]').should(
+          'not.be.checked'
+        );
+
+        cy.get('[data-cy="selector-input"]').select('ALF');
+        cy.get('[data-cy="picker-options"] input[type="checkbox"]').should(
+          'not.be.checked'
+        );
+      });
+  });
 });

--- a/components/LocationSelector/LocationSelector.events.comp.cy.js
+++ b/components/LocationSelector/LocationSelector.events.comp.cy.js
@@ -259,13 +259,15 @@ describe('Test the LocationSelector component events', () => {
     cy.get('@readySpy')
       .should('have.been.calledOnce')
       .then(() => {
-        cy.get('[data-cy="selector-input"]').select('CHUAU');
         cy.get('@updateSpy').should('have.been.calledOnce');
+
+        cy.get('[data-cy="selector-input"]').select('CHUAU');
+        cy.get('@updateSpy').should('have.been.calledTwice');
 
         // Pick CHUAU-1
         cy.get('[data-cy="picker-options"]').find('input').eq(0).check();
 
-        cy.get('@updateSpy').should('have.been.calledTwice');
+        cy.get('@updateSpy').should('have.been.calledThrice');
         cy.get('@updateSpy').should('have.been.calledWith', ['CHUAU-1'], 5);
       });
   });
@@ -297,7 +299,7 @@ describe('Test the LocationSelector component events', () => {
     });
   });
 
-  it('Selected beds are cleared when location is changed', () => {
+  it('Selected beds are cleared when new location with beds is picked', () => {
     const readySpy = cy.spy().as('readySpy');
     const updateSpy = cy.spy().as('updateSpy');
 
@@ -329,6 +331,42 @@ describe('Test the LocationSelector component events', () => {
         cy.get('@updateSpy').should('have.been.calledThrice');
         cy.get('@updateSpy').its('args[2][0]').should('deep.equal', []);
         cy.get('@updateSpy').its('args[2][1]').should('equal', 5);
+      });
+  });
+
+  it('Selected beds are cleared when new location with no beds is picked', () => {
+    const readySpy = cy.spy().as('readySpy');
+    const updateSpy = cy.spy().as('updateSpy');
+
+    cy.mount(LocationSelector, {
+      props: {
+        includeGreenhouses: true,
+        includeFields: true,
+        selected: 'CHUAU',
+        pickedBeds: ['CHUAU-1', 'CHUAU-3'],
+        onReady: readySpy,
+        'onUpdate:beds': updateSpy,
+      },
+    });
+
+    cy.get('@readySpy')
+      .should('have.been.calledOnce')
+      .then(() => {
+        cy.get('@updateSpy').should('have.been.calledOnce');
+        cy.get('@updateSpy')
+          .its('args[0][0]')
+          .should('deep.equal', ['CHUAU-1', 'CHUAU-3']);
+        cy.get('@updateSpy').its('args[0][1]').should('equal', 5);
+
+        cy.get('[data-cy="selector-input"]').select('A');
+        cy.get('@updateSpy').should('have.been.calledTwice');
+        cy.get('@updateSpy').its('args[1][0]').should('deep.equal', []);
+        cy.get('@updateSpy').its('args[1][1]').should('equal', 0);
+
+        cy.get('[data-cy="selector-input"]').select('B');
+        cy.get('@updateSpy').should('have.been.calledThrice');
+        cy.get('@updateSpy').its('args[2][0]').should('deep.equal', []);
+        cy.get('@updateSpy').its('args[2][1]').should('equal', 0);
       });
   });
 

--- a/components/LocationSelector/LocationSelector.events.comp.cy.js
+++ b/components/LocationSelector/LocationSelector.events.comp.cy.js
@@ -260,14 +260,41 @@ describe('Test the LocationSelector component events', () => {
       .should('have.been.calledOnce')
       .then(() => {
         cy.get('[data-cy="selector-input"]').select('CHUAU');
-        cy.get('@updateSpy').should('not.have.been.called');
+        cy.get('@updateSpy').should('have.been.calledOnce');
 
         // Pick CHUAU-1
         cy.get('[data-cy="picker-options"]').find('input').eq(0).check();
 
-        cy.get('@updateSpy').should('have.been.calledOnce');
+        cy.get('@updateSpy').should('have.been.calledTwice');
         cy.get('@updateSpy').should('have.been.calledWith', ['CHUAU-1'], 5);
       });
+  });
+
+  it('Emits "update:beds" when the pickedBeds prop changes', () => {
+    const readySpy = cy.spy().as('readySpy');
+    const updateBedsSpy = cy.spy().as('updateBedsSpy');
+
+    cy.mount(LocationSelector, {
+      props: {
+        includeGreenhouses: true,
+        onReady: readySpy,
+        'onUpdate:beds': updateBedsSpy,
+        selected: 'CHUAU',
+        pickedBeds: ['CHUAU-2'],
+      },
+    }).then(({ wrapper }) => {
+      cy.get('@updateBedsSpy').should('have.been.calledOnce');
+      cy.get('@updateBedsSpy').should('have.been.calledWith', ['CHUAU-2'], 5);
+
+      wrapper.setProps({ pickedBeds: ['CHUAU-1', 'CHUAU-3'] });
+
+      cy.get('@updateBedsSpy').should('have.been.calledTwice');
+      cy.get('@updateBedsSpy').should(
+        'have.been.calledWith',
+        ['CHUAU-1', 'CHUAU-3'],
+        5
+      );
+    });
   });
 
   it('Selected beds are cleared when location is changed', () => {
@@ -287,17 +314,21 @@ describe('Test the LocationSelector component events', () => {
     cy.get('@readySpy')
       .should('have.been.calledOnce')
       .then(() => {
-        cy.get('[data-cy="selector-input"]').select('GHANA');
+        cy.get('@updateSpy').should('have.been.calledOnce');
+        cy.get('@updateSpy')
+          .its('args[0][0]')
+          .should('deep.equal', ['CHUAU-1', 'CHUAU-3']);
+        cy.get('@updateSpy').its('args[0][1]').should('equal', 5);
 
-        cy.get('@updateSpy').should('have.been.calledThrice');
-        cy.get('@updateSpy').its('args[2][0]').should('deep.equal', []);
-        cy.get('@updateSpy').its('args[2][1]').should('equal', 4);
+        cy.get('[data-cy="selector-input"]').select('GHANA');
+        cy.get('@updateSpy').should('have.been.calledTwice');
+        cy.get('@updateSpy').its('args[1][0]').should('deep.equal', []);
+        cy.get('@updateSpy').its('args[1][1]').should('equal', 4);
 
         cy.get('[data-cy="selector-input"]').select('CHUAU');
-
-        cy.get('@updateSpy').its('callCount').should('equal', 4);
-        cy.get('@updateSpy').its('args[3][0]').should('deep.equal', []);
-        cy.get('@updateSpy').its('args[3][1]').should('equal', 5);
+        cy.get('@updateSpy').should('have.been.calledThrice');
+        cy.get('@updateSpy').its('args[2][0]').should('deep.equal', []);
+        cy.get('@updateSpy').its('args[2][1]').should('equal', 5);
       });
   });
 

--- a/components/LocationSelector/LocationSelector.vue
+++ b/components/LocationSelector/LocationSelector.vue
@@ -405,19 +405,14 @@ export default {
     },
   },
   watch: {
-    selectedBeds() {
-      this.checkedBeds = this.selectedBeds;
-    },
     checkedBeds: {
       handler() {
-        if (this.selectedLocation && this.showBedSelection) {
-          /**
-           * The selected beds have changed.
-           * @property {Array<string>} checkedBeds an array containing the names of the selected beds.
-           * @property {number} totalBeds the total number of beds in the selected location.
-           */
-          this.$emit('update:beds', this.checkedBeds, this.beds.length);
-        }
+        /**
+         * The selected beds have changed.
+         * @property {Array<string>} checkedBeds an array containing the names of the selected beds.
+         * @property {number} totalBeds the total number of beds in the selected location.
+         */
+        this.$emit('update:beds', this.checkedBeds, this.beds.length);
       },
       deep: true,
     },

--- a/components/LocationSelector/LocationSelector.vue
+++ b/components/LocationSelector/LocationSelector.vue
@@ -40,9 +40,8 @@
           id="location-bed-picker"
           data-cy="location-bed-picker"
           v-bind:location="selectedLocation"
-          v-bind:picked="checkedBeds"
+          v-model:picked="checkedBeds"
           v-bind:required="requireBedSelection"
-          v-on:update:picked="handleUpdateBeds($event)"
           v-bind:showValidityStyling="showValidityStyling"
           v-on:valid="handleBedsValid($event)"
         />
@@ -150,6 +149,13 @@ export default {
      * is false, this property is ignored.
      */
     requireBedSelection: {
+      type: Boolean,
+      default: false,
+    },
+    /**
+     * Whether to select all beds within a location by default.
+     */
+    selectAllBedsByDefault: {
       type: Boolean,
       default: false,
     },
@@ -318,22 +324,13 @@ export default {
     },
   },
   methods: {
-    handleUpdateBeds(event) {
-      this.checkedBeds = event;
-
-      /**
-       * The selected beds have changed.
-       * @property {Array<string>} checkedBeds an array containing the names of the selected beds.
-       * @property {number} totalBeds the total number of beds in the selected location.
-       */
-      this.$emit('update:beds', this.checkedBeds, this.beds.length);
-    },
     handleUpdateSelected(event) {
       this.selectedLocation = event;
 
-      // Clear any picked beds for the new location.
-      if (this.pickedBeds.length > 0) {
-        this.handleUpdateBeds([]);
+      if (this.selectAllBedsByDefault) {
+        this.checkedBeds = this.beds;
+      } else {
+        this.checkedBeds = [];
       }
 
       /**
@@ -410,6 +407,19 @@ export default {
   watch: {
     selectedBeds() {
       this.checkedBeds = this.selectedBeds;
+    },
+    checkedBeds: {
+      handler() {
+        if (this.selectedLocation && this.showBedSelection) {
+          /**
+           * The selected beds have changed.
+           * @property {Array<string>} checkedBeds an array containing the names of the selected beds.
+           * @property {number} totalBeds the total number of beds in the selected location.
+           */
+          this.$emit('update:beds', this.checkedBeds, this.beds.length);
+        }
+      },
+      deep: true,
     },
     pickedBeds() {
       this.checkedBeds = this.pickedBeds;

--- a/components/PickerBase/PickerBase.events.comp.cy.js
+++ b/components/PickerBase/PickerBase.events.comp.cy.js
@@ -150,6 +150,36 @@ describe('Test the PickerBase component events', () => {
       });
   });
 
+  it('Emits "update:picked" when the picked prop is changed', () => {
+    const readySpy = cy.spy().as('readySpy');
+    const updatePickedSpy = cy.spy().as('updatePickedSpy');
+
+    cy.mount(PickerBase, {
+      props: {
+        onReady: readySpy,
+        'onUpdate:picked': updatePickedSpy,
+        label: 'Picker',
+        options: ['Option 1', 'Option 2', 'Option 3'],
+        picked: ['Option 1'],
+        required: false,
+        invalidFeedbackText: 'Invalid feedback text.',
+      },
+    }).then(({ wrapper }) => {
+      cy.get('@readySpy')
+        .should('have.been.calledOnce')
+        .then(() => {
+          cy.get('@updatePickedSpy').should('not.have.been.called');
+          wrapper.setProps({ picked: ['Option 2', 'Option 3'] });
+
+          cy.get('@updatePickedSpy').should('have.been.calledOnce');
+          cy.get('@updatePickedSpy').should('have.been.calledWith', [
+            'Option 2',
+            'Option 3',
+          ]);
+        });
+    });
+  });
+
   it('Emits "update:picked" when "All" button is clicked', () => {
     const readySpy = cy.spy().as('readySpy');
     const updateSpy = cy.spy().as('updateSpy');

--- a/components/PickerBase/PickerBase.vue
+++ b/components/PickerBase/PickerBase.vue
@@ -46,7 +46,6 @@
           v-model="checked"
           v-bind:options="options"
           v-bind:state="validationStyling"
-          v-on:change="updatePicked($event)"
         />
 
         <BFormInvalidFeedback
@@ -190,21 +189,12 @@ export default {
     },
   },
   methods: {
-    updatePicked() {
-      /**
-       * The picked options have changed.
-       * @property {Array} picked An array of strings with the names of the picked options.
-       */
-      this.$emit('update:picked', this.checked);
-    },
     pickAll() {
       if (this.checked.length === this.options.length) {
         this.checked = [];
       } else {
         this.checked = [...this.options];
       }
-
-      this.updatePicked();
     },
   },
   watch: {
@@ -215,6 +205,16 @@ export default {
        */
       this.$emit('valid', this.isValid);
     },
+    checked: {
+      handler() {
+        /**
+         * The picked options have changed.
+         * @property {Array} picked An array of strings with the names of the picked options.
+         */
+        this.$emit('update:picked', this.checked);
+      },
+      deep: true,
+    },
     picked() {
       this.checked = this.picked;
     },
@@ -224,8 +224,6 @@ export default {
           this.checked = this.checked.filter((option) =>
             this.options.includes(option)
           );
-
-          this.updatePicked();
         }
       },
       deep: true,

--- a/modules/farm_fd2_examples/src/entrypoints/location_selector/App.vue
+++ b/modules/farm_fd2_examples/src/entrypoints/location_selector/App.vue
@@ -18,6 +18,7 @@
     v-bind:includeGreenhousesWithBeds="includeGreenhousesWithBeds"
     v-bind:allowBedSelection="allowBedSelection"
     v-bind:requireBedSelection="requireBedSelection"
+    v-bind:selectAllBedsByDefault="selectAllBedsByDefault"
     v-model:selected="this.form.selected"
     v-model:pickedBeds="this.form.pickedBeds"
     v-on:update:beds="(beds) => (this.form.pickedBeds = beds)"
@@ -123,6 +124,17 @@
             data-cy="requireBedSelection-checkbox"
             switch
             v-model="requireBedSelection"
+          />
+        </td>
+      </tr>
+      <tr>
+        <td>selectAllBedsByDefault</td>
+        <td>
+          <BFormCheckbox
+            id="selectAllBedsByDefault-checkbox"
+            data-cy="selectAllBedsByDefault-checkbox"
+            switch
+            v-model="selectAllBedsByDefault"
           />
         </td>
       </tr>
@@ -258,6 +270,7 @@ export default {
       includeGreenhousesWithBeds: true,
       allowBedSelection: true,
       requireBedSelection: false,
+      selectAllBedsByDefault: true,
       form: {
         selected: null,
         pickedBeds: [],

--- a/modules/farm_fd2_examples/src/entrypoints/location_selector/App.vue
+++ b/modules/farm_fd2_examples/src/entrypoints/location_selector/App.vue
@@ -142,6 +142,16 @@
         <td>selected</td>
         <td>
           <BButton
+            id="clear-selected-field-button"
+            data-cy="clear-selected-field-button"
+            variant="outline-primary"
+            size="sm"
+            v-on:click="this.form.selected = ''"
+            v-bind:disabled="!includeFields || this.form.selected == ''"
+          >
+            None
+          </BButton>
+          <BButton
             id="select-field-button"
             data-cy="select-field-button"
             variant="outline-primary"

--- a/modules/farm_fd2_examples/src/entrypoints/location_selector/App.vue
+++ b/modules/farm_fd2_examples/src/entrypoints/location_selector/App.vue
@@ -270,7 +270,7 @@ export default {
       includeGreenhousesWithBeds: true,
       allowBedSelection: true,
       requireBedSelection: false,
-      selectAllBedsByDefault: true,
+      selectAllBedsByDefault: false,
       form: {
         selected: null,
         pickedBeds: [],


### PR DESCRIPTION
**Pull Request Description**

This PR improves how `PickerBase`, `BedPicker`, and `LocationSelector` handle changes to their `picked` values. Instead of only emitting `update:picked` events when users interact with the UI, these components now also emit the event when the `picked` prop is updated externally. This makes their behavior more consistent and relies on Vue’s reactivity instead of manual updates.

**Changes:**
- **PickerBase:**  
  - Emits `update:picked` when the `picked` prop changes, not just on user interaction.
  - Added tests to confirm this behavior.
  
- **BedPicker:**  
  - Works with the updated PickerBase without extra changes.
  - Added a test to ensure it emits `update:picked` when its `picked` prop changes.
  
- **LocationSelector:**  
  - Adjusted to properly handle `update:picked` events from BedPicker and PickerBase, now emitting `update:beds` as needed.
  - Introduced a new `selectAllBedsByDefault` prop, which selects all beds automatically when a location is chosen if enabled.
  - Added tests covering the new prop and the updated event handling.

The `LocationSelector` example page has also been updated to let you see and test the `selectAllBedsByDefault` feature.

**Closes #406**

---

**Licensing Certification**

FarmData2 is a [Free Cultural Work](https://freedomdefined.org/Definition) and all accepted contributions are licensed as described in the LICENSE.md file. This requires that the contributor holds the rights to do so. By submitting this pull request **I certify that I satisfy the terms of the [Developer Certificate of Origin](https://developercertificate.org/)** for its contents.
