### PR TITLE
fix: Updates tests for sample DB with location J

### DIFF
--- a/components/LocationSelector/LocationSelector.content.comp.cy.js
+++ b/components/LocationSelector/LocationSelector.content.comp.cy.js
@@ -81,9 +81,9 @@ describe('Test the default LocationSelector content', () => {
       .then(() => {
         cy.get('[data-cy="selector-input"]')
           .find('option')
-          .should('have.length', 10); // includes '' first item.
+          .should('have.length', 11); // includes '' first item.
         cy.get('[data-cy="selector-option-1"]').should('have.text', 'A');
-        cy.get('[data-cy="selector-option-9"]').should('have.text', 'H');
+        cy.get('[data-cy="selector-option-10"]').should('have.text', 'J');
       });
   });
 
@@ -103,9 +103,9 @@ describe('Test the default LocationSelector content', () => {
       .then(() => {
         cy.get('[data-cy="selector-input"]')
           .find('option')
-          .should('have.length', 13); // includes '' first item.
+          .should('have.length', 14); // includes '' first item.
         cy.get('[data-cy="selector-option-1"]').should('have.text', 'A');
-        cy.get('[data-cy="selector-option-12"]').should('have.text', 'JASMINE');
+        cy.get('[data-cy="selector-option-13"]').should('have.text', 'JASMINE');
       });
   });
 

--- a/library/farmosUtil/farmosUtil.fields.unit.cy.js
+++ b/library/farmosUtil/farmosUtil.fields.unit.cy.js
@@ -14,13 +14,13 @@ describe('Test the field utility functions', () => {
   it('Get the field land assets', () => {
     cy.wrap(farmosUtil.getFields()).then((fields) => {
       expect(fields).to.not.be.null;
-      expect(fields.length).to.equal(9);
+      expect(fields.length).to.equal(10);
 
       expect(fields[0].attributes.name).to.equal('A');
       expect(fields[0].type).to.equal('asset--land');
 
-      expect(fields[8].attributes.name).to.equal('H');
-      expect(fields[8].type).to.equal('asset--land');
+      expect(fields[9].attributes.name).to.equal('J');
+      expect(fields[9].type).to.equal('asset--land');
     });
   });
 
@@ -53,7 +53,7 @@ describe('Test the field utility functions', () => {
   it('Get the FieldNameToAsset map', () => {
     cy.wrap(farmosUtil.getFieldNameToAssetMap()).then((fieldNameMap) => {
       expect(fieldNameMap).to.not.be.null;
-      expect(fieldNameMap.size).to.equal(9);
+      expect(fieldNameMap.size).to.equal(10);
 
       expect(fieldNameMap.get('A')).to.not.be.null;
       expect(fieldNameMap.get('A').type).to.equal('asset--land');
@@ -68,7 +68,7 @@ describe('Test the field utility functions', () => {
   it('Get the FieldIdToAsset map', () => {
     cy.wrap(farmosUtil.getFieldIdToAssetMap()).then((fieldIdMap) => {
       expect(fieldIdMap).to.not.be.null;
-      expect(fieldIdMap.size).to.equal(9);
+      expect(fieldIdMap.size).to.equal(10);
 
       cy.wrap(farmosUtil.getFieldNameToAssetMap()).then((fieldNameMap) => {
         const fieldAId = fieldNameMap.get('A').id;

--- a/modules/farm_fd2/src/entrypoints/cover_crop_seeding/cover_crop_seeding.location.e2e.cy.js
+++ b/modules/farm_fd2/src/entrypoints/cover_crop_seeding/cover_crop_seeding.location.e2e.cy.js
@@ -34,7 +34,7 @@ describe('Cover Crop Seeding: Location Component', () => {
     cy.get('[data-cy="cover-crop-seeding-location"]')
       .find('[data-cy="selector-input"]')
       .find('option')
-      .should('have.length', 12);
+      .should('have.length', 13);
     cy.get('[data-cy="cover-crop-seeding-location"]')
       .find('[data-cy="selector-option-1"]')
       .should('have.value', 'A');
@@ -42,8 +42,8 @@ describe('Cover Crop Seeding: Location Component', () => {
       .find('[data-cy="selector-option-10"]')
       .should('have.value', 'GHANA');
     cy.get('[data-cy="cover-crop-seeding-location"]')
-      .find('[data-cy="selector-option-11"]')
-      .should('have.value', 'H');
+      .find('[data-cy="selector-option-12"]')
+      .should('have.value', 'J');
   });
 
   it('Location validity styling works', () => {

--- a/modules/farm_fd2/src/entrypoints/direct_seeding/direct_seeding.location.e2e.cy.js
+++ b/modules/farm_fd2/src/entrypoints/direct_seeding/direct_seeding.location.e2e.cy.js
@@ -34,7 +34,7 @@ describe('Direct Seeding: Location Component', () => {
     cy.get('[data-cy="direct-seeding-location"]')
       .find('[data-cy="selector-input"]')
       .find('option')
-      .should('have.length', 12);
+      .should('have.length', 13);
     cy.get('[data-cy="direct-seeding-location"]')
       .find('[data-cy="selector-option-1"]')
       .should('have.value', 'A');
@@ -42,8 +42,8 @@ describe('Direct Seeding: Location Component', () => {
       .find('[data-cy="selector-option-10"]')
       .should('have.value', 'GHANA');
     cy.get('[data-cy="direct-seeding-location"]')
-      .find('[data-cy="selector-option-11"]')
-      .should('have.value', 'H');
+      .find('[data-cy="selector-option-12"]')
+      .should('have.value', 'J');
   });
 
   it('Location validity styling works', () => {

--- a/modules/farm_fd2/src/entrypoints/soil_disturbance/soil_disturbance.location.e2e.cy.js
+++ b/modules/farm_fd2/src/entrypoints/soil_disturbance/soil_disturbance.location.e2e.cy.js
@@ -34,7 +34,7 @@ describe('Soil Disturbance: Location Component', () => {
     cy.get('[data-cy="soil-disturbance-location"]')
       .find('[data-cy="selector-input"]')
       .find('option')
-      .should('have.length', 12);
+      .should('have.length', 13);
     cy.get('[data-cy="soil-disturbance-location"]')
       .find('[data-cy="selector-option-1"]')
       .should('have.value', 'A');
@@ -42,8 +42,8 @@ describe('Soil Disturbance: Location Component', () => {
       .find('[data-cy="selector-option-10"]')
       .should('have.value', 'GHANA');
     cy.get('[data-cy="soil-disturbance-location"]')
-      .find('[data-cy="selector-option-11"]')
-      .should('have.value', 'H');
+      .find('[data-cy="selector-option-12"]')
+      .should('have.value', 'J');
   });
 
   it('Location validity styling works', () => {

--- a/modules/farm_fd2/src/entrypoints/transplanting/transplanting.location.e2e.cy.js
+++ b/modules/farm_fd2/src/entrypoints/transplanting/transplanting.location.e2e.cy.js
@@ -34,7 +34,7 @@ describe('Transplanting: Location Component', () => {
     cy.get('[data-cy="transplanting-location"]')
       .find('[data-cy="selector-input"]')
       .find('option')
-      .should('have.length', 12);
+      .should('have.length', 13);
     cy.get('[data-cy="transplanting-location"]')
       .find('[data-cy="selector-option-1"]')
       .should('have.value', 'A');
@@ -42,8 +42,8 @@ describe('Transplanting: Location Component', () => {
       .find('[data-cy="selector-option-10"]')
       .should('have.value', 'GHANA');
     cy.get('[data-cy="transplanting-location"]')
-      .find('[data-cy="selector-option-11"]')
-      .should('have.value', 'H');
+      .find('[data-cy="selector-option-12"]')
+      .should('have.value', 'J');
   });
 
   it('Location validity styling works', () => {


### PR DESCRIPTION
**Pull Request Description**

Updates the test suite to match a new sample database that includes a new location (field J) that contains no beds and no active plant assets.

---

**Licensing Certification**

FarmData2 is a [Free Cultural Work](https://freedomdefined.org/Definition) and all accepted contributions are licensed as described in the LICENSE.md file. This requires that the contributor holds the rights to do so. By submitting this pull request **I certify that I satisfy the terms of the [Developer Certificate of Origin](https://developercertificate.org/)** for its contents.
