### PR TITLE
fix(dev): Fixes link to vale linter and makes setup.bash re-runnable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,4 @@ spikes
 .vale
 .fd2
 .devcontainer/fd2_welcome.md
+bin/vale

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -9,5 +9,6 @@
   // codeActionsOnSave that sends a heartbeat signal to
   // the codespace that keeps it from timing out due to inactivity.
   "files.autoSave": "afterDelay",
-  "files.autoSaveDelay": 1000
+  "files.autoSaveDelay": 1000,
+  "vale.valeCLI.path": "${workspaceFolder}/node_modules/@vvago/vale/bin/vale"
 }

--- a/bin/setup.bash
+++ b/bin/setup.bash
@@ -46,7 +46,9 @@ if [ -f /usr/local/bin/vale ]; then
   echo "fd2dev" | sudo -Sk -p "" rm /usr/local/bin/vale
 fi
 # Link to the version of vale installed by npm
-echo "fd2dev" | sudo -Sk -p "" ln -s "$REPO_ROOT_DIR"/node_modules/@vvago/vale/bin/vale /usr/local/bin/vale
+if [ ! -f "$REPO_ROOT_DIR"/bin/vale ]; then
+  echo "fd2dev" | sudo -Sk -p "" ln -s "$REPO_ROOT_DIR"/node_modules/@vvago/vale/bin/vale "$REPO_ROOT_DIR"/bin/vale
+fi
 vale sync
 echo "  Configured."
 
@@ -56,18 +58,41 @@ echo "    that you make from the FarmData2 development environment."
 echo ""
 
 CONFIRM="N"
+GIT_USER=$(git config --global --list | grep user.name | cut -d"=" -f2)
+GIT_EMAIL=$(git config --global --list | grep user.email | cut -d"=" -f2)
 while [ "${CONFIRM,,}" != "y" ]; do
-  read -rp "    Name (user.name): " GIT_USER
-  read -rp "    Email (user.email): " GIT_EMAIL
+
+  if [ "$GIT_USER" = "" ]; then
+    read -rp "    Name (user.name): " GIT_USER
+  fi
+
+  if [ "$GIT_EMAIL" = "" ]; then
+    read -rp "    Email (user.email): " GIT_EMAIL
+  fi
+
+  echo ""
+  echo "user.name=$GIT_USER"
+  echo "user.email=$GIT_EMAIL"
   echo ""
   read -rp "    Is the above information correct? (Y/n) " CONFIRM
+
+  if [ "$CONFIRM" = "N" ] || [ "$CONFIRM" = "n" ]; then
+    GIT_USER=""
+    GIT_EMAIL=""
+  fi
 done
+
 git config --global user.name "$GIT_USER"
 git config --global user.email "$GIT_EMAIL"
 echo ""
-echo "    Setting the upstream remote..."
-git remote add upstream https://github.com/FarmData2/FarmData2.git
-echo "    Set."
+
+UPSTREAM=$(git remote -v | grep "upstream.*https://github.com/FarmData2/FarmData2.git")
+if [ "$UPSTREAM" = "" ]; then
+  echo "    Setting the upstream remote..."
+  git remote add upstream https://github.com/FarmData2/FarmData2.git
+  echo "    Set."
+fi
+
 echo "  Configured."
 
 echo ""


### PR DESCRIPTION
**Pull Request Description**

Ensures that vale linter is on the path and that it can be found by VSCode.

In addition, setup.bash was cleaned up so that unnecessary tasks are not performed if it is re-run in the fd2_dev container.

Closes #440

---

**Licensing Certification**

FarmData2 is a [Free Cultural Work](https://freedomdefined.org/Definition) and all accepted contributions are licensed as described in the LICENSE.md file. This requires that the contributor holds the rights to do so. By submitting this pull request **I certify that I satisfy the terms of the [Developer Certificate of Origin](https://developercertificate.org/)** for its contents.
