### PR TITLE
fix(comp): closes direct seeding soil disturbance accordion on reset

### DIFF
--- a/modules/farm_fd2/src/entrypoints/direct_seeding/App.vue
+++ b/modules/farm_fd2/src/entrypoints/direct_seeding/App.vue
@@ -125,6 +125,7 @@
           <BAccordionItem
             id="direct-seeding-soil-disturbance-accordion-item"
             data-cy="direct-seeding-soil-disturbance-accordion-item"
+            v-model="directSeedingAccordionOpen"
           >
             <template #title>
               <span
@@ -243,6 +244,7 @@ export default {
       submitting: false,
       errorShowing: false,
       createdCount: 0,
+      directSeedingAccordionOpen: false,
     };
   },
   computed: {
@@ -327,6 +329,7 @@ export default {
         this.form.equipment = [];
         this.form.depth = 0;
         this.form.speed = 0;
+        this.directSeedingAccordionOpen = false;
       }
 
       this.form.cropName = null;

--- a/modules/farm_fd2/src/entrypoints/direct_seeding/direct_seeding.submitReset.e2e.cy.js
+++ b/modules/farm_fd2/src/entrypoints/direct_seeding/direct_seeding.submitReset.e2e.cy.js
@@ -250,8 +250,11 @@ describe('Direct Seeding: Submit/Reset Buttons component', () => {
     cy.get(
       '[data-cy="direct-seeding-soil-disturbance-accordion-title"]'
     ).click();
-    cy.get('[data-cy="multi-equipment-selector"]').should('be.visible');
-    cy.get('[data-cy="selector-input"]').should('have.value', null);
+    cy.get('[data-cy="multi-equipment-selector"]')
+      .should('be.visible')
+      .find('[data-cy="selector-1"]')
+      .find('[data-cy="selector-input"]')
+      .should('have.value', null);
 
     cy.get('[data-cy="multi-equipment-selector"]')
       .find('[data-cy="selector-1"]')

--- a/modules/farm_fd2/src/entrypoints/direct_seeding/direct_seeding.submitReset.e2e.cy.js
+++ b/modules/farm_fd2/src/entrypoints/direct_seeding/direct_seeding.submitReset.e2e.cy.js
@@ -251,6 +251,7 @@ describe('Direct Seeding: Submit/Reset Buttons component', () => {
       '[data-cy="direct-seeding-soil-disturbance-accordion-title"]'
     ).click();
     cy.get('[data-cy="multi-equipment-selector"]').should('be.visible');
+    cy.get('[data-cy="selector-input"]').should('have.value', null);
 
     cy.get('[data-cy="multi-equipment-selector"]')
       .find('[data-cy="selector-1"]')

--- a/modules/farm_fd2/src/entrypoints/direct_seeding/direct_seeding.submitReset.e2e.cy.js
+++ b/modules/farm_fd2/src/entrypoints/direct_seeding/direct_seeding.submitReset.e2e.cy.js
@@ -242,13 +242,15 @@ describe('Direct Seeding: Submit/Reset Buttons component', () => {
       .find('[data-cy="selector-input"]')
       .should('have.value', '1');
 
-    cy.get('[data-cy="multi-equipment-selector"]')
-      .find('[data-cy="selector-1"]')
-      .find('[data-cy="selector-input"]')
-      .should('have.value', null);
+    cy.get('[data-cy="multi-equipment-selector"]').should('not.be.visible');
     cy.get('[data-cy="soil-disturbance-depth"]').should('not.exist');
     cy.get('[data-cy="soil-disturbance-speed"]').should('not.exist');
     cy.get('[data-cy="soil-disturbance-area"]').should('not.exist');
+
+    cy.get(
+      '[data-cy="direct-seeding-soil-disturbance-accordion-title"]'
+    ).click();
+    cy.get('[data-cy="multi-equipment-selector"]').should('be.visible');
 
     cy.get('[data-cy="multi-equipment-selector"]')
       .find('[data-cy="selector-1"]')
@@ -257,9 +259,12 @@ describe('Direct Seeding: Submit/Reset Buttons component', () => {
 
     cy.get('[data-cy="soil-disturbance-depth"]')
       .find('[data-cy="numeric-input"]')
+      .should('be.visible')
       .should('have.value', '0.0');
+
     cy.get('[data-cy="soil-disturbance-speed"]')
       .find('[data-cy="numeric-input"]')
+      .should('be.visible')
       .should('have.value', '0.0');
   });
 });


### PR DESCRIPTION
**Pull Request Description**

Added a few lines of code to make the Accordion properly close when reset and rewrote a few tests in test file to ensure it works properly.

Closes #324 

---

**Licensing Certification**

FarmData2 is a [Free Cultural Work](https://freedomdefined.org/Definition) and all accepted contributions are licensed as described in the LICENSE.md file. This requires that the contributor holds the rights to do so. By submitting this pull request **I certify that I satisfy the terms of the [Developer Certificate of Origin](https://developercertificate.org/)** for its contents.

Co-authored-by: Niloy Saha <143445417+niloy-saha-123@users.noreply.github.com>
