### PR TITLE
fix(lib): patches the permissions api call for deploy

### DIFF
--- a/library/farmosUtil/farmosUtil.js
+++ b/library/farmosUtil/farmosUtil.js
@@ -1312,9 +1312,14 @@ export async function getPermissions() {
   return fetchWithCaching('permissions', async () => {
     try {
       const farm = await getFarmOSInstance();
-      const resp = await farm.remote.request.get(
-        'http://farmos/api/permissions'
-      );
+      let url = '';
+      if (inFarmOS()) {
+        const host = 'http://' + document.URL.split('/')[2];
+        url = host + '/api/permissions';
+      } else {
+        url = 'http://farmos/api/permissions';
+      }
+      const resp = await farm.remote.request.get(url);
       return resp.data.permissions;
     } catch (err) {
       throw new Error('Unable to fetch permissions.', err);


### PR DESCRIPTION
**Pull Request Description**

Uses the `host` from the `document.url` to set the path to the permissions api when the page making the call has been retrieved from a farmOS instance.

Closes #441 

---

**Licensing Certification**

FarmData2 is a [Free Cultural Work](https://freedomdefined.org/Definition) and all accepted contributions are licensed as described in the LICENSE.md file. This requires that the contributor holds the rights to do so. By submitting this pull request **I certify that I satisfy the terms of the [Developer Certificate of Origin](https://developercertificate.org/)** for its contents.
