### PR TITLE
added prop for includeemptybeds

### DIFF
--- a/components/ActivePlantAssetPicklist/ActivePlantAssetPicklist.behavior.comp.cy.js
+++ b/components/ActivePlantAssetPicklist/ActivePlantAssetPicklist.behavior.comp.cy.js
@@ -232,4 +232,191 @@ describe('Test the ActivePlantAssetPicklist component behavior', () => {
         });
     });
   });
+
+  it('Should filter beds when includeEmptyBeds changes from true to false for ALF', () => {
+    const readySpy = cy.spy().as('readySpy');
+
+    cy.mount(ActivePlantAssetPicklist, {
+      props: {
+        location: 'ALF',
+        isInGround: true,
+        isInTrays: true,
+        includeEmptyBeds: true,
+        onReady: readySpy,
+      },
+    }).then(({ wrapper }) => {
+      cy.get('@readySpy')
+        .should('have.been.calledOnce')
+        .then(() => {
+          // Initially shows all beds (ALF-1, ALF-2, ALF-3, ALF-4)
+          cy.get(
+            '[data-cy="picker-options"] input[name="picker-options"]'
+          ).should('have.length', 4);
+          cy.get(
+            '[data-cy="picker-options"] input[name="picker-options"][value="ALF-3"]'
+          ).should('exist');
+          cy.get(
+            '[data-cy="picker-options"] input[name="picker-options"][value="ALF-4"]'
+          ).should('exist');
+        })
+        .then(() => {
+          wrapper.setProps({ includeEmptyBeds: false });
+
+          // Now shows only beds with active plant assets (ALF-1, ALF-2)
+          cy.get(
+            '[data-cy="picker-options"] input[name="picker-options"]'
+          ).should('have.length', 2);
+          cy.get(
+            '[data-cy="picker-options"] input[name="picker-options"][value="ALF-3"]'
+          ).should('not.exist');
+          cy.get(
+            '[data-cy="picker-options"] input[name="picker-options"][value="ALF-4"]'
+          ).should('not.exist');
+        });
+    });
+  });
+
+  it('Should show all beds when includeEmptyBeds changes from false to true for ALF', () => {
+    const readySpy = cy.spy().as('readySpy');
+
+    cy.mount(ActivePlantAssetPicklist, {
+      props: {
+        location: 'ALF',
+        isInGround: true,
+        isInTrays: true,
+        includeEmptyBeds: false,
+        onReady: readySpy,
+      },
+    }).then(({ wrapper }) => {
+      cy.get('@readySpy')
+        .should('have.been.calledOnce')
+        .then(() => {
+          // Initially shows only beds with active plant assets (ALF-1, ALF-2)
+          cy.get(
+            '[data-cy="picker-options"] input[name="picker-options"]'
+          ).should('have.length', 2);
+          cy.get(
+            '[data-cy="picker-options"] input[name="picker-options"][value="ALF-3"]'
+          ).should('not.exist');
+          cy.get(
+            '[data-cy="picker-options"] input[name="picker-options"][value="ALF-4"]'
+          ).should('not.exist');
+        })
+        .then(() => {
+          wrapper.setProps({ includeEmptyBeds: true });
+
+          // Now shows all beds (ALF-1, ALF-2, ALF-3, ALF-4)
+          cy.get(
+            '[data-cy="picker-options"] input[name="picker-options"]'
+          ).should('have.length', 4);
+          cy.get(
+            '[data-cy="picker-options"] input[name="picker-options"][value="ALF-3"]'
+          ).should('exist');
+          cy.get(
+            '[data-cy="picker-options"] input[name="picker-options"][value="ALF-4"]'
+          ).should('exist');
+        });
+    });
+  });
+
+  it('Should hide bed picker when switching from H (includeEmptyBeds: true) to H (includeEmptyBeds: false)', () => {
+    const readySpy = cy.spy().as('readySpy');
+
+    cy.mount(ActivePlantAssetPicklist, {
+      props: {
+        location: 'H',
+        isInGround: true,
+        isInTrays: true,
+        includeEmptyBeds: true,
+        onReady: readySpy,
+      },
+    }).then(({ wrapper }) => {
+      cy.get('@readySpy')
+        .should('have.been.calledOnce')
+        .then(() => {
+          // Initially shows bed picker with all beds (H-1, H-2)
+          cy.get('[data-cy="active-plant-asset-bed-picker"]').should('exist');
+          cy.get(
+            '[data-cy="picker-options"] input[name="picker-options"]'
+          ).should('have.length', 2);
+        })
+        .then(() => {
+          wrapper.setProps({ includeEmptyBeds: false });
+
+          // Now hides bed picker (no beds with active plant assets)
+          cy.get('[data-cy="active-plant-asset-bed-picker"]').should(
+            'not.exist'
+          );
+        });
+    });
+  });
+
+  it('Should show bed picker when switching from H (includeEmptyBeds: false) to H (includeEmptyBeds: true)', () => {
+    const readySpy = cy.spy().as('readySpy');
+
+    cy.mount(ActivePlantAssetPicklist, {
+      props: {
+        location: 'H',
+        isInGround: true,
+        isInTrays: true,
+        includeEmptyBeds: false,
+        onReady: readySpy,
+      },
+    }).then(({ wrapper }) => {
+      cy.get('@readySpy')
+        .should('have.been.calledOnce')
+        .then(() => {
+          // Initially hides bed picker (no beds with active plant assets)
+          cy.get('[data-cy="active-plant-asset-bed-picker"]').should(
+            'not.exist'
+          );
+        })
+        .then(() => {
+          wrapper.setProps({ includeEmptyBeds: true });
+
+          // Now shows bed picker with all beds (H-1, H-2)
+          cy.get('[data-cy="active-plant-asset-bed-picker"]').should('exist');
+          cy.get(
+            '[data-cy="picker-options"] input[name="picker-options"]'
+          ).should('have.length', 2);
+        });
+    });
+  });
+
+  it('Should maintain correct bed filtering when changing location with includeEmptyBeds: false', () => {
+    const readySpy = cy.spy().as('readySpy');
+
+    cy.mount(ActivePlantAssetPicklist, {
+      props: {
+        location: 'ALF',
+        isInGround: true,
+        isInTrays: true,
+        includeEmptyBeds: false,
+        onReady: readySpy,
+      },
+    }).then(({ wrapper }) => {
+      cy.get('@readySpy')
+        .should('have.been.calledOnce')
+        .then(() => {
+          // ALF with includeEmptyBeds: false shows only ALF-1, ALF-2
+          cy.get(
+            '[data-cy="picker-options"] input[name="picker-options"]'
+          ).should('have.length', 2);
+          cy.get(
+            '[data-cy="picker-options"] input[name="picker-options"][value="ALF-1"]'
+          ).should('exist');
+          cy.get(
+            '[data-cy="picker-options"] input[name="picker-options"][value="ALF-2"]'
+          ).should('exist');
+        })
+        .then(() => {
+          wrapper.setProps({ location: 'H' });
+
+          // H with includeEmptyBeds: false shows no beds (no active plant assets)
+          cy.get('[data-cy="active-plant-asset-bed-picker"]').should(
+            'not.exist'
+          );
+        });
+    });
+  });
 });

--- a/components/ActivePlantAssetPicklist/ActivePlantAssetPicklist.content.comp.cy.js
+++ b/components/ActivePlantAssetPicklist/ActivePlantAssetPicklist.content.comp.cy.js
@@ -265,4 +265,129 @@ describe('Test the default ActivePlantAssetPicklist content', () => {
       .last()
       .should('have.value', 'H-2');
   });
+
+  it('Shows all beds when includeEmptyBeds is true (default) for ALF', () => {
+    const readySpy = cy.spy().as('readySpy');
+
+    cy.mount(ActivePlantAssetPicklist, {
+      props: {
+        isInGround: true,
+        isInTrays: true,
+        location: 'ALF',
+        includeEmptyBeds: true,
+        onReady: readySpy,
+      },
+    });
+
+    cy.get('@readySpy')
+      .should('have.been.calledOnce')
+      .then(() => {
+        // Should show picklist with active plant assets
+        cy.get('[data-cy="active-plant-asset-picklist"]').should('exist');
+        cy.get('[data-cy="active-plant-asset-bed-picker"]').should('exist');
+
+        // Should show all beds (ALF-1, ALF-2, ALF-3, ALF-4) even though only ALF-1 and ALF-2 have plants
+        cy.get('[data-cy="picker-options"] input[name="picker-options"]')
+          .should('have.length', 4)
+          .first()
+          .should('have.value', 'ALF-1');
+        cy.get('[data-cy="picker-options"] input[name="picker-options"]')
+          .last()
+          .should('have.value', 'ALF-4');
+      });
+  });
+
+  it('Shows only beds with active plant assets when includeEmptyBeds is false for ALF', () => {
+    const readySpy = cy.spy().as('readySpy');
+
+    cy.mount(ActivePlantAssetPicklist, {
+      props: {
+        isInGround: true,
+        isInTrays: true,
+        location: 'ALF',
+        includeEmptyBeds: false,
+        onReady: readySpy,
+      },
+    });
+
+    cy.get('@readySpy')
+      .should('have.been.calledOnce')
+      .then(() => {
+        // Should show picklist with active plant assets
+        cy.get('[data-cy="active-plant-asset-picklist"]').should('exist');
+        cy.get('[data-cy="active-plant-asset-bed-picker"]').should('exist');
+
+        // Should show only beds with active plant assets (ALF-1, ALF-2)
+        cy.get('[data-cy="picker-options"] input[name="picker-options"]')
+          .should('have.length', 2)
+          .first()
+          .should('have.value', 'ALF-1');
+        cy.get('[data-cy="picker-options"] input[name="picker-options"]')
+          .last()
+          .should('have.value', 'ALF-2');
+
+        // Should NOT show ALF-3 and ALF-4 (beds without active plant assets)
+        cy.get(
+          '[data-cy="picker-options"] input[name="picker-options"][value="ALF-3"]'
+        ).should('not.exist');
+        cy.get(
+          '[data-cy="picker-options"] input[name="picker-options"][value="ALF-4"]'
+        ).should('not.exist');
+      });
+  });
+
+  it('Shows all beds when includeEmptyBeds is true for H', () => {
+    const readySpy = cy.spy().as('readySpy');
+
+    cy.mount(ActivePlantAssetPicklist, {
+      props: {
+        isInGround: true,
+        isInTrays: true,
+        location: 'H',
+        includeEmptyBeds: true,
+        onReady: readySpy,
+      },
+    });
+
+    cy.get('@readySpy')
+      .should('have.been.calledOnce')
+      .then(() => {
+        // Should show no picklist (no active plants)
+        cy.get('[data-cy="active-plant-asset-picklist"]').should('not.exist');
+        // Should show bed picker with all beds
+        cy.get('[data-cy="active-plant-asset-bed-picker"]').should('exist');
+
+        // Should show all beds (H-1, H-2)
+        cy.get('[data-cy="picker-options"] input[name="picker-options"]')
+          .should('have.length', 2)
+          .first()
+          .should('have.value', 'H-1');
+        cy.get('[data-cy="picker-options"] input[name="picker-options"]')
+          .last()
+          .should('have.value', 'H-2');
+      });
+  });
+
+  it('Shows no beds when includeEmptyBeds is false for H', () => {
+    const readySpy = cy.spy().as('readySpy');
+
+    cy.mount(ActivePlantAssetPicklist, {
+      props: {
+        isInGround: true,
+        isInTrays: true,
+        location: 'H',
+        includeEmptyBeds: false,
+        onReady: readySpy,
+      },
+    });
+
+    cy.get('@readySpy')
+      .should('have.been.calledOnce')
+      .then(() => {
+        // Should show no picklist
+        cy.get('[data-cy="active-plant-asset-picklist"]').should('not.exist');
+        // Should show no bed picker
+        cy.get('[data-cy="active-plant-asset-bed-picker"]').should('not.exist');
+      });
+  });
 });

--- a/components/ActivePlantAssetPicklist/ActivePlantAssetPicklist.events.area.comp.cy.js
+++ b/components/ActivePlantAssetPicklist/ActivePlantAssetPicklist.events.area.comp.cy.js
@@ -756,4 +756,50 @@ describe('Test the ActivePlantAssetPicklist `update:area` event', () => {
         });
     });
   });
+
+  it('Should reset area when switching from ALF to CHUAU with includeEmptyBeds false', () => {
+    const readySpy = cy.spy().as('readySpy');
+    const areaSpy = cy.spy().as('areaSpy');
+    const bedPickedSpy = cy.spy().as('bedPickedSpy');
+
+    cy.mount(ActivePlantAssetPicklist, {
+      props: {
+        location: 'ALF',
+        includeEmptyBeds: false,
+        onReady: readySpy,
+        'onUpdate:area': areaSpy,
+        'onUpdate:checkedBeds': bedPickedSpy,
+      },
+    }).then(({ wrapper }) => {
+      cy.get('@readySpy')
+        .should('have.been.calledOnce')
+        .then(() => {
+          cy.get('@areaSpy').should('have.been.calledTwice');
+          cy.get('@bedPickedSpy').should('not.have.been.called');
+
+          // Select a bed in ALF that has active plant assets
+          cy.get(
+            '[data-cy="picker-options"] input[name="picker-options"][value="ALF-2"]'
+          ).check();
+
+          cy.get('@areaSpy')
+            .should('have.been.calledThrice')
+            .its('lastCall.args.0')
+            .should((areaValue) => {
+              expect(areaValue).to.be.greaterThan(0);
+            });
+        })
+        .then(() => {
+          // Switch to CHUAU
+          wrapper.setProps({ location: 'CHUAU' });
+          // Area should reset (likely to 0)
+          cy.get('@areaSpy')
+            .should('have.callCount', 4)
+            .its('lastCall.args.0')
+            .should((areaValue) => {
+              expect(areaValue).to.equal(0);
+            });
+        });
+    });
+  });
 });

--- a/components/ActivePlantAssetPicklist/ActivePlantAssetPicklist.vue
+++ b/components/ActivePlantAssetPicklist/ActivePlantAssetPicklist.vue
@@ -245,8 +245,10 @@ export default {
       this.$emit('update:area', area);
       this.updateCheckedBedsFromPicked(this.pickedRow);
 
-      // End update cycle
-      this.updateInProgress = false;
+      // End the update cycle AFTER Vue has processed watcher updates.
+      this.$nextTick(() => {
+        this.updateInProgress = false;
+      });
     },
 
     updateCheckedBedsFromPicked(newPicked) {
@@ -294,24 +296,17 @@ export default {
       this.picklistValid = valid;
     },
 
-    handleBedPickerUpdate(newBeds) {
-      // Track the previous state to detect changes
-      const previousBeds = [...this.checkedBeds];
-      this.checkedBeds = newBeds;
+    handleBedPickerUpdate(newBeds, oldBeds) {
+      // Emit the change event.
+      this.$emit('update:checkedBeds', newBeds);
 
-      /**
-       * Emitted when the set of selected beds changes.
-       *
-       * @event update:checkedBeds
-       * @property {string[]} checkedBeds - An array of bed identifiers that are currently selected in the BedPicker.
-       */
-      this.$emit('update:checkedBeds', this.checkedBeds);
+      // If an update cycle is already in progress, exit to prevent a loop.
+      if (this.updateInProgress) return;
 
-      // Find which beds were added and which were removed
-      const added = newBeds.filter((bed) => !previousBeds.includes(bed));
-      const removed = previousBeds.filter((bed) => !newBeds.includes(bed));
+      // Find which beds were added and which were removed...
+      const added = newBeds.filter((bed) => !oldBeds.includes(bed));
+      const removed = oldBeds.filter((bed) => !newBeds.includes(bed));
 
-      // If beds were added/removed, update the picklist
       if (added.length > 0 || removed.length > 0) {
         this.updatePickedFromCheckedBeds(added, removed);
       }
@@ -540,8 +535,8 @@ export default {
     },
 
     checkedBeds: {
-      handler(newBeds) {
-        this.handleBedPickerUpdate(newBeds);
+      handler(newBeds, oldBeds) {
+        this.handleBedPickerUpdate(newBeds, oldBeds);
       },
     },
 

--- a/components/ActivePlantAssetPicklist/ActivePlantAssetPicklist.vue
+++ b/components/ActivePlantAssetPicklist/ActivePlantAssetPicklist.vue
@@ -172,26 +172,24 @@ export default {
     locationHasBeds() {
       return this.filteredBedNames.length > 0;
     },
-    filteredBedsInLocation() {
+    filteredBedNames() {
+      // Extract bed names from bedsInLocation once
+      const allBedNames = this.bedsInLocation.map((bed) =>
+        bed.attributes ? bed.attributes.name : bed
+      );
+
       if (this.includeEmptyBeds) {
-        return this.bedsInLocation;
+        // Return all bed names
+        return allBedNames;
       } else {
-        // Only beds that have active plant assets
+        // Only return bed names that have active plant assets
         const bedsWithPlants = new Set(
           this.affectedPlants
             .map((plant) => plant.bed)
             .filter((bed) => bed && bed !== 'N/A')
         );
-        return this.bedsInLocation.filter((bed) => {
-          const bedName = bed.attributes ? bed.attributes.name : bed;
-          return bedsWithPlants.has(bedName);
-        });
+        return Array.from(bedsWithPlants);
       }
-    },
-    filteredBedNames() {
-      return this.filteredBedsInLocation.map((bed) =>
-        bed.attributes ? bed.attributes.name : bed
-      );
     },
 
     picklistRequired() {
@@ -297,11 +295,6 @@ export default {
     },
 
     handleBedPickerUpdate(newBeds) {
-      // If we're already processing an update, don't trigger another update cycle
-      if (this.updateInProgress) return;
-
-      this.updateInProgress = true; // Start update cycle
-
       // Track the previous state to detect changes
       const previousBeds = [...this.checkedBeds];
       this.checkedBeds = newBeds;
@@ -322,9 +315,6 @@ export default {
       if (added.length > 0 || removed.length > 0) {
         this.updatePickedFromCheckedBeds(added, removed);
       }
-
-      // End update cycle
-      this.updateInProgress = false;
     },
 
     updatePickedFromCheckedBeds(added = [], removed = []) {

--- a/components/ActivePlantAssetPicklist/ActivePlantAssetPicklist.vue
+++ b/components/ActivePlantAssetPicklist/ActivePlantAssetPicklist.vue
@@ -1,15 +1,16 @@
 <template>
   <div class="active-plant-asset-picklist-container">
-    <BedPicker
+    <PickerBase
       v-if="location && locationHasBeds"
       id="active-plant-asset-bed-picker"
       data-cy="active-plant-asset-bed-picker"
+      label="Beds"
+      invalid-feedback-text="At least one bed is required"
       v-bind:required="required"
-      v-bind:location="location"
-      v-bind:picked="checkedBeds"
-      v-on:update:picked="handleBedPickerUpdate($event)"
       v-bind:showValidityStyling="showValidityStyling"
-      v-on:valid="handleBedsValid($event)"
+      v-bind:options="filteredBedNames"
+      v-model:picked="checkedBeds"
+      v-on:valid="handleBedsValid"
     />
 
     <PicklistBase
@@ -34,7 +35,7 @@
 <script>
 import * as farmosUtil from '@libs/farmosUtil/farmosUtil';
 import PicklistBase from '@comps/PicklistBase/PicklistBase.vue';
-import BedPicker from '@comps/BedPicker/BedPicker.vue';
+import PickerBase from '@comps/PickerBase/PickerBase.vue';
 
 /**
  * The ActivePlantAssetPicklist allows the user to pick crops from a location.
@@ -76,7 +77,7 @@ import BedPicker from '@comps/BedPicker/BedPicker.vue';
  */
 export default {
   name: 'ActivePlantAssetPicklist',
-  components: { PicklistBase, BedPicker },
+  components: { PicklistBase, PickerBase },
   emits: [
     'ready',
     'valid',
@@ -138,6 +139,13 @@ export default {
       type: Boolean,
       default: false,
     },
+    /**
+     * Whether to include beds that do not have active plant assets.
+     */
+    includeEmptyBeds: {
+      type: Boolean,
+      default: true,
+    },
   },
 
   data() {
@@ -162,7 +170,28 @@ export default {
       return this.affectedPlants.length > 0;
     },
     locationHasBeds() {
-      return this.bedsInLocation.length > 0;
+      return this.filteredBedNames.length > 0;
+    },
+    filteredBedsInLocation() {
+      if (this.includeEmptyBeds) {
+        return this.bedsInLocation;
+      } else {
+        // Only beds that have active plant assets
+        const bedsWithPlants = new Set(
+          this.affectedPlants
+            .map((plant) => plant.bed)
+            .filter((bed) => bed && bed !== 'N/A')
+        );
+        return this.bedsInLocation.filter((bed) => {
+          const bedName = bed.attributes ? bed.attributes.name : bed;
+          return bedsWithPlants.has(bedName);
+        });
+      }
+    },
+    filteredBedNames() {
+      return this.filteredBedsInLocation.map((bed) =>
+        bed.attributes ? bed.attributes.name : bed
+      );
     },
 
     picklistRequired() {
@@ -257,6 +286,14 @@ export default {
       ) {
         this.checkedBeds = merged;
       }
+    },
+
+    handleBedsValid(event) {
+      this.bedsValid = event;
+    },
+
+    handlePicklistValid(valid) {
+      this.picklistValid = valid;
     },
 
     handleBedPickerUpdate(newBeds) {
@@ -368,14 +405,6 @@ export default {
       const areaPercentage = Math.round((weightedSum / totalUniqueBeds) * 100);
 
       return areaPercentage;
-    },
-
-    handleBedsValid(event) {
-      this.bedsValid = event;
-    },
-
-    handlePicklistValid(valid) {
-      this.picklistValid = valid;
     },
 
     async checkPlantsAtLocation() {
@@ -517,6 +546,12 @@ export default {
     isInGround: {
       handler() {
         this.checkPlantsAtLocation();
+      },
+    },
+
+    checkedBeds: {
+      handler(newBeds) {
+        this.handleBedPickerUpdate(newBeds);
       },
     },
 

--- a/modules/farm_fd2/src/entrypoints/soil_disturbance/App.vue
+++ b/modules/farm_fd2/src/entrypoints/soil_disturbance/App.vue
@@ -99,6 +99,7 @@
             v-bind:location="form.location"
             v-bind:showValidityStyling="validity.show"
             v-bind:picked="form.picked"
+            v-bind:includeEmptyBeds="true"
             v-on:update:picked="form.picked = $event"
             v-on:hasPlants="plantsAtLocation = $event"
             v-on:update:area="form.area = $event"

--- a/modules/farm_fd2/src/entrypoints/soil_disturbance/soil_disturbance.selections.e2e.cy.js
+++ b/modules/farm_fd2/src/entrypoints/soil_disturbance/soil_disturbance.selections.e2e.cy.js
@@ -33,9 +33,7 @@ describe('Soil Disturbance: Selector visibility scenarios', () => {
       .select('A');
     cy.get('[data-cy="termination-event-group"]').should('be.visible');
     cy.get('[data-cy="termination-event-picklist"]').should('be.visible');
-    cy.get('[data-cy="active-plant-asset-bed-picker"]')
-      .should('exist')
-      .and('be.visible');
+    cy.get('[data-cy="active-plant-asset-bed-picker"]').should('not.exist');
     cy.get('[data-cy="location-beds-accordion"]').should('not.exist');
   });
 
@@ -57,9 +55,7 @@ describe('Soil Disturbance: Selector visibility scenarios', () => {
       .select('J');
     cy.get('[data-cy="termination-event-group"]').should('not.be.visible');
     cy.get('[data-cy="termination-event-picklist"]').should('not.be.visible');
-    cy.get('[data-cy="active-plant-asset-bed-picker"]').should(
-      'not.be.visible'
-    );
+    cy.get('[data-cy="active-plant-asset-bed-picker"]').should('not.exist');
     cy.get('[data-cy="location-beds-accordion"]').should('not.exist');
   });
 });

--- a/modules/farm_fd2_examples/src/entrypoints/active_plant_asset_picklist/App.vue
+++ b/modules/farm_fd2_examples/src/entrypoints/active_plant_asset_picklist/App.vue
@@ -27,6 +27,7 @@
     v-bind:picked="form.picked"
     v-bind:isInTrays="isInTrays"
     v-bind:isInGround="isInGround"
+    v-bind:includeEmptyBeds="includeEmptyBeds"
     v-on:hasPlants="form.hasPlants = $event"
     v-on:update:picked="form.picked = $event"
     v-on:update:area="form.area = $event"
@@ -102,6 +103,17 @@
           />
         </td>
       </tr>
+      <tr>
+        <td>includeEmptyBeds</td>
+        <td>
+          <BFormCheckbox
+            id="includeEmptyBeds-checkbox"
+            data-cy="includeEmptyBeds-checkbox"
+            switch
+            v-model="includeEmptyBeds"
+          />
+        </td>
+      </tr>
     </tbody>
   </table>
 
@@ -172,6 +184,7 @@ export default {
       requiredRow: false,
       isInTrays: false,
       isInGround: true,
+      includeEmptyBeds: true,
       createdCount: 0,
     };
   },


### PR DESCRIPTION
**Pull Request Description**

Added includeEmptyBeds prop to ActivePlantAssetPicklist to control bed filtering
When includeEmptyBeds is false, only show beds with active plant assets. When true, show all beds in the location. Uses PickerBase directly for cleaner implementation.

Closes #513 

---

**Licensing Certification**

FarmData2 is a [Free Cultural Work](https://freedomdefined.org/Definition) and all accepted contributions are licensed as described in the LICENSE.md file. This requires that the contributor holds the rights to do so. By submitting this pull request **I certify that I satisfy the terms of the [Developer Certificate of Origin](https://developercertificate.org/)** for its contents.
