### PR TITLE
fix(fd2): adds farm_transplanting as dependency

### DIFF
--- a/modules/farm_fd2/src/module/farm_fd2.info.yml
+++ b/modules/farm_fd2/src/module/farm_fd2.info.yml
@@ -7,6 +7,7 @@ core_version_requirement: '>=10'
 dependencies:
   - farm
   - farm_inventory
+  - farm_transplanting
   - views
   - simple_oauth_password_grant
   - farm_api_default_consumer


### PR DESCRIPTION
**Pull Request Description**

Adds the farm_transplanting module as a dependency of the farm_fd2 module.

Related to #370 

---

**Licensing Certification**

FarmData2 is a [Free Cultural Work](https://freedomdefined.org/Definition) and all accepted contributions are licensed as described in the LICENSE.md file. This requires that the contributor holds the rights to do so. By submitting this pull request **I certify that I satisfy the terms of the [Developer Certificate of Origin](https://developercertificate.org/)** for its contents.
