### PR TITLE
feat(dev): install correct db version when branch changes

### DIFF
--- a/.fd2-cspell.txt
+++ b/.fd2-cspell.txt
@@ -22,6 +22,7 @@ dockercompose
 dockerlint
 drupalcode
 drush
+elif
 entrypoints
 esbenp
 Farhan

--- a/.fd2dev/db.conf
+++ b/.fd2dev/db.conf
@@ -1,0 +1,2 @@
+v3.6.0
+db.sample.tar.gz

--- a/.fd2dev/db.conf
+++ b/.fd2dev/db.conf
@@ -1,2 +1,2 @@
-v3.6.0
+v3.5.0
 db.sample.tar.gz

--- a/.fd2dev/db.conf
+++ b/.fd2dev/db.conf
@@ -1,2 +1,2 @@
-v3.5.0
+v3.6.0
 db.sample.tar.gz

--- a/.githooks/post-checkout
+++ b/.githooks/post-checkout
@@ -55,6 +55,13 @@ echo "OLD_BRANCH_DB_ASSET: $OLD_BRANCH_DB_ASSET"
 NEW_BRANCH=$(git rev-parse --abbrev-ref HEAD)
 echo "NEW_BRANCH: $NEW_BRANCH"
 
+if
+  [ "$NEW_BRANCH_DB_VERSION" != "$WORKING_FILES_DB_VERSION" ] \
+    || [ "$NEW_BRANCH_DB_ASSET" != "$OLD_BRANCH_DB_ASSET" ]
+then
+  echo "Database version has been changed but not committed."
+fi
+
 #if [ "$NEW_DB_VERSION" != "$OLD_DB_VERSION" ] || [ "$NEW_DB_ASSET" != "$OLD_DB_ASSET" ]; then
 #  echo "Branch $NEW_BRANCH requires $NEW_DB_ASSET from $NEW_DB_VERSION."
 #  installDB.bash --release="$NEW_DB_VERSION" --asset="$NEW_DB_ASSET"

--- a/.githooks/post-checkout
+++ b/.githooks/post-checkout
@@ -8,6 +8,7 @@ source "$REPO_ROOT_DIR/bin/lib.bash"
 
 FROM_REF=$1
 TO_REF=$2
+IS_FILE=$3
 
 # Don't run this when a repo is cloned.
 if [ -z "$FROM_REF" ]; then
@@ -19,7 +20,10 @@ if [ "$FROM_REF" = "$TO_REF" ]; then
   exit 0
 fi
 
-# Don't run this unless we are in the FarmData2 repo.
+# Don't run this if this is a file checkout.
+if [ ! "$IS_FILE" ]; then
+  exit 0
+fi
 
 echo "Running FarmData2 post-checkout hook..."
 

--- a/.githooks/post-checkout
+++ b/.githooks/post-checkout
@@ -27,11 +27,30 @@ if [ ! "$IS_FILE" ]; then
   exit 0
 fi
 
-NEW_DB_VERSION=$(head -1 ".fd2dev/db.conf")
-NEW_DB_ASSET=$(tail -1 ".fd2dev/db.conf")
+# Check if the db.conf information has been modified since the last commit.
+# GIT_STATUS=$(git status --porcelain | grep "M  .fd2dev/db.conf")
+# if [ "$GIT_STATUS" ]; then
+#   # If the file is modified, get the new version and asset from the commit.
+
+# fi
+
+NEW_DB_COMMITTED_VERSION=$(git show "$TO_REF:.fd2dev/db.conf" 2> /dev/null | head -1)
+NEW_DB_COMMITTED_ASSET=$(git show "$TO_REF:.fd2dev/db.conf" 2> /dev/null | tail -1)
+
+DB_WORKING_VERSION=$(head -1 ".fd2dev/db.conf")
+DB_WORKING_ASSET=$(tail -1 ".fd2dev/db.conf")
 
 OLD_DB_VERSION=$(git show "$FROM_REF:.fd2dev/db.conf" 2> /dev/null | head -1)
 OLD_DB_ASSET=$(git show "$FROM_REF:.fd2dev/db.conf" 2> /dev/null | tail -1)
+
+echo "NEW_DB_COMMITTED_VERSION: $NEW_DB_COMMITTED_VERSION"
+echo "NEW_DB_COMMITTED_ASSET: $NEW_DB_COMMITTED_ASSET"
+
+echo "DB_WORKING_VERSION: $DB_WORKING_VERSION"
+echo "DB_WORKING_ASSET: $DB_WORKING_ASSET"
+
+echo "OLD_DB_VERSION: $OLD_DB_VERSION"
+echo "OLD_DB_ASSET: $OLD_DB_ASSET"
 
 NEW_BRANCH=$(git rev-parse --abbrev-ref HEAD)
 

--- a/.githooks/post-checkout
+++ b/.githooks/post-checkout
@@ -29,30 +29,12 @@ fi
 
 NEW_BRANCH_DB_VERSION=$(git show "$TO_REF:.fd2dev/db.conf" 2> /dev/null | head -1)
 NEW_BRANCH_DB_ASSET=$(git show "$TO_REF:.fd2dev/db.conf" 2> /dev/null | tail -1)
-# Don't run this if the new branch does not have db information
-# This will happen when switching to a branch made before this script was merged
-# into development.
-if [ ! "$NEW_BRANCH_DB_VERSION" ]; then
-  exit 0
-fi
 
 WORKING_FILES_DB_VERSION=$(head -1 ".fd2dev/db.conf")
 WORKING_FILES_DB_ASSET=$(tail -1 ".fd2dev/db.conf")
 
 OLD_BRANCH_DB_VERSION=$(git show "$FROM_REF:.fd2dev/db.conf" 2> /dev/null | head -1)
 OLD_BRANCH_DB_ASSET=$(git show "$FROM_REF:.fd2dev/db.conf" 2> /dev/null | tail -1)
-
-echo "NEW_BRANCH_DB_VERSION: $NEW_BRANCH_DB_VERSION"
-echo "NEW_BRANCH_DB_ASSET: $NEW_BRANCH_DB_ASSET"
-
-echo "WORKING_FILES_DB_VERSION: $WORKING_FILES_DB_VERSION"
-echo "WORKING_FILES_DB_ASSET: $WORKING_FILES_DB_ASSET"
-
-echo "OLD_BRANCH_DB_VERSION: $OLD_BRANCH_DB_VERSION"
-echo "OLD_BRANCH_DB_ASSET: $OLD_BRANCH_DB_ASSET"
-
-NEW_BRANCH=$(git rev-parse --abbrev-ref HEAD)
-echo "NEW_BRANCH: $NEW_BRANCH"
 
 if
   [ "$NEW_BRANCH_DB_VERSION" != "$WORKING_FILES_DB_VERSION" ] \

--- a/.githooks/post-checkout
+++ b/.githooks/post-checkout
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+# This post-checkout hook ensures the version of the sampleDB
+# that is installed is compatible with the code in the branch.
+
+# shellcheck disable=SC1091  # Make sources okay.
+source lib.bash
+
+FROM_BRANCH=$1
+TO_BRANCH=$2
+
+echo "$FROM_BRANCH"
+echo "$TO_BRANCH"

--- a/.githooks/post-checkout
+++ b/.githooks/post-checkout
@@ -27,7 +27,12 @@ fi
 
 echo "Running FarmData2 post-checkout hook..."
 
+DB_VERSION=$(head -1 ~/.fd2/db.version)
+DB_ASSET=$(tail -1 ~/.fd2/db.asset)
+
 echo "$FROM_REF"
 echo "$TO_REF"
+echo "$DB_VERSION"
+echo "$DB_ASSET"
 
 echo "Done."

--- a/.githooks/post-checkout
+++ b/.githooks/post-checkout
@@ -31,8 +31,13 @@ echo "Running FarmData2 post-checkout hook..."
 
 NEW_DB_VERSION=$(head -1 ".fd2dev/db.conf")
 NEW_DB_ASSET=$(tail -1 ".fd2dev/db.conf")
-OLD_DB_VERSION=$(git show "$FROM_REF:.fd2dev/db.conf" | head -1)
-OLD_DB_ASSET=$(git show "$FROM_REF:.fd2dev/db.conf" | tail -1)
+
+OLD_DB_VERSION=$(git show "$FROM_REF:.fd2dev/db.conf" 2> /dev/null | head -1)
+OLD_DB_ASSET=$(git show "$FROM_REF:.fd2dev/db.conf" 2> /dev/null | tail -1)
+if [ -z "$OLD_DB_VERSION" ]; then
+  echo "new branch predates db versioning"
+  exit 0
+fi
 
 NEW_BRANCH=$(git rev-parse --abbrev-ref HEAD)
 

--- a/.githooks/post-checkout
+++ b/.githooks/post-checkout
@@ -34,10 +34,6 @@ NEW_DB_ASSET=$(tail -1 ".fd2dev/db.conf")
 
 OLD_DB_VERSION=$(git show "$FROM_REF:.fd2dev/db.conf" 2> /dev/null | head -1)
 OLD_DB_ASSET=$(git show "$FROM_REF:.fd2dev/db.conf" 2> /dev/null | tail -1)
-if [ -z "$OLD_DB_VERSION" ]; then
-  echo "new branch predates db versioning"
-  exit 0
-fi
 
 NEW_BRANCH=$(git rev-parse --abbrev-ref HEAD)
 

--- a/.githooks/post-checkout
+++ b/.githooks/post-checkout
@@ -36,6 +36,8 @@ WORKING_FILES_DB_ASSET=$(tail -1 ".fd2dev/db.conf")
 OLD_BRANCH_DB_VERSION=$(git show "$FROM_REF:.fd2dev/db.conf" 2> /dev/null | head -1)
 OLD_BRANCH_DB_ASSET=$(git show "$FROM_REF:.fd2dev/db.conf" 2> /dev/null | tail -1)
 
+NEW_BRANCH=$(git branch --show-current)
+
 if
   [ "$NEW_BRANCH_DB_VERSION" != "$WORKING_FILES_DB_VERSION" ] \
     || [ "$NEW_BRANCH_DB_ASSET" != "$WORKING_FILES_DB_ASSET" ]

--- a/.githooks/post-checkout
+++ b/.githooks/post-checkout
@@ -6,11 +6,16 @@
 REPO_ROOT_DIR=$(git rev-parse --show-toplevel)
 source "$REPO_ROOT_DIR/bin/lib.bash"
 
-FROM_BRANCH=$1
-TO_BRANCH=$2
+FROM_REF=$1
+TO_REF=$2
 
 # Don't run this when a repo is cloned.
-if [ -z "$FROM_BRANCH" ]; then
+if [ -z "$FROM_REF" ]; then
+  exit 0
+fi
+
+# Don't run this if there are no changes (e.g. switching to a new branch).
+if [ "$FROM_REF" = "$TO_REF" ]; then
   exit 0
 fi
 
@@ -18,7 +23,7 @@ fi
 
 echo "Running FarmData2 post-checkout hook..."
 
-echo "$FROM_BRANCH"
-echo "$TO_BRANCH"
+echo "$FROM_REF"
+echo "$TO_REF"
 
 echo "Done."

--- a/.githooks/post-checkout
+++ b/.githooks/post-checkout
@@ -46,5 +46,5 @@ then
 elif [ "$NEW_BRANCH_DB_VERSION" != "$OLD_BRANCH_DB_VERSION" ] \
   || [ "$NEW_BRANCH_DB_ASSET" != "$OLD_BRANCH_DB_ASSET" ]; then
   echo "Branch $NEW_BRANCH requires $NEW_BRANCH_DB_ASSET from $NEW_BRANCH_DB_VERSION."
-  installDB.bash --release="$NEW_DB_VERSION" --asset="$NEW_DB_ASSET"
+  installDB.bash --release="$NEW_BRANCH_DB_VERSION" --asset="$NEW_BRANCH_DB_ASSET"
 fi

--- a/.githooks/post-checkout
+++ b/.githooks/post-checkout
@@ -34,27 +34,28 @@ fi
 
 # fi
 
-NEW_DB_COMMITTED_VERSION=$(git show "$TO_REF:.fd2dev/db.conf" 2> /dev/null | head -1)
-NEW_DB_COMMITTED_ASSET=$(git show "$TO_REF:.fd2dev/db.conf" 2> /dev/null | tail -1)
+NEW_BRANCH_DB_VERSION=$(git show "$TO_REF:.fd2dev/db.conf" 2> /dev/null | head -1)
+NEW_BRANCH_DB_ASSET=$(git show "$TO_REF:.fd2dev/db.conf" 2> /dev/null | tail -1)
 
-DB_WORKING_VERSION=$(head -1 ".fd2dev/db.conf")
-DB_WORKING_ASSET=$(tail -1 ".fd2dev/db.conf")
+WORKING_FILES_DB_VERSION=$(head -1 ".fd2dev/db.conf")
+WORKING_FILES_DB_ASSET=$(tail -1 ".fd2dev/db.conf")
 
-OLD_DB_VERSION=$(git show "$FROM_REF:.fd2dev/db.conf" 2> /dev/null | head -1)
-OLD_DB_ASSET=$(git show "$FROM_REF:.fd2dev/db.conf" 2> /dev/null | tail -1)
+OLD_BRANCH_DB_VERSION=$(git show "$FROM_REF:.fd2dev/db.conf" 2> /dev/null | head -1)
+OLD_BRANCH_DB_ASSET=$(git show "$FROM_REF:.fd2dev/db.conf" 2> /dev/null | tail -1)
 
-echo "NEW_DB_COMMITTED_VERSION: $NEW_DB_COMMITTED_VERSION"
-echo "NEW_DB_COMMITTED_ASSET: $NEW_DB_COMMITTED_ASSET"
+echo "NEW_BRANCH_DB_VERSION: $NEW_BRANCH_DB_VERSION"
+echo "NEW_BRANCH_DB_ASSET: $NEW_BRANCH_DB_ASSET"
 
-echo "DB_WORKING_VERSION: $DB_WORKING_VERSION"
-echo "DB_WORKING_ASSET: $DB_WORKING_ASSET"
+echo "WORKING_FILES_DB_VERSION: $WORKING_FILES_DB_VERSION"
+echo "WORKING_FILES_DB_ASSET: $WORKING_FILES_DB_ASSET"
 
-echo "OLD_DB_VERSION: $OLD_DB_VERSION"
-echo "OLD_DB_ASSET: $OLD_DB_ASSET"
+echo "OLD_BRANCH_DB_VERSION: $OLD_BRANCH_DB_VERSION"
+echo "OLD_BRANCH_DB_ASSET: $OLD_BRANCH_DB_ASSET"
 
 NEW_BRANCH=$(git rev-parse --abbrev-ref HEAD)
+echo "NEW_BRANCH: $NEW_BRANCH"
 
-if [ "$NEW_DB_VERSION" != "$OLD_DB_VERSION" ] || [ "$NEW_DB_ASSET" != "$OLD_DB_ASSET" ]; then
-  echo "Branch $NEW_BRANCH requires $NEW_DB_ASSET from $NEW_DB_VERSION."
-  installDB.bash --release="$NEW_DB_VERSION" --asset="$NEW_DB_ASSET"
-fi
+#if [ "$NEW_DB_VERSION" != "$OLD_DB_VERSION" ] || [ "$NEW_DB_ASSET" != "$OLD_DB_ASSET" ]; then
+#  echo "Branch $NEW_BRANCH requires $NEW_DB_ASSET from $NEW_DB_VERSION."
+#  installDB.bash --release="$NEW_DB_VERSION" --asset="$NEW_DB_ASSET"
+#fi

--- a/.githooks/post-checkout
+++ b/.githooks/post-checkout
@@ -6,9 +6,16 @@
 REPO_ROOT_DIR=$(git rev-parse --show-toplevel)
 source "$REPO_ROOT_DIR/bin/lib.bash"
 
+safe_cd "$REPO_ROOT_DIR"
+
 FROM_REF=$1
 TO_REF=$2
 IS_FILE=$3
+
+echo "FROM_REF: $FROM_REF"
+echo "TO_REF: $TO_REF"
+echo "IS_FILE: $IS_FILE"
+echo ""
 
 # Don't run this when a repo is cloned.
 if [ -z "$FROM_REF" ]; then
@@ -27,11 +34,11 @@ fi
 
 echo "Running FarmData2 post-checkout hook..."
 
-NEW_DB_VERSION=$(head -1 "$REPO_ROOT_DIR"/.fd2dev/db.conf)
-NEW_DB_ASSET=$(tail -1 "$REPO_ROOT_DIR"/.fd2dev/db.conf)
+NEW_DB_VERSION=$(head -1 ".fd2dev/db.conf")
+NEW_DB_ASSET=$(tail -1 ".fd2dev/db.conf")
 
-OLD_DB_VERSION=$(git show "$FROM_REF:$REPO_ROOT_DIR/.fd2dev/db.conf" | head -1)
-OLD_DB_ASSET=$(git show "$FROM_REF:$REPO_ROOT_DIR/.fd2dev/db.conf" | tail -1)
+OLD_DB_VERSION=$(git show ".fd2dev/db.conf" | head -1)
+OLD_DB_ASSET=$(git show ".fd2dev/db.conf" | tail -1)
 
 echo "New branch DB version: $NEW_DB_VERSION"
 echo "  New branch DB asset: $NEW_DB_ASSET"

--- a/.githooks/post-checkout
+++ b/.githooks/post-checkout
@@ -58,13 +58,11 @@ if
   [ "$NEW_BRANCH_DB_VERSION" != "$WORKING_FILES_DB_VERSION" ] \
     || [ "$NEW_BRANCH_DB_ASSET" != "$WORKING_FILES_DB_ASSET" ]
 then
-  echo "A new database version was installed by installDB.bash."
-  echo "But .fd2dev/db.conf has not been committed."
-  echo "Thus the currently installed database may not be compatible with the $NEW_BRANCH branch."
-  echo "Be sure to commit the changes to .fd2dev/db.conf to your feature branch."
+  echo -e "${ORANGE}WARNING: The installed database may not be compatible with the $NEW_BRANCH branch.${NO_COLOR}"
+  echo "  A new database version was installed by installDB.bash but .fd2dev/db.conf was not been committed."
+  echo "  You should commit the changes to .fd2dev/db.conf to your feature branch."
+elif [ "$NEW_BRANCH_DB_VERSION" != "$OLD_BRANCH_DB_VERSION" ] \
+  || [ "$NEW_BRANCH_DB_ASSET" != "$OLD_BRANCH_DB_ASSET" ]; then
+  echo "Branch $NEW_BRANCH requires $NEW_BRANCH_DB_ASSET from $NEW_BRANCH_DB_VERSION."
+  installDB.bash --release="$NEW_DB_VERSION" --asset="$NEW_DB_ASSET"
 fi
-
-#if [ "$NEW_DB_VERSION" != "$OLD_DB_VERSION" ] || [ "$NEW_DB_ASSET" != "$OLD_DB_ASSET" ]; then
-#  echo "Branch $NEW_BRANCH requires $NEW_DB_ASSET from $NEW_DB_VERSION."
-#  installDB.bash --release="$NEW_DB_VERSION" --asset="$NEW_DB_ASSET"
-#fi

--- a/.githooks/post-checkout
+++ b/.githooks/post-checkout
@@ -27,15 +27,14 @@ if [ ! "$IS_FILE" ]; then
   exit 0
 fi
 
-# Check if the db.conf information has been modified since the last commit.
-# GIT_STATUS=$(git status --porcelain | grep "M  .fd2dev/db.conf")
-# if [ "$GIT_STATUS" ]; then
-#   # If the file is modified, get the new version and asset from the commit.
-
-# fi
-
 NEW_BRANCH_DB_VERSION=$(git show "$TO_REF:.fd2dev/db.conf" 2> /dev/null | head -1)
 NEW_BRANCH_DB_ASSET=$(git show "$TO_REF:.fd2dev/db.conf" 2> /dev/null | tail -1)
+# Don't run this if the new branch does not have db information
+# This will happen when switching to a branch made before this script was merged
+# into development.
+if [ ! "$NEW_BRANCH_DB_VERSION" ]; then
+  exit 0
+fi
 
 WORKING_FILES_DB_VERSION=$(head -1 ".fd2dev/db.conf")
 WORKING_FILES_DB_ASSET=$(tail -1 ".fd2dev/db.conf")
@@ -59,7 +58,10 @@ if
   [ "$NEW_BRANCH_DB_VERSION" != "$WORKING_FILES_DB_VERSION" ] \
     || [ "$NEW_BRANCH_DB_ASSET" != "$WORKING_FILES_DB_ASSET" ]
 then
-  echo "Database version has been changed but not committed."
+  echo "A new database version was installed by installDB.bash."
+  echo "But .fd2dev/db.conf has not been committed."
+  echo "Thus the currently installed database may not be compatible with the $NEW_BRANCH branch."
+  echo "Be sure to commit the changes to .fd2dev/db.conf to your feature branch."
 fi
 
 #if [ "$NEW_DB_VERSION" != "$OLD_DB_VERSION" ] || [ "$NEW_DB_ASSET" != "$OLD_DB_ASSET" ]; then

--- a/.githooks/post-checkout
+++ b/.githooks/post-checkout
@@ -12,11 +12,6 @@ FROM_REF=$1
 TO_REF=$2
 IS_FILE=$3
 
-echo "FROM_REF: $FROM_REF"
-echo "TO_REF: $TO_REF"
-echo "IS_FILE: $IS_FILE"
-echo ""
-
 # Don't run this when a repo is cloned.
 if [ -z "$FROM_REF" ]; then
   exit 0
@@ -36,13 +31,14 @@ echo "Running FarmData2 post-checkout hook..."
 
 NEW_DB_VERSION=$(head -1 ".fd2dev/db.conf")
 NEW_DB_ASSET=$(tail -1 ".fd2dev/db.conf")
-
 OLD_DB_VERSION=$(git show "$FROM_REF:.fd2dev/db.conf" | head -1)
 OLD_DB_ASSET=$(git show "$FROM_REF:.fd2dev/db.conf" | tail -1)
 
-echo "New branch DB version: $NEW_DB_VERSION"
-echo "  New branch DB asset: $NEW_DB_ASSET"
-echo "Old branch DB version: $OLD_DB_VERSION"
-echo "  Old branch DB asset: $OLD_DB_ASSET"
+NEW_BRANCH=$(git rev-parse --abbrev-ref HEAD)
+
+if [ "$NEW_DB_VERSION" != "$OLD_DB_VERSION" ] || [ "$NEW_DB_ASSET" != "$OLD_DB_ASSET" ]; then
+  echo "Branch $NEW_BRANCH requires $NEW_DB_ASSET from $NEW_DB_VERSION."
+  installDB.bash --release="$NEW_DB_VERSION" --asset="$NEW_DB_ASSET"
+fi
 
 echo "Done."

--- a/.githooks/post-checkout
+++ b/.githooks/post-checkout
@@ -27,8 +27,8 @@ fi
 
 echo "Running FarmData2 post-checkout hook..."
 
-DB_VERSION=$(head -1 "$REPO_ROOT_DIR"/.fd2/db.version)
-DB_ASSET=$(tail -1 "$REPO_ROOT_DIR"/.fd2/db.asset)
+DB_VERSION=$(head -1 "$REPO_ROOT_DIR"/.fd2dev/db.conf)
+DB_ASSET=$(tail -1 "$REPO_ROOT_DIR"/.fd2dev/db.conf)
 
 echo "$FROM_REF"
 echo "$TO_REF"

--- a/.githooks/post-checkout
+++ b/.githooks/post-checkout
@@ -30,8 +30,8 @@ echo "Running FarmData2 post-checkout hook..."
 NEW_DB_VERSION=$(head -1 "$REPO_ROOT_DIR"/.fd2dev/db.conf)
 NEW_DB_ASSET=$(tail -1 "$REPO_ROOT_DIR"/.fd2dev/db.conf)
 
-OLD_DB_VERSION=$(git show "$FROM_REF:$REPO_ROOT_DIR/.fd2/db.conf" | head -1)
-OLD_DB_ASSET=$(git show "$FROM_REF:$REPO_ROOT_DIR/.fd2/db.conf" | tail -1)
+OLD_DB_VERSION=$(git show "$FROM_REF:$REPO_ROOT_DIR/.fd2dev/db.conf" | head -1)
+OLD_DB_ASSET=$(git show "$FROM_REF:$REPO_ROOT_DIR/.fd2dev/db.conf" | tail -1)
 
 echo "New branch DB version: $NEW_DB_VERSION"
 echo "  New branch DB asset: $NEW_DB_ASSET"

--- a/.githooks/post-checkout
+++ b/.githooks/post-checkout
@@ -37,8 +37,8 @@ echo "Running FarmData2 post-checkout hook..."
 NEW_DB_VERSION=$(head -1 ".fd2dev/db.conf")
 NEW_DB_ASSET=$(tail -1 ".fd2dev/db.conf")
 
-OLD_DB_VERSION=$(git show ".fd2dev/db.conf" | head -1)
-OLD_DB_ASSET=$(git show ".fd2dev/db.conf" | tail -1)
+OLD_DB_VERSION=$(git show "$FROM_REF:.fd2dev/db.conf" | head -1)
+OLD_DB_ASSET=$(git show "$FROM_REF:.fd2dev/db.conf" | tail -1)
 
 echo "New branch DB version: $NEW_DB_VERSION"
 echo "  New branch DB asset: $NEW_DB_ASSET"

--- a/.githooks/post-checkout
+++ b/.githooks/post-checkout
@@ -27,8 +27,8 @@ fi
 
 echo "Running FarmData2 post-checkout hook..."
 
-DB_VERSION=$(head -1 ~/.fd2/db.version)
-DB_ASSET=$(tail -1 ~/.fd2/db.asset)
+DB_VERSION=$(head -1 "$REPO_ROOT_DIR"/.fd2/db.version)
+DB_ASSET=$(tail -1 "$REPO_ROOT_DIR"/.fd2/db.asset)
 
 echo "$FROM_REF"
 echo "$TO_REF"

--- a/.githooks/post-checkout
+++ b/.githooks/post-checkout
@@ -10,7 +10,7 @@ FROM_BRANCH=$1
 TO_BRANCH=$2
 
 # Don't run this when a repo is cloned.
-if (! "$FROM_BRANCH"); then
+if [ -z "$FROM_BRANCH" ]; then
   exit 0
 fi
 

--- a/.githooks/post-checkout
+++ b/.githooks/post-checkout
@@ -3,11 +3,22 @@
 # This post-checkout hook ensures the version of the sampleDB
 # that is installed is compatible with the code in the branch.
 
-# shellcheck disable=SC1091  # Make sources okay.
-source lib.bash
+REPO_ROOT_DIR=$(git rev-parse --show-toplevel)
+source "$REPO_ROOT_DIR/bin/lib.bash"
 
 FROM_BRANCH=$1
 TO_BRANCH=$2
 
+# Don't run this when a repo is cloned.
+if (! "$FROM_BRANCH"); then
+  exit 0
+fi
+
+# Don't run this unless we are in the FarmData2 repo.
+
+echo "Running FarmData2 post-checkout hook..."
+
 echo "$FROM_BRANCH"
 echo "$TO_BRANCH"
+
+echo "Done."

--- a/.githooks/post-checkout
+++ b/.githooks/post-checkout
@@ -27,8 +27,6 @@ if [ ! "$IS_FILE" ]; then
   exit 0
 fi
 
-echo "Running FarmData2 post-checkout hook..."
-
 NEW_DB_VERSION=$(head -1 ".fd2dev/db.conf")
 NEW_DB_ASSET=$(tail -1 ".fd2dev/db.conf")
 
@@ -41,5 +39,3 @@ if [ "$NEW_DB_VERSION" != "$OLD_DB_VERSION" ] || [ "$NEW_DB_ASSET" != "$OLD_DB_A
   echo "Branch $NEW_BRANCH requires $NEW_DB_ASSET from $NEW_DB_VERSION."
   installDB.bash --release="$NEW_DB_VERSION" --asset="$NEW_DB_ASSET"
 fi
-
-echo "Done."

--- a/.githooks/post-checkout
+++ b/.githooks/post-checkout
@@ -27,12 +27,15 @@ fi
 
 echo "Running FarmData2 post-checkout hook..."
 
-DB_VERSION=$(head -1 "$REPO_ROOT_DIR"/.fd2dev/db.conf)
-DB_ASSET=$(tail -1 "$REPO_ROOT_DIR"/.fd2dev/db.conf)
+NEW_DB_VERSION=$(head -1 "$REPO_ROOT_DIR"/.fd2dev/db.conf)
+NEW_DB_ASSET=$(tail -1 "$REPO_ROOT_DIR"/.fd2dev/db.conf)
 
-echo "$FROM_REF"
-echo "$TO_REF"
-echo "$DB_VERSION"
-echo "$DB_ASSET"
+OLD_DB_VERSION=$(git show "$FROM_REF:$REPO_ROOT_DIR/.fd2/db.conf" | head -1)
+OLD_DB_ASSET=$(git show "$FROM_REF:$REPO_ROOT_DIR/.fd2/db.conf" | tail -1)
+
+echo "New branch DB version: $NEW_DB_VERSION"
+echo "  New branch DB asset: $NEW_DB_ASSET"
+echo "Old branch DB version: $OLD_DB_VERSION"
+echo "  Old branch DB asset: $OLD_DB_ASSET"
 
 echo "Done."

--- a/.githooks/post-checkout
+++ b/.githooks/post-checkout
@@ -57,7 +57,7 @@ echo "NEW_BRANCH: $NEW_BRANCH"
 
 if
   [ "$NEW_BRANCH_DB_VERSION" != "$WORKING_FILES_DB_VERSION" ] \
-    || [ "$NEW_BRANCH_DB_ASSET" != "$OLD_BRANCH_DB_ASSET" ]
+    || [ "$NEW_BRANCH_DB_ASSET" != "$WORKING_FILES_DB_ASSET" ]
 then
   echo "Database version has been changed but not committed."
 fi

--- a/.gitignore
+++ b/.gitignore
@@ -39,5 +39,6 @@ scratch
 spikes
 .vale
 .fd2
+!.fd2dev/*
 .devcontainer/fd2_welcome.md
 bin/vale

--- a/bin/installDB.bash
+++ b/bin/installDB.bash
@@ -189,13 +189,13 @@ else
 fi
 
 if [ -n "$CURRENT" ]; then
-  echo -e "${UNDERLINE_GREEN}Installing $DB_ASSET from $HOME/.fd2/...${NO_COLOR}"
+  echo -e "${UNDERLINE_GREEN}Installing $DB_ASSET from $REPO_DIR/.fd2/...${NO_COLOR}"
 else
   echo -e "${UNDERLINE_GREEN}Installing $DB_ASSET from release $DB_RELEASE...${NO_COLOR}"
 
-  if [ -f "$HOME/.fd2/$DB_ASSET" ]; then
+  if [ -f "$REPO_DIR/.fd2/$DB_ASSET" ]; then
     echo "Deleting existing database archives..."
-    rm "$HOME/.fd2/$DB_ASSET"
+    rm "$REPO_DIR/.fd2/$DB_ASSET"
     error_check "Unable to delete existing database archives."
     echo "  Deleted."
   fi
@@ -203,7 +203,7 @@ else
   echo "Downloading database \"$DB_ASSET\" from release $DB_RELEASE..."
   gh release download "$DB_RELEASE" \
     --repo FarmData2/FD2-SampleDBs \
-    --dir "$HOME/.fd2/" \
+    --dir "$REPO_DIR/.fd2/" \
     --pattern "$DB_ASSET" \
     --clobber
   error_check "Unable to download the database."
@@ -237,7 +237,7 @@ error_check "Unable to delete the current database."
 echo "  Deleted."
 
 echo "Extracting $DB_ASSET..."
-echo "fd2dev" | sudo -Sk -p "" tar -xzf "$HOME/.fd2/$DB_ASSET" > /dev/null
+echo "fd2dev" | sudo -Sk -p "" tar -xzf "$REPO_DIR/.fd2/$DB_ASSET" > /dev/null
 error_check "Error extracting the database."
 echo "  Extracted."
 
@@ -270,9 +270,9 @@ echo "  Drupal cache cleared."
 echo -e "${ORANGE}RECOMMENDED ACTION: Clear browser cache.${NO_COLOR}"
 
 if [ -n "$CURRENT" ]; then
-  echo -e "${UNDERLINE_GREEN}Installed $DB_ASSET from $HOME/.fd2/.${NO_COLOR}"
+  echo -e "${UNDERLINE_GREEN}Installed $DB_ASSET from $REPO_DIR/.fd2/.${NO_COLOR}"
 else
-  echo "$DB_RELEASE" > "$HOME/.fd2/db.version.txt"
-  echo "$DB_ASSET" >> "$HOME/.fd2/db.version.txt"
+  echo "$DB_RELEASE" > "$REPO_DIR/.fd2dev/db.conf"
+  echo "$DB_ASSET" >> "$REPO_DIR/.fd2dev/db.conf"
   echo -e "${UNDERLINE_GREEN}Installed $DB_ASSET from release $DB_RELEASE.${NO_COLOR}"
 fi

--- a/bin/installDB.bash
+++ b/bin/installDB.bash
@@ -52,42 +52,42 @@ else
 
   while true; do
     case $1 in
-    -a | --asset)
-      if [ "$2" == "" ]; then
-        echo -e "${ON_RED}ERROR:${NO_COLOR} -a|--asset requires an argument."
-        echo "Use installDB.bash --help for usage information"
-        exit 255
-      fi
-      DB_ASSET=$2
-      shift 2
-      ;;
-    -c | --current)
-      CURRENT=1
-      shift 2
-      ;;
-    -h | --help)
-      usage
-      ;;
-    -p | --prompt)
-      PROMPT=1
-      shift 2
-      ;;
-    -r | --release)
-      if [ "$2" == "" ]; then
-        echo -e "${ON_RED}ERROR:${NO_COLOR} -r|--release requires an argument."
-        echo "Use installDB.bash --help for usage information"
-        exit 255
-      fi
-      DB_RELEASE=$2
-      shift 2
-      ;;
-    --)
-      shift
-      break
-      ;;
-    *)
-      usage
-      ;;
+      -a | --asset)
+        if [ "$2" == "" ]; then
+          echo -e "${ON_RED}ERROR:${NO_COLOR} -a|--asset requires an argument."
+          echo "Use installDB.bash --help for usage information"
+          exit 255
+        fi
+        DB_ASSET=$2
+        shift 2
+        ;;
+      -c | --current)
+        CURRENT=1
+        shift 2
+        ;;
+      -h | --help)
+        usage
+        ;;
+      -p | --prompt)
+        PROMPT=1
+        shift 2
+        ;;
+      -r | --release)
+        if [ "$2" == "" ]; then
+          echo -e "${ON_RED}ERROR:${NO_COLOR} -r|--release requires an argument."
+          echo "Use installDB.bash --help for usage information"
+          exit 255
+        fi
+        DB_RELEASE=$2
+        shift 2
+        ;;
+      --)
+        shift
+        break
+        ;;
+      *)
+        usage
+        ;;
     esac
   done
 fi
@@ -130,8 +130,8 @@ elif [ -n "$DB_RELEASE" ] && [ -n "$DB_ASSET" ]; then
   # shellcheck disable=SC2207
   RELEASES=(
     $(gh release list \
-      --repo FarmData2/FD2-SampleDBs |
-      head -n5 | cut -f1)
+      --repo FarmData2/FD2-SampleDBs \
+      | head -n5 | cut -f1)
   )
   # shellcheck disable=SC2207
   REL_INFO=$(gh release view --repo FarmData2/FD2-SampleDBs "$DB_RELEASE")
@@ -145,8 +145,8 @@ else
       $(gh release list \
         --exclude-drafts \
         --exclude-pre-releases \
-        --repo FarmData2/FD2-SampleDBs |
-        cut -f1)
+        --repo FarmData2/FD2-SampleDBs \
+        | cut -f1)
     )
 
     DB_RELEASE="${RELEASES[0]}"
@@ -157,8 +157,8 @@ else
       $(gh release list \
         --exclude-drafts \
         --exclude-pre-releases \
-        --repo FarmData2/FD2-SampleDBs |
-        head -n5 | cut -f1)
+        --repo FarmData2/FD2-SampleDBs \
+        | head -n5 | cut -f1)
     )
 
     echo "The 5 most recent releases are shown."
@@ -272,5 +272,7 @@ echo -e "${ORANGE}RECOMMENDED ACTION: Clear browser cache.${NO_COLOR}"
 if [ -n "$CURRENT" ]; then
   echo -e "${UNDERLINE_GREEN}Installed $DB_ASSET from $HOME/.fd2/.${NO_COLOR}"
 else
+  echo "$DB_RELEASE" > "$HOME/.fd2/db.version.txt"
+  echo "$DB_ASSET" >> "$HOME/.fd2/db.version.txt"
   echo -e "${UNDERLINE_GREEN}Installed $DB_ASSET from release $DB_RELEASE.${NO_COLOR}"
 fi


### PR DESCRIPTION
**Pull Request Description**

Stashes the currently installed db version and artifact in `.fd2dev/db.conf` when `installDB.bash` is run.  This value is then used by the `post-checkout` Git hook to change the db version when switching to a branch.  This ensures that the db installed is compatible with the code in the branch.

Closes #211

---

**Licensing Certification**

FarmData2 is a [Free Cultural Work](https://freedomdefined.org/Definition) and all accepted contributions are licensed as described in the LICENSE.md file. This requires that the contributor holds the rights to do so. By submitting this pull request **I certify that I satisfy the terms of the [Developer Certificate of Origin](https://developercertificate.org/)** for its contents.
