### PR TITLE
feat(dev): migrate setup.bash to use npm ci as opposed to npm install

### DIFF
--- a/bin/setup.bash
+++ b/bin/setup.bash
@@ -17,7 +17,7 @@ echo "Setting up the FarmData2 Development Environment..."
 safe_cd "$REPO_ROOT_DIR"
 
 echo "  Installing npm dependencies..."
-npm install > /dev/null
+npm ci > /dev/null
 echo "  Installed."
 
 echo ""


### PR DESCRIPTION
**Pull Request Description**

Migrates `setup.bash` to use `npm ci` as opposed to `npm install`. Verified only instance of `npm install` via a recursive find search through the git repository. 

![image](https://github.com/user-attachments/assets/0c78bdc0-678a-4395-aad7-28b66ba0a1c0)

Consistency in package versions confirmed.
![image](https://github.com/user-attachments/assets/d07de06c-44c1-4d36-942b-1575b0439688)

Pursuant to and will close #331 upon merge.

**Licensing Certification**

FarmData2 is a [Free Cultural Work](https://freedomdefined.org/Definition) and all accepted contributions are licensed as described in the LICENSE.md file. This requires that the contributor holds the rights to do so. By submitting this pull request **I certify that I satisfy the terms of the [Developer Certificate of Origin](https://developercertificate.org/)** for its contents.
