### PR TITLE
fix(dev): runs pre-commit e2e tests on live server

### DIFF
--- a/.lintstagedrc.cjs
+++ b/.lintstagedrc.cjs
@@ -29,21 +29,21 @@ const getModuleTestsVue = (files) => {
   const testCommands = files.map((file) => {
     if (file.includes('/farm_fd2/')) {
       return (
-        'test.bash --fd2 --e2e --dev --glob=' +
+        'test.bash --fd2 --e2e --live --glob=' +
         '/modules/farm_fd2/src/entrypoints/' +
         path.basename(path.dirname(file)) +
         '/*.e2e.cy.js'
       );
     } else if (file.includes('/farm_fd2_examples/')) {
       return (
-        'test.bash --examples --e2e --dev --glob=' +
+        'test.bash --examples --e2e --live --glob=' +
         '/modules/farm_fd2_examples/src/entrypoints/' +
         path.basename(path.dirname(file)) +
         '/*.e2e.cy.js'
       );
     } else if (file.includes('/farm_fd2_school/')) {
       return (
-        'test.bash --school --e2e --dev --glob=' +
+        'test.bash --school --e2e --live --glob=' +
         '/modules/farm_fd2_school/src/entrypoints/' +
         path.basename(path.dirname(file)) +
         '/*.e2e.cy.js'
@@ -66,17 +66,17 @@ const getModuleTestsE2ECyJs = (files) => {
   const testCommands = files.map((file) => {
     if (file.includes('/farm_fd2/')) {
       return (
-        'test.bash --fd2 --e2e --dev --glob=' +
+        'test.bash --fd2 --e2e --live --glob=' +
         file.substring(file.indexOf('/modules'))
       );
     } else if (file.includes('/farm_fd2_examples/')) {
       return (
-        'test.bash --examples --e2e --dev --glob=' +
+        'test.bash --examples --e2e --live --glob=' +
         file.substring(file.indexOf('/modules'))
       );
     } else if (file.includes('/farm_fd2_school/')) {
       return (
-        'test.bash --school --e2e --dev --glob=' +
+        'test.bash --school --e2e --live --glob=' +
         file.substring(file.indexOf('/modules'))
       );
     } else {


### PR DESCRIPTION
**Pull Request Description**

Changes the lint staged configuration to run the e2e tests using the live farmOS server instead of the dev server.  General practice has become to manually run tests against the live server. Also all non-e2e tests (e.g. unit/component) use the live server for API calls, so the live server must be running.  So for consistency, the e2e tests now run on the live server as well.

Closes #462

---

**Licensing Certification**

FarmData2 is a [Free Cultural Work](https://freedomdefined.org/Definition) and all accepted contributions are licensed as described in the LICENSE.md file. This requires that the contributor holds the rights to do so. By submitting this pull request **I certify that I satisfy the terms of the [Developer Certificate of Origin](https://developercertificate.org/)** for its contents.
