### PR TITLE
fix(dev): stops redundant testing in lint staged

### DIFF
--- a/.lintstagedrc.cjs
+++ b/.lintstagedrc.cjs
@@ -177,7 +177,7 @@ const getModuleTestsUnitCyJs = (files) => {
         );
       }
     } else if (file.includes('/farm_fd2_school/')) {
-      if (schoolEntrypointsTested.get(path.basename(path.dirname(file)))) {
+      if (schoolLibsTested.get(path.basename(path.dirname(file)))) {
         return 'skipping ' + file;
       } else {
         return (

--- a/.lintstagedrc.cjs
+++ b/.lintstagedrc.cjs
@@ -69,7 +69,9 @@ const getModuleTestsE2ECyJs = (files) => {
   testCommands = files.map((file) => {
     if (file.includes('/farm_fd2/')) {
       // Skip this if the entrypoint has already been tested
-      if (!fd2EntrypointsTested.get(path.basename(path.dirname(file)))) {
+      if (fd2EntrypointsTested.get(path.basename(path.dirname(file)))) {
+        return 'stat --printf="Skipping %n" file';
+      } else {
         return (
           'test.bash --fd2 --e2e --live --glob=' +
           file.substring(file.indexOf('/modules'))

--- a/.lintstagedrc.cjs
+++ b/.lintstagedrc.cjs
@@ -40,7 +40,7 @@ const getModuleTestsVue = (files) => {
         '/*.e2e.cy.js'
       );
     } else if (file.includes('/farm_fd2_examples/')) {
-      examples2EntrypointsTested.set(path.basename(path.dirname(file)), true);
+      examplesEntrypointsTested.set(path.basename(path.dirname(file)), true);
       return (
         'test.bash --examples --e2e --live --glob=' +
         '/modules/farm_fd2_examples/src/entrypoints/' +

--- a/.lintstagedrc.cjs
+++ b/.lintstagedrc.cjs
@@ -2,6 +2,8 @@ const { ESLint } = require('eslint');
 const path = require('path');
 
 const fd2EntrypointsTested = new Map();
+const examplesEntrypointsTested = new Map();
+const schoolEntrypointsTested = new Map();
 
 /*
  * lint-staged provides the command for each pattern with an explicit
@@ -38,6 +40,7 @@ const getModuleTestsVue = (files) => {
         '/*.e2e.cy.js'
       );
     } else if (file.includes('/farm_fd2_examples/')) {
+      examples2EntrypointsTested.set(path.basename(path.dirname(file)), true);
       return (
         'test.bash --examples --e2e --live --glob=' +
         '/modules/farm_fd2_examples/src/entrypoints/' +
@@ -45,6 +48,7 @@ const getModuleTestsVue = (files) => {
         '/*.e2e.cy.js'
       );
     } else if (file.includes('/farm_fd2_school/')) {
+      schoolEntrypointsTested.set(path.basename(path.dirname(file)), true);
       return (
         'test.bash --school --e2e --live --glob=' +
         '/modules/farm_fd2_school/src/entrypoints/' +
@@ -77,15 +81,23 @@ const getModuleTestsE2ECyJs = (files) => {
         );
       }
     } else if (file.includes('/farm_fd2_examples/')) {
-      return (
-        'test.bash --examples --e2e --live --glob=' +
-        file.substring(file.indexOf('/modules'))
-      );
+      if (examplesEntrypointsTested.get(path.basename(path.dirname(file)))) {
+        return 'skipping ' + file;
+      } else {
+        return (
+          'test.bash --examples --e2e --live --glob=' +
+          file.substring(file.indexOf('/modules'))
+        );
+      }
     } else if (file.includes('/farm_fd2_school/')) {
-      return (
-        'test.bash --school --e2e --live --glob=' +
-        file.substring(file.indexOf('/modules'))
-      );
+      if (schoolEntrypointsTested.get(path.basename(path.dirname(file)))) {
+        return 'skipping ' + file;
+      } else {
+        return (
+          'test.bash --school --e2e --live --glob=' +
+          file.substring(file.indexOf('/modules'))
+        );
+      }
     } else {
       console.log('.cy.js file found in unrecognized module.');
       console.log(
@@ -93,12 +105,6 @@ const getModuleTestsE2ECyJs = (files) => {
       );
     }
   });
-
-  // Remove any previously run tests.
-  const prevTests = getModuleTestsVue(files);
-  testCommands = testCommands.filter(
-    (testCommand) => !prevTests.includes(testCommand)
-  );
 
   return testCommands;
 };

--- a/.lintstagedrc.cjs
+++ b/.lintstagedrc.cjs
@@ -8,6 +8,7 @@ const fd2LibsTested = new Map();
 const examplesLibsTested = new Map();
 const schoolLibsTested = new Map();
 const compsTested = new Map();
+const libsTested = new Map();
 
 /*
  * lint-staged provides the command for each pattern with an explicit
@@ -241,6 +242,7 @@ const getCompTestsCompCyJs = (files) => {
  */
 const getLibTestsJs = (files) => {
   const testCommands = files.map((file) => {
+    libsTested.set(path.basename(path.dirname(file)), true);
     return (
       'test.bash --unit --lib --glob=' +
       '/library/' +
@@ -257,10 +259,14 @@ const getLibTestsJs = (files) => {
  */
 const getLibTestsUnitCyJs = (files) => {
   const testCommands = files.map((file) => {
-    return (
-      'test.bash --unit --lib --glob=' +
-      file.substring(file.indexOf('/library'))
-    );
+    if (libsTested.get(path.basename(path.dirname(file)))) {
+      return 'skipping ' + file;
+    } else {
+      return (
+        'test.bash --unit --lib --glob=' +
+        file.substring(file.indexOf('/library'))
+      );
+    }
   });
 
   return testCommands;

--- a/.lintstagedrc.cjs
+++ b/.lintstagedrc.cjs
@@ -1,6 +1,8 @@
 const { ESLint } = require('eslint');
 const path = require('path');
 
+const modulesTested = new Map();
+
 /*
  * lint-staged provides the command for each pattern with an explicit
  * list of files.  If one of those files is ignored by .eslintignore
@@ -27,6 +29,9 @@ const removeIgnoredFiles = async (files) => {
  */
 const getModuleTestsVue = (files) => {
   const testCommands = files.map((file) => {
+    // note the module being tested so we don't re-run individual test files.
+    modulesTested.set(path.basename(path.dirname(file)), true);
+
     if (file.includes('/farm_fd2/')) {
       return (
         'test.bash --fd2 --e2e --live --glob=' +
@@ -65,10 +70,13 @@ const getModuleTestsVue = (files) => {
 const getModuleTestsE2ECyJs = (files) => {
   testCommands = files.map((file) => {
     if (file.includes('/farm_fd2/')) {
-      return (
-        'test.bash --fd2 --e2e --live --glob=' +
-        file.substring(file.indexOf('/modules'))
-      );
+      // Skip this if the module has already been tested
+      if (!modulesTested.get(`farm_fd2`)) {
+        return (
+          'test.bash --fd2 --e2e --live --glob=' +
+          file.substring(file.indexOf('/modules'))
+        );
+      }
     } else if (file.includes('/farm_fd2_examples/')) {
       return (
         'test.bash --examples --e2e --live --glob=' +

--- a/.lintstagedrc.cjs
+++ b/.lintstagedrc.cjs
@@ -1,7 +1,7 @@
 const { ESLint } = require('eslint');
 const path = require('path');
 
-const modulesTested = new Map();
+const fd2EntrypointsTested = new Map();
 
 /*
  * lint-staged provides the command for each pattern with an explicit
@@ -29,10 +29,8 @@ const removeIgnoredFiles = async (files) => {
  */
 const getModuleTestsVue = (files) => {
   const testCommands = files.map((file) => {
-    // note the module being tested so we don't re-run individual test files.
-    modulesTested.set(path.basename(path.dirname(file)), true);
-
     if (file.includes('/farm_fd2/')) {
+      fd2EntrypointsTested.set(path.basename(path.dirname(file)), true);
       return (
         'test.bash --fd2 --e2e --live --glob=' +
         '/modules/farm_fd2/src/entrypoints/' +
@@ -70,8 +68,8 @@ const getModuleTestsVue = (files) => {
 const getModuleTestsE2ECyJs = (files) => {
   testCommands = files.map((file) => {
     if (file.includes('/farm_fd2/')) {
-      // Skip this if the module has already been tested
-      if (!modulesTested.get(`farm_fd2`)) {
+      // Skip this if the entrypoint has already been tested
+      if (!fd2EntrypointsTested.get(path.basename(path.dirname(file)))) {
         return (
           'test.bash --fd2 --e2e --live --glob=' +
           file.substring(file.indexOf('/modules'))

--- a/.lintstagedrc.cjs
+++ b/.lintstagedrc.cjs
@@ -63,7 +63,7 @@ const getModuleTestsVue = (files) => {
  * Construct a test command for each entrypoint e2e.cy.js file that is staged.
  */
 const getModuleTestsE2ECyJs = (files) => {
-  const testCommands = files.map((file) => {
+  testCommands = files.map((file) => {
     if (file.includes('/farm_fd2/')) {
       return (
         'test.bash --fd2 --e2e --live --glob=' +
@@ -86,6 +86,12 @@ const getModuleTestsE2ECyJs = (files) => {
       );
     }
   });
+
+  // Remove any previously run tests.
+  const prevTests = getModuleTestsVue(files);
+  testCommands = testCommands.filter(
+    (testCommand) => !prevTests.includes(testCommand)
+  );
 
   return testCommands;
 };

--- a/.lintstagedrc.cjs
+++ b/.lintstagedrc.cjs
@@ -75,7 +75,7 @@ const getModuleTestsVue = (files) => {
  * Construct a test command for each entrypoint e2e.cy.js file that is staged.
  */
 const getModuleTestsE2ECyJs = (files) => {
-  testCommands = files.map((file) => {
+  const testCommands = files.map((file) => {
     if (file.includes('/farm_fd2/')) {
       if (fd2EntrypointsTested.get(path.basename(path.dirname(file)))) {
         return 'skipping ' + file;

--- a/.lintstagedrc.cjs
+++ b/.lintstagedrc.cjs
@@ -68,9 +68,8 @@ const getModuleTestsVue = (files) => {
 const getModuleTestsE2ECyJs = (files) => {
   testCommands = files.map((file) => {
     if (file.includes('/farm_fd2/')) {
-      // Skip this if the entrypoint has already been tested
       if (fd2EntrypointsTested.get(path.basename(path.dirname(file)))) {
-        return 'stat --printf="Skipping %n" file';
+        return 'skipping ' + file;
       } else {
         return (
           'test.bash --fd2 --e2e --live --glob=' +

--- a/.lintstagedrc.cjs
+++ b/.lintstagedrc.cjs
@@ -4,7 +4,9 @@ const path = require('path');
 const fd2EntrypointsTested = new Map();
 const examplesEntrypointsTested = new Map();
 const schoolEntrypointsTested = new Map();
-
+const fd2LibsTested = new Map();
+const examplesLibsTested = new Map();
+const schoolLibsTested = new Map();
 /*
  * lint-staged provides the command for each pattern with an explicit
  * list of files.  If one of those files is ignored by .eslintignore
@@ -116,6 +118,7 @@ const getModuleTestsE2ECyJs = (files) => {
 const getModuleTestsJs = (files) => {
   const testCommands = files.map((file) => {
     if (file.includes('/farm_fd2/')) {
+      fd2LibsTested.set(path.basename(path.dirname(file)), true);
       return (
         'test.bash --fd2 --unit --glob=' +
         '/modules/farm_fd2/src/entrypoints/' +
@@ -123,6 +126,7 @@ const getModuleTestsJs = (files) => {
         '/lib.*.unit.cy.js'
       );
     } else if (file.includes('/farm_fd2_examples/')) {
+      examplesLibsTested.set(path.basename(path.dirname(file)), true);
       return (
         'test.bash --examples --unit --glob=' +
         '/modules/farm_fd2_examples/src/entrypoints/' +
@@ -130,6 +134,7 @@ const getModuleTestsJs = (files) => {
         '/lib.*.unit.cy.js'
       );
     } else if (file.includes('/farm_fd2_school/')) {
+      schoolLibsTested.set(path.basename(path.dirname(file)), true);
       return (
         'test.bash --school --unit --glob=' +
         '/modules/farm_fd2_school/src/entrypoints/' +
@@ -154,20 +159,32 @@ const getModuleTestsJs = (files) => {
 const getModuleTestsUnitCyJs = (files) => {
   const testCommands = files.map((file) => {
     if (file.includes('/farm_fd2/')) {
-      return (
-        'test.bash --fd2 --unit --glob=' +
-        file.substring(file.indexOf('/modules'))
-      );
+      if (fd2LibsTested.get(path.basename(path.dirname(file)))) {
+        return 'skipping ' + file;
+      } else {
+        return (
+          'test.bash --fd2 --unit --glob=' +
+          file.substring(file.indexOf('/modules'))
+        );
+      }
     } else if (file.includes('/farm_fd2_examples/')) {
-      return (
-        'test.bash --examples --unit --glob=' +
-        file.substring(file.indexOf('/modules'))
-      );
+      if (examplesLibsTested.get(path.basename(path.dirname(file)))) {
+        return 'skipping ' + file;
+      } else {
+        return (
+          'test.bash --examples --unit --glob=' +
+          file.substring(file.indexOf('/modules'))
+        );
+      }
     } else if (file.includes('/farm_fd2_school/')) {
-      return (
-        'test.bash --school --unit --glob=' +
-        file.substring(file.indexOf('/modules'))
-      );
+      if (schoolEntrypointsTested.get(path.basename(path.dirname(file)))) {
+        return 'skipping ' + file;
+      } else {
+        return (
+          'test.bash --school --unit --glob=' +
+          file.substring(file.indexOf('/modules'))
+        );
+      }
     } else {
       console.log('lib.*.unit.cy.js file found in unrecognized module.');
       console.log(

--- a/.lintstagedrc.cjs
+++ b/.lintstagedrc.cjs
@@ -7,6 +7,8 @@ const schoolEntrypointsTested = new Map();
 const fd2LibsTested = new Map();
 const examplesLibsTested = new Map();
 const schoolLibsTested = new Map();
+const compsTested = new Map();
+
 /*
  * lint-staged provides the command for each pattern with an explicit
  * list of files.  If one of those files is ignored by .eslintignore
@@ -203,6 +205,7 @@ const getModuleTestsUnitCyJs = (files) => {
  */
 const getCompTestsVue = (files) => {
   const testCommands = files.map((file) => {
+    compsTested.set(path.basename(path.dirname(file)), true);
     return (
       'test.bash --comp --glob=' +
       '/components/' +
@@ -219,9 +222,13 @@ const getCompTestsVue = (files) => {
  */
 const getCompTestsCompCyJs = (files) => {
   const testCommands = files.map((file) => {
-    return (
-      'test.bash --comp --glob=' + file.substring(file.indexOf('/components'))
-    );
+    if (compsTested.get(path.basename(path.dirname(file)))) {
+      return 'skipping ' + file;
+    } else {
+      return (
+        'test.bash --comp --glob=' + file.substring(file.indexOf('/components'))
+      );
+    }
   });
 
   return testCommands;

--- a/bin/skipping
+++ b/bin/skipping
@@ -1,0 +1,8 @@
+#/bin/bash
+
+# This script is used in lintstagedrc.cjs to skip test files 
+# that have already been run.  It is a bit of a hack because
+# lintstagedrc.cjs requires a command for each staged file.
+# So we just use this command.
+
+sleep 1

--- a/bin/skipping
+++ b/bin/skipping
@@ -1,6 +1,6 @@
-#/bin/bash
+#!/bin/bash
 
-# This script is used in lintstagedrc.cjs to skip test files 
+# This script is used in lintstagedrc.cjs to skip test files
 # that have already been run.  It is a bit of a hack because
 # lintstagedrc.cjs requires a command for each staged file.
 # So we just use this command.


### PR DESCRIPTION
**Pull Request Description**

Lint staged would run all test files for modified entrypoints, components, or library files.  It would then run any individually changed test files.  This if both entrypoint file (.vue) and a test file (.e2e.cy.js) were staged, the e2e.cy.js file would have been run twice.  This PR removes that redundant testing.

Closes #33 

---

**Licensing Certification**

FarmData2 is a [Free Cultural Work](https://freedomdefined.org/Definition) and all accepted contributions are licensed as described in the LICENSE.md file. This requires that the contributor holds the rights to do so. By submitting this pull request **I certify that I satisfy the terms of the [Developer Certificate of Origin](https://developercertificate.org/)** for its contents.

Co-authored-by: Ty Chermsirivatana <28925758+WarpWing@users.noreply.github.com>