### PR TITLE
fix(fd2): SoilDisturbance - select all beds if no active plant assets

### DIFF
--- a/components/LocationSelector/LocationSelector.events.comp.cy.js
+++ b/components/LocationSelector/LocationSelector.events.comp.cy.js
@@ -411,4 +411,25 @@ describe('Test the LocationSelector component events', () => {
         .should('have.been.calledWith', 'Unable to fetch locations.');
     });
   });
+
+  it('emits update:beds with full bed list as third argument', () => {
+    const updateBedsSpy = cy.spy().as('updateBedsSpy');
+    cy.mount(LocationSelector, {
+      props: {
+        includeFields: true,
+        onUpdate: { beds: updateBedsSpy },
+      },
+    });
+
+    // Select a location with beds (e.g., "H")
+    cy.get('[data-cy="selector-input"]').select('H');
+    cy.get('@updateBedsSpy').should('have.been.called');
+
+    cy.get('@updateBedsSpy').then((spy) => {
+      const args = spy.lastCall.args;
+      expect(Array.isArray(args[2])).to.be.true; // third arg is array
+      expect(args[2].length).to.be.greaterThan(0); // should have beds
+      expect(args[2]).to.include('H-1'); // example bed
+    });
+  });
 });

--- a/components/LocationSelector/LocationSelector.vue
+++ b/components/LocationSelector/LocationSelector.vue
@@ -418,14 +418,8 @@ export default {
          * The selected beds have changed.
          * @property {Array<string>} checkedBeds an array containing the names of the selected beds.
          * @property {number} totalBeds the total number of beds in the selected location.
-         * @property {Array<string>} allBeds the full list of beds for the selected location.
          */
-        this.$emit(
-          'update:beds',
-          this.checkedBeds,
-          this.beds.length,
-          this.beds
-        );
+        this.$emit('update:beds', this.checkedBeds, this.beds.length);
       },
       deep: true,
     },
@@ -438,6 +432,22 @@ export default {
        * @property {boolean} event whether the selections are valid or not.
        */
       this.$emit('valid', this.isValid);
+    },
+    selectAllBedsByDefault: {
+      handler(newVal) {
+        if (newVal && this.beds.length > 0) {
+          this.checkedBeds = [...this.beds];
+        }
+      },
+      immediate: true,
+    },
+    beds: {
+      handler(newBeds) {
+        if (this.selectAllBedsByDefault && newBeds.length > 0) {
+          this.checkedBeds = [...newBeds];
+        }
+      },
+      immediate: true,
     },
   },
   created() {

--- a/components/LocationSelector/LocationSelector.vue
+++ b/components/LocationSelector/LocationSelector.vue
@@ -418,8 +418,14 @@ export default {
          * The selected beds have changed.
          * @property {Array<string>} checkedBeds an array containing the names of the selected beds.
          * @property {number} totalBeds the total number of beds in the selected location.
+         * @property {Array<string>} allBeds the full list of beds for the selected location.
          */
-        this.$emit('update:beds', this.checkedBeds, this.beds.length);
+        this.$emit(
+          'update:beds',
+          this.checkedBeds,
+          this.beds.length,
+          this.beds
+        );
       },
       deep: true,
     },

--- a/modules/farm_fd2/src/entrypoints/soil_disturbance/App.vue
+++ b/modules/farm_fd2/src/entrypoints/soil_disturbance/App.vue
@@ -52,9 +52,10 @@
           v-model:selected="form.location"
           v-bind:pickedBeds="form.beds"
           v-bind:allowBedSelection="!plantsAtLocation"
+          v-bind:selectAllBedsByDefault="!plantsAtLocation"
           v-bind:showValidityStyling="validity.show"
           v-on:valid="validity.location = $event"
-          v-on:update:beds="onBedsUpdate"
+          v-on:update:beds="handleBedsUpdate"
           v-on:update:selected="form.location = $event"
           v-on:error="(msg) => showErrorToast('Network Error', msg)"
           v-on:ready="createdCount++"
@@ -234,10 +235,6 @@ export default {
         timestamp: 'Planted Date',
       },
       picklistValid: false,
-      allBedsForLocation: [],
-      autoSelectAttemptedForLocation: null,
-      plantAssetStatusKnown: false,
-      pendingBedsUpdate: null,
     };
   },
   computed: {
@@ -260,31 +257,11 @@ export default {
     },
   },
   methods: {
-    onBedsUpdate(checkedBeds, totalBeds, allBeds) {
-      this.pendingBedsUpdate = { checkedBeds, totalBeds, allBeds };
-      this.tryHandleBedsUpdate();
-    },
-    tryHandleBedsUpdate() {
-      if (this.plantAssetStatusKnown && this.pendingBedsUpdate) {
-        const { checkedBeds, totalBeds, allBeds } = this.pendingBedsUpdate;
-        this.handleBedsUpdate(checkedBeds, totalBeds, allBeds);
-        this.pendingBedsUpdate = null;
-      }
-    },
-    handleBedsUpdate(checkedBeds, totalBeds, allBeds) {
-      this.allBedsForLocation = allBeds || [];
-      if (
-        this.allBedsForLocation.length > 0 &&
-        !this.plantsAtLocation &&
-        this.form.beds.length !== this.allBedsForLocation.length
-      ) {
-        this.form.beds = [...this.allBedsForLocation];
-      } else {
-        this.form.beds = checkedBeds;
-      }
+    handleBedsUpdate(checkedBeds, totalBeds) {
+      this.form.beds = checkedBeds;
       this.form.area =
         totalBeds > 0
-          ? Math.round((this.form.beds.length / totalBeds) * 100)
+          ? Math.round((checkedBeds.length / totalBeds) * 100)
           : 100;
     },
     submit() {
@@ -357,28 +334,16 @@ export default {
       this.form.termination = false;
       this.form.picked = new Map();
       this.form.area = 100;
-      this.allBedsForLocation = [];
-      this.autoSelectAttemptedForLocation = null;
-      this.plantsAtLocation = false;
-      this.plantAssetStatusKnown = false;
-      this.pendingBedsUpdate = null;
     },
   },
   watch: {
+    plantsAtLocation(newVal) {
+      if (!newVal) {
+        this.form.termination = false;
+      }
+    },
     pickedValidity(newVal) {
       this.validity.picked = newVal;
-    },
-    plantsAtLocation: {
-      handler() {
-        this.$emit('hasPlants', this.plantsAtLocation);
-        this.plantAssetStatusKnown = true;
-        this.tryHandleBedsUpdate();
-      },
-      immediate: false,
-    },
-    'form.location'() {
-      this.plantAssetStatusKnown = false;
-      this.pendingBedsUpdate = null;
     },
   },
   created() {

--- a/modules/farm_fd2/src/entrypoints/soil_disturbance/App.vue
+++ b/modules/farm_fd2/src/entrypoints/soil_disturbance/App.vue
@@ -261,21 +261,10 @@ export default {
   },
   methods: {
     onBedsUpdate(checkedBeds, totalBeds, allBeds) {
-      console.log('[onBedsUpdate] called with:', {
-        checkedBeds,
-        totalBeds,
-        allBeds,
-      });
       this.pendingBedsUpdate = { checkedBeds, totalBeds, allBeds };
       this.tryHandleBedsUpdate();
     },
     tryHandleBedsUpdate() {
-      console.log(
-        '[tryHandleBedsUpdate] plantAssetStatusKnown:',
-        this.plantAssetStatusKnown,
-        'pendingBedsUpdate:',
-        this.pendingBedsUpdate
-      );
       if (this.plantAssetStatusKnown && this.pendingBedsUpdate) {
         const { checkedBeds, totalBeds, allBeds } = this.pendingBedsUpdate;
         this.handleBedsUpdate(checkedBeds, totalBeds, allBeds);
@@ -283,12 +272,6 @@ export default {
       }
     },
     handleBedsUpdate(checkedBeds, totalBeds, allBeds) {
-      console.log('[handleBedsUpdate] called with:', {
-        checkedBeds,
-        totalBeds,
-        allBeds,
-        plantsAtLocation: this.plantsAtLocation,
-      });
       this.allBedsForLocation = allBeds || [];
       if (
         this.allBedsForLocation.length > 0 &&
@@ -296,19 +279,13 @@ export default {
         this.form.beds.length !== this.allBedsForLocation.length
       ) {
         this.form.beds = [...this.allBedsForLocation];
-        console.log(
-          '[handleBedsUpdate] auto-selecting all beds:',
-          this.form.beds
-        );
       } else {
         this.form.beds = checkedBeds;
-        console.log('[handleBedsUpdate] using checkedBeds:', this.form.beds);
       }
       this.form.area =
         totalBeds > 0
           ? Math.round((this.form.beds.length / totalBeds) * 100)
           : 100;
-      console.log('[handleBedsUpdate] form.area set to:', this.form.area);
     },
     submit() {
       this.submitting = true;
@@ -392,18 +369,14 @@ export default {
       this.validity.picked = newVal;
     },
     plantsAtLocation: {
-      handler(newValue) {
-        console.log('[plantsAtLocation watcher] newValue:', newValue);
-        this.$emit('hasPlants', newValue);
+      handler() {
+        this.$emit('hasPlants', this.plantsAtLocation);
         this.plantAssetStatusKnown = true;
         this.tryHandleBedsUpdate();
       },
       immediate: false,
     },
     'form.location'() {
-      console.log(
-        '[form.location watcher] resetting plantAssetStatusKnown and pendingBedsUpdate'
-      );
       this.plantAssetStatusKnown = false;
       this.pendingBedsUpdate = null;
     },

--- a/modules/farm_fd2/src/entrypoints/soil_disturbance/App.vue
+++ b/modules/farm_fd2/src/entrypoints/soil_disturbance/App.vue
@@ -55,7 +55,8 @@
           v-bind:showValidityStyling="validity.show"
           v-on:valid="validity.location = $event"
           v-on:update:beds="
-            (checkedBeds, totalBeds) => handleBedsUpdate(checkedBeds, totalBeds)
+            (checkedBeds, totalBeds, allBeds) =>
+              handleBedsUpdate(checkedBeds, totalBeds, allBeds)
           "
           v-on:update:selected="form.location = $event"
           v-on:error="(msg) => showErrorToast('Network Error', msg)"
@@ -236,6 +237,7 @@ export default {
         timestamp: 'Planted Date',
       },
       picklistValid: false,
+      allBedsForLocation: [],
     };
   },
   computed: {
@@ -258,7 +260,8 @@ export default {
     },
   },
   methods: {
-    handleBedsUpdate(checkedBeds, totalBeds) {
+    handleBedsUpdate(checkedBeds, totalBeds, allBeds) {
+      this.allBedsForLocation = allBeds || [];
       if (!this.plantsAtLocation) {
         this.form.beds = checkedBeds;
         this.form.area =
@@ -341,6 +344,9 @@ export default {
     plantsAtLocation(newVal) {
       if (!newVal) {
         this.form.termination = false;
+        if (this.form.location && this.allBedsForLocation.length > 0) {
+          this.form.beds = [...this.allBedsForLocation];
+        }
       }
     },
     pickedValidity(newVal) {

--- a/modules/farm_fd2/src/entrypoints/soil_disturbance/App.vue
+++ b/modules/farm_fd2/src/entrypoints/soil_disturbance/App.vue
@@ -238,6 +238,7 @@ export default {
       },
       picklistValid: false,
       allBedsForLocation: [],
+      autoSelectAttemptedForLocation: null,
     };
   },
   computed: {
@@ -261,6 +262,11 @@ export default {
   },
   methods: {
     handleBedsUpdate(checkedBeds, totalBeds, allBeds) {
+      console.log('[handleBedsUpdate] update:beds event:');
+      console.log('  Picked beds:', checkedBeds);
+      console.log('  Total beds:', totalBeds);
+      console.log('  All beds:', allBeds);
+      console.log('  plantsAtLocation:', this.plantsAtLocation);
       this.allBedsForLocation = allBeds || [];
       if (!this.plantsAtLocation) {
         this.form.beds = checkedBeds;
@@ -338,6 +344,29 @@ export default {
       this.form.termination = false;
       this.form.picked = new Map();
       this.form.area = 100;
+      this.allBedsForLocation = [];
+      this.autoSelectAttemptedForLocation = null;
+      this.plantsAtLocation = false;
+    },
+    tryAutoSelectBeds() {
+      console.log('[tryAutoSelectBeds] called');
+      console.log('  allBedsForLocation:', this.allBedsForLocation);
+      console.log('  plantsAtLocation:', this.plantsAtLocation);
+      console.log('  form.beds before:', this.form.beds);
+      if (
+        !this.showActivePlantAssetUI &&
+        this.showLocationBedPickerUI &&
+        this.form.beds.length !== this.allBedsForLocation.length &&
+        this.autoSelectAttemptedForLocation !== this.form.location
+      ) {
+        this.form.beds = [...this.allBedsForLocation];
+        this.autoSelectAttemptedForLocation = this.form.location;
+        console.log(
+          '[tryAutoSelectBeds] AUTO-SELECT ALL BEDS for',
+          this.form.location
+        );
+        console.log('  form.beds after:', this.form.beds);
+      }
     },
   },
   watch: {
@@ -351,6 +380,12 @@ export default {
     },
     pickedValidity(newVal) {
       this.validity.picked = newVal;
+    },
+    'form.location'() {
+      this.allBedsForLocation = [];
+      this.autoSelectAttemptedForLocation = null;
+      this.form.beds = [];
+      this.plantsAtLocation = false;
     },
   },
   created() {

--- a/modules/farm_fd2/src/entrypoints/soil_disturbance/App.vue
+++ b/modules/farm_fd2/src/entrypoints/soil_disturbance/App.vue
@@ -54,10 +54,7 @@
           v-bind:allowBedSelection="!plantsAtLocation"
           v-bind:showValidityStyling="validity.show"
           v-on:valid="validity.location = $event"
-          v-on:update:beds="
-            (checkedBeds, totalBeds, allBeds) =>
-              handleBedsUpdate(checkedBeds, totalBeds, allBeds)
-          "
+          v-on:update:beds="onBedsUpdate"
           v-on:update:selected="form.location = $event"
           v-on:error="(msg) => showErrorToast('Network Error', msg)"
           v-on:ready="createdCount++"
@@ -239,6 +236,8 @@ export default {
       picklistValid: false,
       allBedsForLocation: [],
       autoSelectAttemptedForLocation: null,
+      plantAssetStatusKnown: false,
+      pendingBedsUpdate: null,
     };
   },
   computed: {
@@ -261,7 +260,35 @@ export default {
     },
   },
   methods: {
+    onBedsUpdate(checkedBeds, totalBeds, allBeds) {
+      console.log('[onBedsUpdate] called with:', {
+        checkedBeds,
+        totalBeds,
+        allBeds,
+      });
+      this.pendingBedsUpdate = { checkedBeds, totalBeds, allBeds };
+      this.tryHandleBedsUpdate();
+    },
+    tryHandleBedsUpdate() {
+      console.log(
+        '[tryHandleBedsUpdate] plantAssetStatusKnown:',
+        this.plantAssetStatusKnown,
+        'pendingBedsUpdate:',
+        this.pendingBedsUpdate
+      );
+      if (this.plantAssetStatusKnown && this.pendingBedsUpdate) {
+        const { checkedBeds, totalBeds, allBeds } = this.pendingBedsUpdate;
+        this.handleBedsUpdate(checkedBeds, totalBeds, allBeds);
+        this.pendingBedsUpdate = null;
+      }
+    },
     handleBedsUpdate(checkedBeds, totalBeds, allBeds) {
+      console.log('[handleBedsUpdate] called with:', {
+        checkedBeds,
+        totalBeds,
+        allBeds,
+        plantsAtLocation: this.plantsAtLocation,
+      });
       this.allBedsForLocation = allBeds || [];
       if (
         this.allBedsForLocation.length > 0 &&
@@ -269,13 +296,19 @@ export default {
         this.form.beds.length !== this.allBedsForLocation.length
       ) {
         this.form.beds = [...this.allBedsForLocation];
+        console.log(
+          '[handleBedsUpdate] auto-selecting all beds:',
+          this.form.beds
+        );
       } else {
         this.form.beds = checkedBeds;
+        console.log('[handleBedsUpdate] using checkedBeds:', this.form.beds);
       }
       this.form.area =
         totalBeds > 0
           ? Math.round((this.form.beds.length / totalBeds) * 100)
           : 100;
+      console.log('[handleBedsUpdate] form.area set to:', this.form.area);
     },
     submit() {
       this.submitting = true;
@@ -350,6 +383,8 @@ export default {
       this.allBedsForLocation = [];
       this.autoSelectAttemptedForLocation = null;
       this.plantsAtLocation = false;
+      this.plantAssetStatusKnown = false;
+      this.pendingBedsUpdate = null;
     },
   },
   watch: {
@@ -358,10 +393,19 @@ export default {
     },
     plantsAtLocation: {
       handler(newValue) {
+        console.log('[plantsAtLocation watcher] newValue:', newValue);
         this.$emit('hasPlants', newValue);
         this.plantAssetStatusKnown = true;
+        this.tryHandleBedsUpdate();
       },
       immediate: false,
+    },
+    'form.location'() {
+      console.log(
+        '[form.location watcher] resetting plantAssetStatusKnown and pendingBedsUpdate'
+      );
+      this.plantAssetStatusKnown = false;
+      this.pendingBedsUpdate = null;
     },
   },
   created() {

--- a/modules/farm_fd2/src/entrypoints/soil_disturbance/App.vue
+++ b/modules/farm_fd2/src/entrypoints/soil_disturbance/App.vue
@@ -261,12 +261,21 @@ export default {
     },
   },
   methods: {
-    handleBedsUpdate(checkedBeds, totalBeds) {
-      this.form.beds = checkedBeds;
+    handleBedsUpdate(checkedBeds, totalBeds, allBeds) {
+      this.allBedsForLocation = allBeds || [];
+      if (
+        this.allBedsForLocation.length > 0 &&
+        !this.plantsAtLocation &&
+        this.form.beds.length !== this.allBedsForLocation.length
+      ) {
+        this.form.beds = [...this.allBedsForLocation];
+      } else {
+        this.form.beds = checkedBeds;
+      }
       this.form.area =
         totalBeds > 0
-          ? Math.round((checkedBeds.length / totalBeds) * 100)
-          : 100; // default to 100% if there are no beds
+          ? Math.round((this.form.beds.length / totalBeds) * 100)
+          : 100;
     },
     submit() {
       this.submitting = true;
@@ -342,44 +351,17 @@ export default {
       this.autoSelectAttemptedForLocation = null;
       this.plantsAtLocation = false;
     },
-    tryAutoSelectBeds() {
-      console.log('[tryAutoSelectBeds] called');
-      console.log('  allBedsForLocation:', this.allBedsForLocation);
-      console.log('  plantsAtLocation:', this.plantsAtLocation);
-      console.log('  form.beds before:', this.form.beds);
-      if (
-        !this.showActivePlantAssetUI &&
-        this.showLocationBedPickerUI &&
-        this.form.beds.length !== this.allBedsForLocation.length &&
-        this.autoSelectAttemptedForLocation !== this.form.location
-      ) {
-        this.form.beds = [...this.allBedsForLocation];
-        this.autoSelectAttemptedForLocation = this.form.location;
-        console.log(
-          '[tryAutoSelectBeds] AUTO-SELECT ALL BEDS for',
-          this.form.location
-        );
-        console.log('  form.beds after:', this.form.beds);
-      }
-    },
   },
   watch: {
-    plantsAtLocation(newVal) {
-      if (!newVal) {
-        this.form.termination = false;
-        if (this.form.location && this.allBedsForLocation.length > 0) {
-          this.form.beds = [...this.allBedsForLocation];
-        }
-      }
-    },
     pickedValidity(newVal) {
       this.validity.picked = newVal;
     },
-    'form.location'() {
-      this.allBedsForLocation = [];
-      this.autoSelectAttemptedForLocation = null;
-      this.form.beds = [];
-      this.plantsAtLocation = false;
+    plantsAtLocation: {
+      handler(newValue) {
+        this.$emit('hasPlants', newValue);
+        this.plantAssetStatusKnown = true;
+      },
+      immediate: false,
     },
   },
   created() {

--- a/modules/farm_fd2/src/entrypoints/soil_disturbance/soil_disturbance.location.e2e.cy.js
+++ b/modules/farm_fd2/src/entrypoints/soil_disturbance/soil_disturbance.location.e2e.cy.js
@@ -52,4 +52,26 @@ describe('Soil Disturbance: Location Component', () => {
       .find('[data-cy="selector-input"]')
       .should('have.class', 'is-invalid');
   });
+
+  it('selects all beds by default for location with beds but no active plant assets (H)', () => {
+    cy.get('[data-cy="soil-disturbance-location"]')
+      .find('[data-cy="selector-input"]')
+      .select('H');
+    cy.get('[data-cy="location-bed-picker"]')
+      .find('input[type="checkbox"]')
+      .each(($el) => {
+        cy.wrap($el).should('be.checked');
+      });
+  });
+
+  it('does not select all beds by default for location with beds and active plant assets (ALF)', () => {
+    cy.get('[data-cy="soil-disturbance-location"]')
+      .find('[data-cy="selector-input"]')
+      .select('ALF');
+    cy.get('[data-cy="location-bed-picker"]')
+      .find('input[type="checkbox"]')
+      .each(($el) => {
+        cy.wrap($el).should('not.be.checked');
+      });
+  });
 });

--- a/modules/farm_fd2/src/entrypoints/soil_disturbance/soil_disturbance.location.e2e.cy.js
+++ b/modules/farm_fd2/src/entrypoints/soil_disturbance/soil_disturbance.location.e2e.cy.js
@@ -53,25 +53,26 @@ describe('Soil Disturbance: Location Component', () => {
       .should('have.class', 'is-invalid');
   });
 
-  it('selects all beds by default for location with beds but no active plant assets (H)', () => {
+  it('selects all beds by default for H', () => {
     cy.get('[data-cy="soil-disturbance-location"]')
       .find('[data-cy="selector-input"]')
       .select('H');
     cy.get('[data-cy="location-bed-picker"]')
       .find('input[type="checkbox"]')
-      .each(($el) => {
-        cy.wrap($el).should('be.checked');
+      .each((checkbox) => {
+        cy.wrap(checkbox).should('be.checked');
       });
   });
 
-  it('does not select all beds by default for location with beds and active plant assets (ALF)', () => {
+  it('does not select all beds by default for ALF', () => {
     cy.get('[data-cy="soil-disturbance-location"]')
       .find('[data-cy="selector-input"]')
       .select('ALF');
     cy.get('[data-cy="location-bed-picker"]')
       .find('input[type="checkbox"]')
-      .each(($el) => {
-        cy.wrap($el).should('not.be.checked');
+      .should('have.length.greaterThan', 0)
+      .each((checkbox) => {
+        cy.wrap(checkbox).should('not.be.checked');
       });
   });
 });

--- a/modules/farm_fd2/vite.config.js.timestamp-1751917425623-6389b17ba9f2b.mjs
+++ b/modules/farm_fd2/vite.config.js.timestamp-1751917425623-6389b17ba9f2b.mjs
@@ -1,0 +1,107 @@
+// modules/farm_fd2/vite.config.js
+import { fileURLToPath, URL } from "node:url";
+import glob from "file:///home/fd2dev/FarmData2/node_modules/glob/glob.js";
+import { defineConfig } from "file:///home/fd2dev/FarmData2/node_modules/vite/dist/node/index.js";
+import { viteStaticCopy } from "file:///home/fd2dev/FarmData2/node_modules/vite-plugin-static-copy/dist/index.js";
+import vue from "file:///home/fd2dev/FarmData2/node_modules/@vitejs/plugin-vue/dist/index.mjs";
+import { exec } from "child_process";
+import Components from "file:///home/fd2dev/FarmData2/node_modules/unplugin-vue-components/dist/vite.mjs";
+import { BootstrapVueNextResolver } from "file:///home/fd2dev/FarmData2/node_modules/unplugin-vue-components/dist/resolvers.mjs";
+var __vite_injected_original_import_meta_url = "file:///home/fd2dev/FarmData2/modules/farm_fd2/vite.config.js";
+var viteConfig = {
+  root: "modules/farm_fd2/src/entrypoints",
+  publicDir: "../public",
+  base: "/fd2/",
+  plugins: [
+    vue(),
+    Components({
+      resolvers: [BootstrapVueNextResolver()]
+    }),
+    viteStaticCopy({
+      // Copy the Drupal module stuff...
+      targets: [
+        {
+          src: "../module/*.yml",
+          dest: "."
+        },
+        {
+          src: "../module/*.install",
+          dest: "."
+        },
+        {
+          src: "../module/Controller",
+          dest: "src/"
+        },
+        {
+          src: "../module/config",
+          dest: "."
+        },
+        {
+          src: "../composer.json",
+          dest: "."
+        },
+        {
+          src: "../module/*.css",
+          dest: "style/"
+        },
+        {
+          src: "../module/*.module",
+          dest: "."
+        }
+      ]
+    }),
+    {
+      // This plugin runs after a build and clears the drupal cache so that
+      // the live farmos server shows the most recent content.
+      name: "afterBuild",
+      closeBundle: async () => {
+        exec("docker exec fd2_farmos drush cr", (error, stderr, stdout) => {
+          if (error) {
+            console.error(`error:  ${error.message}`);
+            return;
+          }
+          if (stderr) {
+            console.error(`stderr: ${stderr}`);
+            return;
+          }
+          console.log(`Rebuilding drupal cache...
+  ${stdout}`);
+        });
+      }
+    }
+  ],
+  build: {
+    outDir: "../../dist/farmdata2",
+    emptyOutDir: true,
+    cssCodeSplit: false,
+    rollupOptions: {
+      input: Object.fromEntries(
+        glob.sync("modules/farm_fd2/src/entrypoints/*/*.html").map((dir) => {
+          let key = dir.split("/").at(-2) + "/" + dir.split("/").at(-1);
+          return [key, dir];
+        })
+      ),
+      output: {
+        // Ensures that the entry point and css names are not hashed.
+        entryFileNames: "[name]/[name].js",
+        assetFileNames: "[name]/[name].[ext]",
+        chunkFileNames: "[name]/[name].js"
+      }
+    }
+  },
+  resolve: {
+    alias: {
+      "@": fileURLToPath(new URL("./src/", __vite_injected_original_import_meta_url)),
+      "@comps": fileURLToPath(new URL("../../components/", __vite_injected_original_import_meta_url)),
+      "@libs": fileURLToPath(new URL("../../library/", __vite_injected_original_import_meta_url)),
+      "@css": fileURLToPath(new URL("../css/", __vite_injected_original_import_meta_url))
+    }
+  }
+};
+console.log("Building: ");
+console.log(viteConfig.build.rollupOptions.input);
+var vite_config_default = defineConfig(viteConfig);
+export {
+  vite_config_default as default
+};
+//# sourceMappingURL=data:application/json;base64,ewogICJ2ZXJzaW9uIjogMywKICAic291cmNlcyI6IFsibW9kdWxlcy9mYXJtX2ZkMi92aXRlLmNvbmZpZy5qcyJdLAogICJzb3VyY2VzQ29udGVudCI6IFsiY29uc3QgX192aXRlX2luamVjdGVkX29yaWdpbmFsX2Rpcm5hbWUgPSBcIi9ob21lL2ZkMmRldi9GYXJtRGF0YTIvbW9kdWxlcy9mYXJtX2ZkMlwiO2NvbnN0IF9fdml0ZV9pbmplY3RlZF9vcmlnaW5hbF9maWxlbmFtZSA9IFwiL2hvbWUvZmQyZGV2L0Zhcm1EYXRhMi9tb2R1bGVzL2Zhcm1fZmQyL3ZpdGUuY29uZmlnLmpzXCI7Y29uc3QgX192aXRlX2luamVjdGVkX29yaWdpbmFsX2ltcG9ydF9tZXRhX3VybCA9IFwiZmlsZTovLy9ob21lL2ZkMmRldi9GYXJtRGF0YTIvbW9kdWxlcy9mYXJtX2ZkMi92aXRlLmNvbmZpZy5qc1wiO2ltcG9ydCB7IGZpbGVVUkxUb1BhdGgsIFVSTCB9IGZyb20gJ25vZGU6dXJsJztcbmltcG9ydCBnbG9iIGZyb20gJ2dsb2InO1xuaW1wb3J0IHsgZGVmaW5lQ29uZmlnIH0gZnJvbSAndml0ZSc7XG5pbXBvcnQgeyB2aXRlU3RhdGljQ29weSB9IGZyb20gJ3ZpdGUtcGx1Z2luLXN0YXRpYy1jb3B5JztcbmltcG9ydCB2dWUgZnJvbSAnQHZpdGVqcy9wbHVnaW4tdnVlJztcbmltcG9ydCB7IGV4ZWMgfSBmcm9tICdjaGlsZF9wcm9jZXNzJztcbmltcG9ydCBDb21wb25lbnRzIGZyb20gJ3VucGx1Z2luLXZ1ZS1jb21wb25lbnRzL3ZpdGUnO1xuaW1wb3J0IHsgQm9vdHN0cmFwVnVlTmV4dFJlc29sdmVyIH0gZnJvbSAndW5wbHVnaW4tdnVlLWNvbXBvbmVudHMvcmVzb2x2ZXJzJztcblxubGV0IHZpdGVDb25maWcgPSB7XG4gIHJvb3Q6ICdtb2R1bGVzL2Zhcm1fZmQyL3NyYy9lbnRyeXBvaW50cycsXG4gIHB1YmxpY0RpcjogJy4uL3B1YmxpYycsXG4gIGJhc2U6ICcvZmQyLycsXG4gIHBsdWdpbnM6IFtcbiAgICB2dWUoKSxcbiAgICBDb21wb25lbnRzKHtcbiAgICAgIHJlc29sdmVyczogW0Jvb3RzdHJhcFZ1ZU5leHRSZXNvbHZlcigpXSxcbiAgICB9KSxcbiAgICB2aXRlU3RhdGljQ29weSh7XG4gICAgICAvLyBDb3B5IHRoZSBEcnVwYWwgbW9kdWxlIHN0dWZmLi4uXG4gICAgICB0YXJnZXRzOiBbXG4gICAgICAgIHtcbiAgICAgICAgICBzcmM6ICcuLi9tb2R1bGUvKi55bWwnLFxuICAgICAgICAgIGRlc3Q6ICcuJyxcbiAgICAgICAgfSxcbiAgICAgICAge1xuICAgICAgICAgIHNyYzogJy4uL21vZHVsZS8qLmluc3RhbGwnLFxuICAgICAgICAgIGRlc3Q6ICcuJyxcbiAgICAgICAgfSxcbiAgICAgICAge1xuICAgICAgICAgIHNyYzogJy4uL21vZHVsZS9Db250cm9sbGVyJyxcbiAgICAgICAgICBkZXN0OiAnc3JjLycsXG4gICAgICAgIH0sXG4gICAgICAgIHtcbiAgICAgICAgICBzcmM6ICcuLi9tb2R1bGUvY29uZmlnJyxcbiAgICAgICAgICBkZXN0OiAnLicsXG4gICAgICAgIH0sXG4gICAgICAgIHtcbiAgICAgICAgICBzcmM6ICcuLi9jb21wb3Nlci5qc29uJyxcbiAgICAgICAgICBkZXN0OiAnLicsXG4gICAgICAgIH0sXG4gICAgICAgIHtcbiAgICAgICAgICBzcmM6ICcuLi9tb2R1bGUvKi5jc3MnLFxuICAgICAgICAgIGRlc3Q6ICdzdHlsZS8nLFxuICAgICAgICB9LFxuICAgICAgICB7XG4gICAgICAgICAgc3JjOiAnLi4vbW9kdWxlLyoubW9kdWxlJyxcbiAgICAgICAgICBkZXN0OiAnLicsXG4gICAgICAgIH0sXG4gICAgICBdLFxuICAgIH0pLFxuICAgIHtcbiAgICAgIC8vIFRoaXMgcGx1Z2luIHJ1bnMgYWZ0ZXIgYSBidWlsZCBhbmQgY2xlYXJzIHRoZSBkcnVwYWwgY2FjaGUgc28gdGhhdFxuICAgICAgLy8gdGhlIGxpdmUgZmFybW9zIHNlcnZlciBzaG93cyB0aGUgbW9zdCByZWNlbnQgY29udGVudC5cbiAgICAgIG5hbWU6ICdhZnRlckJ1aWxkJyxcbiAgICAgIGNsb3NlQnVuZGxlOiBhc3luYyAoKSA9PiB7XG4gICAgICAgIGV4ZWMoJ2RvY2tlciBleGVjIGZkMl9mYXJtb3MgZHJ1c2ggY3InLCAoZXJyb3IsIHN0ZGVyciwgc3Rkb3V0KSA9PiB7XG4gICAgICAgICAgaWYgKGVycm9yKSB7XG4gICAgICAgICAgICBjb25zb2xlLmVycm9yKGBlcnJvcjogICR7ZXJyb3IubWVzc2FnZX1gKTtcbiAgICAgICAgICAgIHJldHVybjtcbiAgICAgICAgICB9XG4gICAgICAgICAgaWYgKHN0ZGVycikge1xuICAgICAgICAgICAgY29uc29sZS5lcnJvcihgc3RkZXJyOiAke3N0ZGVycn1gKTtcbiAgICAgICAgICAgIHJldHVybjtcbiAgICAgICAgICB9XG4gICAgICAgICAgY29uc29sZS5sb2coYFJlYnVpbGRpbmcgZHJ1cGFsIGNhY2hlLi4uXFxuICAke3N0ZG91dH1gKTtcbiAgICAgICAgfSk7XG4gICAgICB9LFxuICAgIH0sXG4gIF0sXG4gIGJ1aWxkOiB7XG4gICAgb3V0RGlyOiAnLi4vLi4vZGlzdC9mYXJtZGF0YTInLFxuICAgIGVtcHR5T3V0RGlyOiB0cnVlLFxuICAgIGNzc0NvZGVTcGxpdDogZmFsc2UsXG4gICAgcm9sbHVwT3B0aW9uczoge1xuICAgICAgaW5wdXQ6IE9iamVjdC5mcm9tRW50cmllcyhcbiAgICAgICAgZ2xvYi5zeW5jKCdtb2R1bGVzL2Zhcm1fZmQyL3NyYy9lbnRyeXBvaW50cy8qLyouaHRtbCcpLm1hcCgoZGlyKSA9PiB7XG4gICAgICAgICAgbGV0IGtleSA9IGRpci5zcGxpdCgnLycpLmF0KC0yKSArICcvJyArIGRpci5zcGxpdCgnLycpLmF0KC0xKTtcbiAgICAgICAgICByZXR1cm4gW2tleSwgZGlyXTtcbiAgICAgICAgfSlcbiAgICAgICksXG4gICAgICBvdXRwdXQ6IHtcbiAgICAgICAgLy8gRW5zdXJlcyB0aGF0IHRoZSBlbnRyeSBwb2ludCBhbmQgY3NzIG5hbWVzIGFyZSBub3QgaGFzaGVkLlxuICAgICAgICBlbnRyeUZpbGVOYW1lczogJ1tuYW1lXS9bbmFtZV0uanMnLFxuICAgICAgICBhc3NldEZpbGVOYW1lczogJ1tuYW1lXS9bbmFtZV0uW2V4dF0nLFxuICAgICAgICBjaHVua0ZpbGVOYW1lczogJ1tuYW1lXS9bbmFtZV0uanMnLFxuICAgICAgfSxcbiAgICB9LFxuICB9LFxuICByZXNvbHZlOiB7XG4gICAgYWxpYXM6IHtcbiAgICAgICdAJzogZmlsZVVSTFRvUGF0aChuZXcgVVJMKCcuL3NyYy8nLCBpbXBvcnQubWV0YS51cmwpKSxcbiAgICAgICdAY29tcHMnOiBmaWxlVVJMVG9QYXRoKG5ldyBVUkwoJy4uLy4uL2NvbXBvbmVudHMvJywgaW1wb3J0Lm1ldGEudXJsKSksXG4gICAgICAnQGxpYnMnOiBmaWxlVVJMVG9QYXRoKG5ldyBVUkwoJy4uLy4uL2xpYnJhcnkvJywgaW1wb3J0Lm1ldGEudXJsKSksXG4gICAgICAnQGNzcyc6IGZpbGVVUkxUb1BhdGgobmV3IFVSTCgnLi4vY3NzLycsIGltcG9ydC5tZXRhLnVybCkpLFxuICAgIH0sXG4gIH0sXG59O1xuXG5jb25zb2xlLmxvZygnQnVpbGRpbmc6ICcpO1xuY29uc29sZS5sb2codml0ZUNvbmZpZy5idWlsZC5yb2xsdXBPcHRpb25zLmlucHV0KTtcblxuZXhwb3J0IGRlZmF1bHQgZGVmaW5lQ29uZmlnKHZpdGVDb25maWcpO1xuIl0sCiAgIm1hcHBpbmdzIjogIjtBQUF1UyxTQUFTLGVBQWUsV0FBVztBQUMxVSxPQUFPLFVBQVU7QUFDakIsU0FBUyxvQkFBb0I7QUFDN0IsU0FBUyxzQkFBc0I7QUFDL0IsT0FBTyxTQUFTO0FBQ2hCLFNBQVMsWUFBWTtBQUNyQixPQUFPLGdCQUFnQjtBQUN2QixTQUFTLGdDQUFnQztBQVA2SSxJQUFNLDJDQUEyQztBQVN2TyxJQUFJLGFBQWE7QUFBQSxFQUNmLE1BQU07QUFBQSxFQUNOLFdBQVc7QUFBQSxFQUNYLE1BQU07QUFBQSxFQUNOLFNBQVM7QUFBQSxJQUNQLElBQUk7QUFBQSxJQUNKLFdBQVc7QUFBQSxNQUNULFdBQVcsQ0FBQyx5QkFBeUIsQ0FBQztBQUFBLElBQ3hDLENBQUM7QUFBQSxJQUNELGVBQWU7QUFBQTtBQUFBLE1BRWIsU0FBUztBQUFBLFFBQ1A7QUFBQSxVQUNFLEtBQUs7QUFBQSxVQUNMLE1BQU07QUFBQSxRQUNSO0FBQUEsUUFDQTtBQUFBLFVBQ0UsS0FBSztBQUFBLFVBQ0wsTUFBTTtBQUFBLFFBQ1I7QUFBQSxRQUNBO0FBQUEsVUFDRSxLQUFLO0FBQUEsVUFDTCxNQUFNO0FBQUEsUUFDUjtBQUFBLFFBQ0E7QUFBQSxVQUNFLEtBQUs7QUFBQSxVQUNMLE1BQU07QUFBQSxRQUNSO0FBQUEsUUFDQTtBQUFBLFVBQ0UsS0FBSztBQUFBLFVBQ0wsTUFBTTtBQUFBLFFBQ1I7QUFBQSxRQUNBO0FBQUEsVUFDRSxLQUFLO0FBQUEsVUFDTCxNQUFNO0FBQUEsUUFDUjtBQUFBLFFBQ0E7QUFBQSxVQUNFLEtBQUs7QUFBQSxVQUNMLE1BQU07QUFBQSxRQUNSO0FBQUEsTUFDRjtBQUFBLElBQ0YsQ0FBQztBQUFBLElBQ0Q7QUFBQTtBQUFBO0FBQUEsTUFHRSxNQUFNO0FBQUEsTUFDTixhQUFhLFlBQVk7QUFDdkIsYUFBSyxtQ0FBbUMsQ0FBQyxPQUFPLFFBQVEsV0FBVztBQUNqRSxjQUFJLE9BQU87QUFDVCxvQkFBUSxNQUFNLFdBQVcsTUFBTSxPQUFPLEVBQUU7QUFDeEM7QUFBQSxVQUNGO0FBQ0EsY0FBSSxRQUFRO0FBQ1Ysb0JBQVEsTUFBTSxXQUFXLE1BQU0sRUFBRTtBQUNqQztBQUFBLFVBQ0Y7QUFDQSxrQkFBUSxJQUFJO0FBQUEsSUFBaUMsTUFBTSxFQUFFO0FBQUEsUUFDdkQsQ0FBQztBQUFBLE1BQ0g7QUFBQSxJQUNGO0FBQUEsRUFDRjtBQUFBLEVBQ0EsT0FBTztBQUFBLElBQ0wsUUFBUTtBQUFBLElBQ1IsYUFBYTtBQUFBLElBQ2IsY0FBYztBQUFBLElBQ2QsZUFBZTtBQUFBLE1BQ2IsT0FBTyxPQUFPO0FBQUEsUUFDWixLQUFLLEtBQUssMkNBQTJDLEVBQUUsSUFBSSxDQUFDLFFBQVE7QUFDbEUsY0FBSSxNQUFNLElBQUksTUFBTSxHQUFHLEVBQUUsR0FBRyxFQUFFLElBQUksTUFBTSxJQUFJLE1BQU0sR0FBRyxFQUFFLEdBQUcsRUFBRTtBQUM1RCxpQkFBTyxDQUFDLEtBQUssR0FBRztBQUFBLFFBQ2xCLENBQUM7QUFBQSxNQUNIO0FBQUEsTUFDQSxRQUFRO0FBQUE7QUFBQSxRQUVOLGdCQUFnQjtBQUFBLFFBQ2hCLGdCQUFnQjtBQUFBLFFBQ2hCLGdCQUFnQjtBQUFBLE1BQ2xCO0FBQUEsSUFDRjtBQUFBLEVBQ0Y7QUFBQSxFQUNBLFNBQVM7QUFBQSxJQUNQLE9BQU87QUFBQSxNQUNMLEtBQUssY0FBYyxJQUFJLElBQUksVUFBVSx3Q0FBZSxDQUFDO0FBQUEsTUFDckQsVUFBVSxjQUFjLElBQUksSUFBSSxxQkFBcUIsd0NBQWUsQ0FBQztBQUFBLE1BQ3JFLFNBQVMsY0FBYyxJQUFJLElBQUksa0JBQWtCLHdDQUFlLENBQUM7QUFBQSxNQUNqRSxRQUFRLGNBQWMsSUFBSSxJQUFJLFdBQVcsd0NBQWUsQ0FBQztBQUFBLElBQzNEO0FBQUEsRUFDRjtBQUNGO0FBRUEsUUFBUSxJQUFJLFlBQVk7QUFDeEIsUUFBUSxJQUFJLFdBQVcsTUFBTSxjQUFjLEtBQUs7QUFFaEQsSUFBTyxzQkFBUSxhQUFhLFVBQVU7IiwKICAibmFtZXMiOiBbXQp9Cg==

--- a/modules/farm_fd2_examples/src/entrypoints/location_selector/App.vue
+++ b/modules/farm_fd2_examples/src/entrypoints/location_selector/App.vue
@@ -21,7 +21,7 @@
     v-bind:selectAllBedsByDefault="selectAllBedsByDefault"
     v-model:selected="this.form.selected"
     v-model:pickedBeds="this.form.pickedBeds"
-    v-on:update:beds="(beds) => (this.form.pickedBeds = beds)"
+    v-on:update:beds="handleBedsUpdate"
     v-on:valid="(valid) => (validity.selected = valid)"
     v-on:ready="createdCount++"
   />
@@ -247,7 +247,11 @@
       </tr>
       <tr>
         <td>update:beds</td>
-        <td>{{ form.pickedBeds }}</td>
+        <td>
+          Picked: {{ bedsInfo.picked }}<br />
+          Total beds: {{ bedsInfo.total }}<br />
+          All beds: {{ bedsInfo.all }}
+        </td>
       </tr>
       <tr>
         <td>valid</td>
@@ -290,11 +294,20 @@ export default {
         selected: false,
       },
       createdCount: 0,
+      bedsInfo: {
+        picked: [],
+        total: 0,
+        all: [],
+      },
     };
   },
   methods: {
     handleAddClicked() {
       this.addClicked = 'empty payload';
+    },
+    handleBedsUpdate(picked, total, all) {
+      this.form.pickedBeds = picked;
+      this.bedsInfo = { picked, total, all };
     },
   },
   watch: {


### PR DESCRIPTION
**Pull Request Description**

Select all beds by default when a location with beds but no active plant assets is chosen.

Closes #499 

---

**Licensing Certification**

FarmData2 is a [Free Cultural Work](https://freedomdefined.org/Definition) and all accepted contributions are licensed as described in the LICENSE.md file. This requires that the contributor holds the rights to do so. By submitting this pull request **I certify that I satisfy the terms of the [Developer Certificate of Origin](https://developercertificate.org/)** for its contents.
