### PR TITLE
Lint testing

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -10,6 +10,11 @@ module.exports = {
     'plugin:json/recommended',
     'plugin:prettier/recommended',
   ],
+
+  rules: {
+    'vue/v-on-style': ['error', 'longform'],
+    'vue/v-bind-style': ['error', 'longform'],
+  },
   overrides: [
     {
       files: ['**/*.comp.cy.js', '**/*.unit.cy.js', '**/*.e2e.cy.js'],

--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -10,12 +10,14 @@ module.exports = {
     'plugin:json/recommended',
     'plugin:prettier/recommended',
   ],
-
-  rules: {
-    'vue/v-on-style': ['error', 'longform'],
-    'vue/v-bind-style': ['error', 'longform'],
-  },
   overrides: [
+    {
+      files: ['*.vue'],
+      rules: {
+        'vue/v-on-style': ['error', 'longform'],
+        'vue/v-bind-style': ['error', 'longform'],
+      },
+    },
     {
       files: ['**/*.comp.cy.js', '**/*.unit.cy.js', '**/*.e2e.cy.js'],
       extends: ['plugin:cypress/recommended'],

--- a/.fd2-cspell.txt
+++ b/.fd2-cspell.txt
@@ -77,3 +77,4 @@ vuese
 vvago
 XDEBUG
 Zulip
+longform


### PR DESCRIPTION
**Pull Request Description**

Added eslint rules for v-on and v-bind to ensure longform is always used instead of shortform notation. 

Closes #387 

---

**Licensing Certification**

FarmData2 is a [Free Cultural Work](https://freedomdefined.org/Definition) and all accepted contributions are licensed as described in the LICENSE.md file. This requires that the contributor holds the rights to do so. By submitting this pull request **I certify that I satisfy the terms of the [Developer Certificate of Origin](https://developercertificate.org/)** for its contents.

Co-authored-by: Niloy Saha <143445417+niloy-saha-123@users.noreply.github.com>
