### PR TITLE
fix(comp): ActivePlantAssetPicklist - shows BedPicker and Picklist as appropriate

### DIFF
--- a/components/ActivePlantAssetPicklist/ActivePlantAssetPicklist.behavior.comp.cy.js
+++ b/components/ActivePlantAssetPicklist/ActivePlantAssetPicklist.behavior.comp.cy.js
@@ -94,4 +94,142 @@ describe('Test the ActivePlantAssetPicklist component behavior', () => {
         });
     });
   });
+
+  it('Should show Picklist and BedPicker component when the location changes from CHUAU to ALF', () => {
+    const readySpy = cy.spy().as('readySpy');
+
+    cy.mount(ActivePlantAssetPicklist, {
+      props: {
+        location: 'CHUAU',
+        isInGround: true,
+        isInTrays: true,
+        onReady: readySpy,
+      },
+    }).then(({ wrapper }) => {
+      cy.get('@readySpy')
+        .should('have.been.calledOnce')
+        .then(() => {
+          cy.get('[data-cy="active-plant-asset-picklist"]').should(
+            'be.visible'
+          );
+          cy.get('[data-cy="active-plant-asset-bed-picker"]').should(
+            'be.visible'
+          );
+        })
+        .then(() => {
+          wrapper.setProps({
+            location: 'ALF',
+          });
+
+          cy.get('[data-cy="active-plant-asset-picklist"]').should(
+            'be.visible'
+          );
+          cy.get('[data-cy="active-plant-asset-bed-picker"]').should(
+            'be.visible'
+          );
+        });
+    });
+  });
+
+  it('Should hide Picklist and show BedPicker component when the location changes from ALF to H', () => {
+    const readySpy = cy.spy().as('readySpy');
+
+    cy.mount(ActivePlantAssetPicklist, {
+      props: {
+        location: 'ALF',
+        isInGround: true,
+        isInTrays: true,
+        onReady: readySpy,
+      },
+    }).then(({ wrapper }) => {
+      cy.get('@readySpy')
+        .should('have.been.calledOnce')
+        .then(() => {
+          cy.get('[data-cy="active-plant-asset-picklist"]').should(
+            'be.visible'
+          );
+          cy.get('[data-cy="active-plant-asset-bed-picker"]').should(
+            'be.visible'
+          );
+        })
+        .then(() => {
+          wrapper.setProps({
+            location: 'H',
+          });
+
+          cy.get('[data-cy="active-plant-asset-picklist"]').should('not.exist');
+          cy.get('[data-cy="active-plant-asset-bed-picker"]').should(
+            'be.visible'
+          );
+        });
+    });
+  });
+
+  it('Should show Picklist and hide BedPicker component when the location changes from H to A', () => {
+    const readySpy = cy.spy().as('readySpy');
+
+    cy.mount(ActivePlantAssetPicklist, {
+      props: {
+        location: 'H',
+        isInGround: true,
+        isInTrays: true,
+        onReady: readySpy,
+      },
+    }).then(({ wrapper }) => {
+      cy.get('@readySpy')
+        .should('have.been.calledOnce')
+        .then(() => {
+          cy.get('[data-cy="active-plant-asset-picklist"]').should('not.exist');
+          cy.get('[data-cy="active-plant-asset-bed-picker"]').should(
+            'be.visible'
+          );
+        })
+        .then(() => {
+          wrapper.setProps({
+            location: 'A',
+          });
+
+          cy.get('[data-cy="active-plant-asset-picklist"]').should(
+            'be.visible'
+          );
+          cy.get('[data-cy="active-plant-asset-bed-picker"]').should(
+            'not.exist'
+          );
+        });
+    });
+  });
+
+  it('Should hide Picklist and BedPicker component when the location changes from A to J', () => {
+    const readySpy = cy.spy().as('readySpy');
+
+    cy.mount(ActivePlantAssetPicklist, {
+      props: {
+        location: 'A',
+        isInGround: true,
+        isInTrays: true,
+        onReady: readySpy,
+      },
+    }).then(({ wrapper }) => {
+      cy.get('@readySpy')
+        .should('have.been.calledOnce')
+        .then(() => {
+          cy.get('[data-cy="active-plant-asset-picklist"]').should(
+            'be.visible'
+          );
+          cy.get('[data-cy="active-plant-asset-bed-picker"]').should(
+            'not.exist'
+          );
+        })
+        .then(() => {
+          wrapper.setProps({
+            location: 'J',
+          });
+
+          cy.get('[data-cy="active-plant-asset-picklist"]').should('not.exist');
+          cy.get('[data-cy="active-plant-asset-bed-picker"]').should(
+            'not.exist'
+          );
+        });
+    });
+  });
 });

--- a/components/ActivePlantAssetPicklist/ActivePlantAssetPicklist.behavior.comp.cy.js
+++ b/components/ActivePlantAssetPicklist/ActivePlantAssetPicklist.behavior.comp.cy.js
@@ -95,12 +95,12 @@ describe('Test the ActivePlantAssetPicklist component behavior', () => {
     });
   });
 
-  it('Should show Picklist and BedPicker component when the location changes from CHUAU to ALF', () => {
+  it('Shows Picklist and BedPicker when switching from "A" to "ALF"', () => {
     const readySpy = cy.spy().as('readySpy');
 
     cy.mount(ActivePlantAssetPicklist, {
       props: {
-        location: 'CHUAU',
+        location: 'A',
         isInGround: true,
         isInTrays: true,
         onReady: readySpy,
@@ -113,7 +113,7 @@ describe('Test the ActivePlantAssetPicklist component behavior', () => {
             'be.visible'
           );
           cy.get('[data-cy="active-plant-asset-bed-picker"]').should(
-            'be.visible'
+            'not.exist'
           );
         })
         .then(() => {
@@ -131,7 +131,7 @@ describe('Test the ActivePlantAssetPicklist component behavior', () => {
     });
   });
 
-  it('Should hide Picklist and show BedPicker component when the location changes from ALF to H', () => {
+  it('Hide Picklist and show BedPicker when switching from ALF to H', () => {
     const readySpy = cy.spy().as('readySpy');
 
     cy.mount(ActivePlantAssetPicklist, {
@@ -165,7 +165,7 @@ describe('Test the ActivePlantAssetPicklist component behavior', () => {
     });
   });
 
-  it('Should show Picklist and hide BedPicker component when the location changes from H to A', () => {
+  it('Show Picklist and hide BedPicker when switching from H to A', () => {
     const readySpy = cy.spy().as('readySpy');
 
     cy.mount(ActivePlantAssetPicklist, {
@@ -199,7 +199,7 @@ describe('Test the ActivePlantAssetPicklist component behavior', () => {
     });
   });
 
-  it('Should hide Picklist and BedPicker component when the location changes from A to J', () => {
+  it('Hide Picklist and BedPicker when switching from A to J', () => {
     const readySpy = cy.spy().as('readySpy');
 
     cy.mount(ActivePlantAssetPicklist, {

--- a/components/ActivePlantAssetPicklist/ActivePlantAssetPicklist.content.comp.cy.js
+++ b/components/ActivePlantAssetPicklist/ActivePlantAssetPicklist.content.comp.cy.js
@@ -174,4 +174,95 @@ describe('Test the default ActivePlantAssetPicklist content', () => {
           .should('have.value', 'CHUAU-5');
       });
   });
+
+  it('Checks active plant assets are fetched and run component tests on them', () => {
+    const readySpy = cy.spy().as('readySpy');
+
+    cy.mount(ActivePlantAssetPicklist, {
+      props: {
+        isInGround: true,
+        isInTrays: true,
+        location: 'A',
+        onReady: readySpy,
+      },
+    });
+
+    cy.get('@readySpy')
+      .should('have.been.calledOnce')
+      .then(() => {
+        cy.get('[data-cy^="picklist-crop-"]')
+          .its('length')
+          .then((count) => {
+            expect(count).to.equal(5);
+          });
+
+        cy.get('[data-cy="active-plant-asset-picklist"]').should('be.visible');
+        cy.get('[data-cy="active-plant-asset-bed-picker"]').should('not.exist');
+      });
+  });
+
+  it('Checks active plant assets are fetched and run component tests on them', () => {
+    const readySpy = cy.spy().as('readySpy');
+
+    cy.mount(ActivePlantAssetPicklist, {
+      props: {
+        isInGround: true,
+        isInTrays: true,
+        location: 'ALF',
+        onReady: readySpy,
+      },
+    });
+
+    cy.get('@readySpy')
+      .should('have.been.calledOnce')
+      .then(() => {
+        cy.get('[data-cy^="picklist-crop-"]')
+          .its('length')
+          .then((count) => {
+            expect(count).to.equal(3);
+          });
+
+        cy.get('[data-cy="active-plant-asset-picklist"]').should('exist');
+        cy.get('[data-cy="active-plant-asset-bed-picker"]').should('exist');
+
+        cy.get('[data-cy="picklist-crop-0"]').should(
+          'have.text',
+          'PEPPERS-BELL'
+        );
+        cy.get('[data-cy="picklist-crop-2"]').should(
+          'have.text',
+          'LETTUCE-ICEBERG'
+        );
+
+        cy.get('[data-cy="picklist-bed-0"]').should('exist');
+        cy.get('[data-cy="picklist-bed-0"]').should('have.text', 'ALF-1');
+        cy.get('[data-cy="picklist-bed-2"]').should('exist');
+        cy.get('[data-cy="picklist-bed-2"]').should('have.text', 'ALF-2');
+      });
+  });
+
+  it('Checks active plant assets are fetched and run component tests on them', () => {
+    cy.mount(ActivePlantAssetPicklist, {
+      props: {
+        isInGround: true,
+        isInTrays: true,
+        location: 'H',
+      },
+    });
+
+    cy.get('[data-cy="active-plant-asset-picklist"]').should('not.exist');
+    cy.get('[data-cy="active-plant-asset-bed-picker"]').should('exist');
+
+    cy.get('[data-cy="picker-options"]').should('exist');
+
+    cy.get('[data-cy="picker-options"] input[name="picker-options"]')
+      .should('have.length', 2)
+      .first()
+      .should('have.value', 'H-1');
+
+    cy.get('[data-cy="picker-options"] input[name="picker-options"]')
+      .should('have.length', 2)
+      .last()
+      .should('have.value', 'H-2');
+  });
 });

--- a/components/ActivePlantAssetPicklist/ActivePlantAssetPicklist.content.comp.cy.js
+++ b/components/ActivePlantAssetPicklist/ActivePlantAssetPicklist.content.comp.cy.js
@@ -175,7 +175,7 @@ describe('Test the default ActivePlantAssetPicklist content', () => {
       });
   });
 
-  it('Checks active plant assets are fetched and run component tests on them', () => {
+  it('Shows Picklist but not BedPicker for "A"', () => {
     const readySpy = cy.spy().as('readySpy');
 
     cy.mount(ActivePlantAssetPicklist, {
@@ -201,7 +201,7 @@ describe('Test the default ActivePlantAssetPicklist content', () => {
       });
   });
 
-  it('Checks active plant assets are fetched and run component tests on them', () => {
+  it('Shows Picklist and BedPicker for "ALF', () => {
     const readySpy = cy.spy().as('readySpy');
 
     cy.mount(ActivePlantAssetPicklist, {
@@ -241,7 +241,7 @@ describe('Test the default ActivePlantAssetPicklist content', () => {
       });
   });
 
-  it('Checks active plant assets are fetched and run component tests on them', () => {
+  it('Shows BedPicker but no Picklist for "H', () => {
     cy.mount(ActivePlantAssetPicklist, {
       props: {
         isInGround: true,

--- a/components/ActivePlantAssetPicklist/ActivePlantAssetPicklist.content.comp.cy.js
+++ b/components/ActivePlantAssetPicklist/ActivePlantAssetPicklist.content.comp.cy.js
@@ -23,15 +23,15 @@ describe('Test the default ActivePlantAssetPicklist content', () => {
     cy.get('@readySpy')
       .should('have.been.calledOnce')
       .then(() => {
-        cy.get('[data-cy="active-plant-asset-picklist"]').should('exist');
+        cy.get('[data-cy="active-plant-asset-picklist"]').should('not.exist');
         cy.get('[data-cy="active-plant-asset-bed-picker"]').should('not.exist');
 
-        cy.get('[data-cy="picklist-table"]').should('exist');
+        cy.get('[data-cy="picklist-table"]').should('not.exist');
         cy.get('[data-cy="picklist-all-button"]').should('not.exist');
         cy.get('[data-cy="picklist-units-button"]').should('not.exist');
-        cy.get('[data-cy="picklist-header-crop"]').should('be.visible');
-        cy.get('[data-cy="picklist-header-bed"]').should('be.visible');
-        cy.get('[data-cy="picklist-header-planted-date"]').should('be.visible');
+        cy.get('[data-cy="picklist-header-crop"]').should('not.exist');
+        cy.get('[data-cy="picklist-header-bed"]').should('not.exist');
+        cy.get('[data-cy="picklist-header-planted-date"]').should('not.exist');
 
         cy.get('[data-cy="picklist-row-0"]').should('not.exist');
       });

--- a/components/ActivePlantAssetPicklist/ActivePlantAssetPicklist.vue
+++ b/components/ActivePlantAssetPicklist/ActivePlantAssetPicklist.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="active-plant-asset-picklist-container">
     <BedPicker
-      v-if="location"
+      v-if="location && showBedPicker"
       id="active-plant-asset-bed-picker"
       data-cy="active-plant-asset-bed-picker"
       v-bind:required="required"
@@ -153,6 +153,7 @@ export default {
       bedsValid: false,
       picklistValid: false,
       updateInProgress: false, // flag to ensure one update cycle
+      showBedPicker: true, // New property to control BedPicker visibility
     };
   },
   computed: {
@@ -165,7 +166,7 @@ export default {
     },
 
     isValid() {
-      return this.picklistValid && this.bedsValid;
+      return this.picklistValid && (this.showBedPicker ? this.bedsValid : true);
     },
   },
 
@@ -416,6 +417,7 @@ export default {
               crop: 'Crop',
               timestamp: 'Planted Date',
             };
+            this.showBedPicker = false;
           } else {
             this.picklistColumns = ['crop', 'bed', 'timestamp'];
             this.picklistLabels = {
@@ -423,6 +425,7 @@ export default {
               bed: 'Bed',
               timestamp: 'Planted Date',
             };
+            this.showBedPicker = true;
           }
 
           if (this.pickedRow.size > 0) {
@@ -457,6 +460,7 @@ export default {
         }
       } else {
         this.affectedPlants = [];
+        this.showBedPicker = false; // Hide  BedPicker when no location
       }
     },
 

--- a/components/ActivePlantAssetPicklist/ActivePlantAssetPicklist.vue
+++ b/components/ActivePlantAssetPicklist/ActivePlantAssetPicklist.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="active-plant-asset-picklist-container">
     <BedPicker
-      v-if="location"
+      v-if="location && locationHasBeds"
       id="active-plant-asset-bed-picker"
       data-cy="active-plant-asset-bed-picker"
       v-bind:required="required"
@@ -151,6 +151,7 @@ export default {
         timestamp: 'Planted Date',
       },
       bedsValid: false,
+      bedsInLocation: [],
       picklistValid: false,
       updateInProgress: false, // flag to ensure one update cycle
     };
@@ -158,6 +159,9 @@ export default {
   computed: {
     plantsAtLocation() {
       return this.affectedPlants.length > 0;
+    },
+    locationHasBeds() {
+      return this.bedsInLocation.length > 0;
     },
 
     picklistRequired() {
@@ -477,12 +481,28 @@ export default {
       }
       return true;
     },
+
+    async checkBedsInLocation() {
+      if (this.location) {
+        try {
+          this.bedsInLocation = await farmosUtil.getBedsInLocation(
+            this.location
+          );
+        } catch (error) {
+          console.error('Error fetching beds for location:', error);
+          this.bedsInLocation = [];
+        }
+      } else {
+        this.bedsInLocation = [];
+      }
+    },
   },
 
   watch: {
     location: {
       handler() {
         this.checkPlantsAtLocation();
+        this.checkBedsInLocation();
       },
       immediate: true,
     },

--- a/components/ActivePlantAssetPicklist/ActivePlantAssetPicklist.vue
+++ b/components/ActivePlantAssetPicklist/ActivePlantAssetPicklist.vue
@@ -13,6 +13,7 @@
     />
 
     <PicklistBase
+      v-if="location && plantsAtLocation"
       id="active-plant-asset-picklist"
       data-cy="active-plant-asset-picklist"
       class="w-100"

--- a/components/ActivePlantAssetPicklist/ActivePlantAssetPicklist.vue
+++ b/components/ActivePlantAssetPicklist/ActivePlantAssetPicklist.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="active-plant-asset-picklist-container">
     <BedPicker
-      v-if="location && showBedPicker"
+      v-if="location"
       id="active-plant-asset-bed-picker"
       data-cy="active-plant-asset-bed-picker"
       v-bind:required="required"
@@ -153,7 +153,6 @@ export default {
       bedsValid: false,
       picklistValid: false,
       updateInProgress: false, // flag to ensure one update cycle
-      showBedPicker: true, // New property to control BedPicker visibility
     };
   },
   computed: {
@@ -166,7 +165,7 @@ export default {
     },
 
     isValid() {
-      return this.picklistValid && (this.showBedPicker ? this.bedsValid : true);
+      return this.picklistValid && this.bedsValid;
     },
   },
 
@@ -417,7 +416,6 @@ export default {
               crop: 'Crop',
               timestamp: 'Planted Date',
             };
-            this.showBedPicker = false;
           } else {
             this.picklistColumns = ['crop', 'bed', 'timestamp'];
             this.picklistLabels = {
@@ -425,7 +423,6 @@ export default {
               bed: 'Bed',
               timestamp: 'Planted Date',
             };
-            this.showBedPicker = true;
           }
 
           if (this.pickedRow.size > 0) {
@@ -460,7 +457,6 @@ export default {
         }
       } else {
         this.affectedPlants = [];
-        this.showBedPicker = false; // Hide  BedPicker when no location
       }
     },
 

--- a/library/farmosUtil/farmosUtil.beds.js
+++ b/library/farmosUtil/farmosUtil.beds.js
@@ -8,6 +8,12 @@ import {
   getFarmOSInstance,
 } from './farmosUtil.core.js';
 
+
+import {
+  getFieldNameToAssetMap,
+  getGreenhouseNameToAssetMap,
+  getBeds
+} from './farmos'
 /**
  * Clear the cached results from prior calls to the `getBeds` function.
  * This is useful when an action may change the beds that exist in the
@@ -95,4 +101,45 @@ export async function getBedIdToAssetMap() {
   const beds = await getBeds();
   const map = new Map(beds.map((bed) => [bed.id, bed]));
   return map;
+}
+
+export async function getBedsInLocation(locationName) {
+  try {
+    const [fieldMap, greenhouseMap, beds] = await Promise.all([
+      getFieldNameToAssetMap(),
+      getGreenhouseNameToAssetMap(),
+      getBeds(),
+    ]);
+
+    let field = fieldMap.get(locationName);
+    let greenhouse = greenhouseMap.get(locationName);
+    letlocationId = null;
+
+    if (field) {
+      locationId = field.id;
+    } else if (greenhouse) {
+      locationId = greenhouse.id;
+    } else {
+      console.warn(
+        `getBedsInLocation: Unable to find location: ${locationName}`
+      );
+      return [];
+    }
+
+    if (!locationId) {
+      return [];
+    }
+
+    const bedsInLocation = beds.filter((bed) => {
+      return bed.relationships.parent[0].id === locationId;
+    });
+
+    return bedsInLocation;
+  } catch (error) {
+    console.error(
+      'getBedsInLocation: Unable to get beds in location: ' + locationName,
+      error
+    );
+    return [];
+  }
 }

--- a/library/farmosUtil/farmosUtil.beds.js
+++ b/library/farmosUtil/farmosUtil.beds.js
@@ -105,14 +105,9 @@ export async function getBedIdToAssetMap() {
  *
  * NOTE: This function makes a call to
  * [`getBeds`]{@link #module_farmosUtil.getBeds}
- * and builds the `Map` using the returned `Array<Object>`.
  *
  * This function queries the farm management system to find all beds
- * that belong to the specified location. The returned bed identifiers
- * can be used for filtering plant assets, validation, or display purposes.
- * @throws {Error} if unable to fetch the beds.
- *
- *
+ * that belong to the specified location.
  *
  * @category Beds
  * }

--- a/library/farmosUtil/farmosUtil.beds.js
+++ b/library/farmosUtil/farmosUtil.beds.js
@@ -8,12 +8,6 @@ import {
   getFarmOSInstance,
 } from './farmosUtil.core.js';
 
-
-import {
-  getFieldNameToAssetMap,
-  getGreenhouseNameToAssetMap,
-  getBeds
-} from './farmos'
 /**
  * Clear the cached results from prior calls to the `getBeds` function.
  * This is useful when an action may change the beds that exist in the

--- a/library/farmosUtil/farmosUtil.beds.js
+++ b/library/farmosUtil/farmosUtil.beds.js
@@ -8,6 +8,9 @@ import {
   getFarmOSInstance,
 } from './farmosUtil.core.js';
 
+import { getFieldNameToAssetMap } from './farmosUtil.fields.js';
+import { getGreenhouseNameToAssetMap } from './farmosUtil.greenhouses.js';
+
 /**
  * Clear the cached results from prior calls to the `getBeds` function.
  * This is useful when an action may change the beds that exist in the
@@ -107,7 +110,7 @@ export async function getBedsInLocation(locationName) {
 
     let field = fieldMap.get(locationName);
     let greenhouse = greenhouseMap.get(locationName);
-    letlocationId = null;
+    let locationId = null;
 
     if (field) {
       locationId = field.id;

--- a/library/farmosUtil/farmosUtil.beds.js
+++ b/library/farmosUtil/farmosUtil.beds.js
@@ -99,7 +99,24 @@ export async function getBedIdToAssetMap() {
   const map = new Map(beds.map((bed) => [bed.id, bed]));
   return map;
 }
-
+/**
+ * Retrieves all beds associated with a specific location.
+ *
+ *
+ * NOTE: This function makes a call to
+ * [`getBeds`]{@link #module_farmosUtil.getBeds}
+ * and builds the `Map` using the returned `Array<Object>`.
+ *
+ * This function queries the farm management system to find all beds
+ * that belong to the specified location. The returned bed identifiers
+ * can be used for filtering plant assets, validation, or display purposes.
+ * @throws {Error} if unable to fetch the beds.
+ *
+ *
+ *
+ * @category Beds
+ * }
+ */
 export async function getBedsInLocation(locationName) {
   try {
     const [fieldMap, greenhouseMap, beds] = await Promise.all([

--- a/library/farmosUtil/farmosUtil.beds.unit.cy.js
+++ b/library/farmosUtil/farmosUtil.beds.unit.cy.js
@@ -103,6 +103,7 @@ describe('Test the bed utility functions', () => {
     const beds = await farmosUtil.getBedsInLocation('ALF');
 
     console.log(beds);
+    console.log(beds[0]);
 
     // Should have beds
     expect(beds).to.be.an('array');

--- a/library/farmosUtil/farmosUtil.beds.unit.cy.js
+++ b/library/farmosUtil/farmosUtil.beds.unit.cy.js
@@ -102,18 +102,15 @@ describe('Test the bed utility functions', () => {
   it('should return beds for ALF location (field with beds)', async () => {
     const beds = await farmosUtil.getBedsInLocation('ALF');
 
-    console.log(beds);
-    console.log(beds[0]);
-
     // Should have beds
     expect(beds).to.be.an('array');
-    expect(beds.length).to.be.greaterThan(0);
+    expect(beds.length).to.equal(4);
+    expect(beds[0].attributes.name).to.equal('ALF-1');
+
+    expect(beds[3].attributes.name).to.equal('ALF-4');
 
     // Each bed should be a proper bed object
     beds.forEach((bed) => {
-      expect(bed).to.have.property('attributes');
-      expect(bed).to.have.property('relationships');
-      expect(bed.attributes).to.have.property('name');
       expect(bed.attributes.name).to.include('ALF');
     });
 
@@ -135,7 +132,11 @@ describe('Test the bed utility functions', () => {
 
     // Should have beds
     expect(beds).to.be.an('array');
-    expect(beds.length).to.be.greaterThan(0);
+    expect(beds.length).to.equal(5);
+
+    expect(beds[0].attributes.name).to.equal('CHUAU-1');
+
+    expect(beds[4].attributes.name).to.equal('CHUAU-5');
 
     // Each bed should belong to CHUAU
     beds.forEach((bed) => {

--- a/library/farmosUtil/farmosUtil.beds.unit.cy.js
+++ b/library/farmosUtil/farmosUtil.beds.unit.cy.js
@@ -98,4 +98,71 @@ describe('Test the bed utility functions', () => {
       }
     );
   });
+
+  it('should return beds for ALF location (field with beds)', async () => {
+    const beds = await farmosUtil.getBedsInLocation('ALF');
+
+    console.log(beds);
+
+    // Should have beds
+    expect(beds).to.be.an('array');
+    expect(beds.length).to.be.greaterThan(0);
+
+    // Each bed should be a proper bed object
+    beds.forEach((bed) => {
+      expect(bed).to.have.property('attributes');
+      expect(bed).to.have.property('relationships');
+      expect(bed.attributes).to.have.property('name');
+      expect(bed.attributes.name).to.include('ALF');
+    });
+
+    // Verify structure matches what we expect
+    const firstBed = beds[0];
+    expect(firstBed.relationships).to.have.property('parent');
+    expect(firstBed.relationships.parent).to.be.an('array');
+  });
+
+  it('should return empty array for A location (field without beds)', async () => {
+    const beds = await farmosUtil.getBedsInLocation('A');
+
+    expect(beds).to.be.an('array');
+    expect(beds).to.have.length(0);
+  });
+
+  it('should return beds for CHUAU location (greenhouse with beds)', async () => {
+    const beds = await farmosUtil.getBedsInLocation('CHUAU');
+
+    // Should have beds
+    expect(beds).to.be.an('array');
+    expect(beds.length).to.be.greaterThan(0);
+
+    // Each bed should belong to CHUAU
+    beds.forEach((bed) => {
+      expect(bed.attributes.name).to.include('CHUAU');
+    });
+  });
+
+  it('should return empty array for JASMINE location (greenhouse without beds)', async () => {
+    const beds = await farmosUtil.getBedsInLocation('JASMINE');
+
+    expect(beds).to.be.an('array');
+    expect(beds).to.have.length(0);
+  });
+
+  it('should return empty array for non-existent location', async () => {
+    const beds = await farmosUtil.getBedsInLocation('NONEXISTENT');
+
+    expect(beds).to.be.an('array');
+    expect(beds).to.have.length(0);
+  });
+
+  it('should handle null/undefined location gracefully', async () => {
+    const bedsNull = await farmosUtil.getBedsInLocation(null);
+    const bedsUndefined = await farmosUtil.getBedsInLocation(undefined);
+
+    expect(bedsNull).to.be.an('array');
+    expect(bedsNull).to.have.length(0);
+    expect(bedsUndefined).to.be.an('array');
+    expect(bedsUndefined).to.have.length(0);
+  });
 });

--- a/modules/farm_fd2/src/entrypoints/soil_disturbance/soil_disturbance.termination.e2e.cy.js
+++ b/modules/farm_fd2/src/entrypoints/soil_disturbance/soil_disturbance.termination.e2e.cy.js
@@ -75,7 +75,7 @@ describe('Direct Seeding: Termination event group', () => {
     cy.get('[data-cy="termination-event-label"]').should('not.be.visible');
     cy.get('[data-cy="termination-event-picklist"]').should('not.be.visible');
     cy.get('[data-cy="picklist-all-button"]').should('not.exist');
-    cy.get('[data-cy="sort-order-button"]').should('not.be.visible');
+    cy.get('[data-cy="sort-order-button"]').should('not.exist');
     cy.get('[data-cy^="picklist-checkbox-"]').should('not.exist');
 
     cy.get('[data-cy="location-beds-accordion"]').should('exist');
@@ -183,7 +183,7 @@ describe('Direct Seeding: Termination event group', () => {
     cy.get('[data-cy="termination-event-label"]').should('not.be.visible');
     cy.get('[data-cy="termination-event-picklist"]').should('not.be.visible');
     cy.get('[data-cy="picklist-all-button"]').should('not.exist');
-    cy.get('[data-cy="sort-order-button"]').should('not.be.visible');
+    cy.get('[data-cy="sort-order-button"]').should('not.exist');
     cy.get('[data-cy^="picklist-checkbox-"]').should('not.exist');
 
     cy.get('[data-cy="location-beds-accordion"]').should('exist');
@@ -247,7 +247,7 @@ describe('Direct Seeding: Termination event group', () => {
     cy.get('[data-cy="termination-event-label"]').should('not.be.visible');
     cy.get('[data-cy="termination-event-picklist"]').should('not.be.visible');
     cy.get('[data-cy="picklist-all-button"]').should('not.exist');
-    cy.get('[data-cy="sort-order-button"]').should('not.be.visible');
+    cy.get('[data-cy="sort-order-button"]').should('not.exist');
     cy.get('[data-cy^="picklist-checkbox-"]').should('not.exist');
 
     cy.get('[data-cy="location-beds-accordion"]').should('exist');

--- a/modules/farm_fd2_examples/src/entrypoints/active_plant_asset_picklist/active_plant_asset_picklist.exists.e2e.cy.js
+++ b/modules/farm_fd2_examples/src/entrypoints/active_plant_asset_picklist/active_plant_asset_picklist.exists.e2e.cy.js
@@ -1,5 +1,5 @@
 describe('Check that the active_plant_asset_picklist entry point in farm_fd2_examples exists.', () => {
-  it('Check that the page loaded.', () => {
+  it.only('Check that the page loaded.', () => {
     // Login if running in live farmOS.
     cy.login('admin', 'admin');
     // Go to the main page.

--- a/modules/farm_fd2_examples/src/entrypoints/active_plant_asset_picklist/active_plant_asset_picklist.exists.e2e.cy.js
+++ b/modules/farm_fd2_examples/src/entrypoints/active_plant_asset_picklist/active_plant_asset_picklist.exists.e2e.cy.js
@@ -1,5 +1,5 @@
 describe('Check that the active_plant_asset_picklist entry point in farm_fd2_examples exists.', () => {
-  it.only('Check that the page loaded.', () => {
+  it('Check that the page loaded.', () => {
     // Login if running in live farmOS.
     cy.login('admin', 'admin');
     // Go to the main page.


### PR DESCRIPTION
**Pull Request Description**

Changed it to it.only in active plant asset picklist to create PR. Will remove after.

Closes #490

---

**Licensing Certification**

FarmData2 is a [Free Cultural Work](https://freedomdefined.org/Definition) and all accepted contributions are licensed as described in the LICENSE.md file. This requires that the contributor holds the rights to do so. By submitting this pull request **I certify that I satisfy the terms of the [Developer Certificate of Origin](https://developercertificate.org/)** for its contents.
