### PR TITLE
fix(comp): ActivePlantAssetPicklist - select all beds if no active plant assets

### DIFF
--- a/components/ActivePlantAssetPicklist/ActivePlantAssetPicklist.vue
+++ b/components/ActivePlantAssetPicklist/ActivePlantAssetPicklist.vue
@@ -579,7 +579,25 @@ export default {
       this.$emit('valid', this.isValid);
     },
 
-    immediate: true,
+    // When there are no active plant assets, auto-select all beds
+    affectedPlants: {
+      handler() {
+        if (
+          this.affectedPlants.length === 0 &&
+          this.bedsInLocation.length > 0
+        ) {
+          const allBedNames = this.bedsInLocation.map((bed) =>
+            bed.attributes ? bed.attributes.name : bed
+          );
+          if (
+            JSON.stringify(this.checkedBeds) !== JSON.stringify(allBedNames)
+          ) {
+            this.checkedBeds = allBedNames;
+          }
+        }
+      },
+      immediate: false,
+    },
   },
 
   created() {

--- a/components/LocationSelector/LocationSelector.content.comp.cy.js
+++ b/components/LocationSelector/LocationSelector.content.comp.cy.js
@@ -253,6 +253,27 @@ describe('Test the default LocationSelector content', () => {
       });
   });
 
+  it('renders location dropdown and ignores pickedBeds when allowBedSelection is false', () => {
+    const readySpy = cy.spy().as('readySpy');
+
+    cy.mount(LocationSelector, {
+      props: {
+        required: true,
+        showValidityStyling: true,
+        allowBedSelection: false,
+        includeGreenhouses: true,
+        onReady: readySpy,
+      },
+    });
+
+    cy.get('@readySpy')
+      .should('have.been.calledOnce')
+      .then(() => {
+        cy.get('[data-cy="selector-input"]').should('exist').and('be.visible');
+        cy.get('[data-cy="location-beds-accordion"]').should('not.exist');
+      });
+  });
+
   it('Verifies the add button is available for fields', () => {
     const readySpy = cy.spy().as('readySpy');
 

--- a/components/LocationSelector/LocationSelector.content.comp.cy.js
+++ b/components/LocationSelector/LocationSelector.content.comp.cy.js
@@ -259,9 +259,11 @@ describe('Test the default LocationSelector content', () => {
     cy.mount(LocationSelector, {
       props: {
         required: true,
-        showValidityStyling: true,
+        includeFields: true,
+        includeGreenhousesWithBeds: true,
+        selected: null,
+        showValidityStyling: false,
         allowBedSelection: false,
-        includeGreenhouses: true,
         onReady: readySpy,
       },
     });

--- a/components/LocationSelector/LocationSelector.vue
+++ b/components/LocationSelector/LocationSelector.vue
@@ -153,6 +153,13 @@ export default {
       default: false,
     },
     /**
+     * Whether to select all beds within a location by default.
+     */
+    selectAllBedsByDefault: {
+      type: Boolean,
+      default: false,
+    },
+    /**
      * Whether a location selection is required or not.
      */
     required: {
@@ -313,15 +320,18 @@ export default {
       return this.locationValid && bv;
     },
     showBedSelection() {
-      // Hide BedPicker UI, always return false
-      return false;
+      return this.allowBedSelection && this.beds.length > 0;
     },
   },
   methods: {
     handleUpdateSelected(event) {
       this.selectedLocation = event;
 
-      // No default bed selection logic needed
+      if (this.selectAllBedsByDefault) {
+        this.checkedBeds = this.beds;
+      } else {
+        this.checkedBeds = [];
+      }
 
       /**
        * The selected location has changed.
@@ -396,7 +406,11 @@ export default {
   },
   watch: {
     allowBedSelection() {
-      // No default bed selection logic needed
+      if (this.selectAllBedsByDefault) {
+        this.checkedBeds = this.beds;
+      } else {
+        this.checkedBeds = [];
+      }
     },
     checkedBeds: {
       handler() {

--- a/components/LocationSelector/LocationSelector.vue
+++ b/components/LocationSelector/LocationSelector.vue
@@ -390,8 +390,8 @@ export default {
           greenhouseMap = await farmosUtil.getGreenhouseIdToAssetMap();
         }
 
-        let beds = null;
-        if (this.allowBedSelection) {
+        let beds = [];
+        if (this.allowBedSelection || this.includeGreenhousesWithBeds) {
           beds = await farmosUtil.getBeds();
         }
 
@@ -449,8 +449,8 @@ export default {
       greenhouseMap = farmosUtil.getGreenhouseIdToAssetMap();
     }
 
-    let beds = null;
-    if (this.allowBedSelection) {
+    let beds = [];
+    if (this.allowBedSelection || this.includeGreenhousesWithBeds) {
       beds = farmosUtil.getBeds();
     }
 

--- a/components/LocationSelector/LocationSelector.vue
+++ b/components/LocationSelector/LocationSelector.vue
@@ -153,13 +153,6 @@ export default {
       default: false,
     },
     /**
-     * Whether to select all beds within a location by default.
-     */
-    selectAllBedsByDefault: {
-      type: Boolean,
-      default: false,
-    },
-    /**
      * Whether a location selection is required or not.
      */
     required: {
@@ -320,18 +313,15 @@ export default {
       return this.locationValid && bv;
     },
     showBedSelection() {
-      return this.allowBedSelection && this.beds.length > 0;
+      // Hide BedPicker UI, always return false
+      return false;
     },
   },
   methods: {
     handleUpdateSelected(event) {
       this.selectedLocation = event;
 
-      if (this.selectAllBedsByDefault) {
-        this.checkedBeds = this.beds;
-      } else {
-        this.checkedBeds = [];
-      }
+      // No default bed selection logic needed
 
       /**
        * The selected location has changed.
@@ -406,11 +396,7 @@ export default {
   },
   watch: {
     allowBedSelection() {
-      if (this.selectAllBedsByDefault) {
-        this.checkedBeds = this.beds;
-      } else {
-        this.checkedBeds = [];
-      }
+      // No default bed selection logic needed
     },
     checkedBeds: {
       handler() {

--- a/modules/farm_fd2/src/entrypoints/soil_disturbance/App.vue
+++ b/modules/farm_fd2/src/entrypoints/soil_disturbance/App.vue
@@ -57,24 +57,6 @@
           v-on:ready="createdCount++"
         />
 
-        <!-- Unified Bed & Plant Asset Selection -->
-        <ActivePlantAssetPicklist
-          id="unified-bed-plant-picklist"
-          data-cy="unified-bed-plant-picklist"
-          v-bind:required="form.termination"
-          v-bind:location="form.location"
-          v-bind:showValidityStyling="validity.show"
-          v-bind:picked="form.picked"
-          v-bind:includeEmptyBeds="true"
-          v-on:update:picked="form.picked = $event"
-          v-on:update:checkedBeds="form.beds = $event"
-          v-on:hasPlants="plantsAtLocation = $event"
-          v-on:update:area="form.area = $event"
-          v-on:valid="(valid) => (picklistValid = valid)"
-          v-on:error="(error) => showErrorToast('Network Error', error.message)"
-          v-on:ready="createdCount++"
-        />
-
         <!-- Termination Event -->
         <div
           id="termination-event-group"
@@ -106,6 +88,24 @@
             />
           </BFormGroup>
         </div>
+
+        <!-- Unified Bed & Plant Asset Selection -->
+        <ActivePlantAssetPicklist
+          id="unified-bed-plant-picklist"
+          data-cy="termination-event-picklist"
+          v-bind:required="form.termination"
+          v-bind:location="form.location"
+          v-bind:showValidityStyling="validity.show"
+          v-bind:picked="form.picked"
+          v-bind:includeEmptyBeds="true"
+          v-on:update:picked="form.picked = $event"
+          v-on:update:checkedBeds="form.beds = $event"
+          v-on:hasPlants="plantsAtLocation = $event"
+          v-on:update:area="form.area = $event"
+          v-on:valid="(valid) => (picklistValid = valid)"
+          v-on:error="(error) => showErrorToast('Network Error', error.message)"
+          v-on:ready="createdCount++"
+        />
         <hr />
 
         <!-- Equipment -->

--- a/modules/farm_fd2/src/entrypoints/soil_disturbance/App.vue
+++ b/modules/farm_fd2/src/entrypoints/soil_disturbance/App.vue
@@ -91,7 +91,7 @@
         </div>
 
         <ActivePlantAssetPicklist
-          id="termination-event--picklist"
+          id="termination-event-picklist"
           data-cy="termination-event-picklist"
           v-bind:required="form.termination"
           v-bind:location="form.location"

--- a/modules/farm_fd2/src/entrypoints/soil_disturbance/App.vue
+++ b/modules/farm_fd2/src/entrypoints/soil_disturbance/App.vue
@@ -50,66 +50,30 @@
           includeFields
           includeGreenhousesWithBeds
           v-model:selected="form.location"
-          v-bind:pickedBeds="form.beds"
-          v-bind:allowBedSelection="!plantsAtLocation"
           v-bind:showValidityStyling="validity.show"
           v-on:valid="validity.location = $event"
-          v-on:update:beds="
-            (checkedBeds, totalBeds) => handleBedsUpdate(checkedBeds, totalBeds)
-          "
           v-on:update:selected="form.location = $event"
           v-on:error="(msg) => showErrorToast('Network Error', msg)"
           v-on:ready="createdCount++"
         />
 
-        <!-- Termination Event -->
-        <div
-          id="termination-event-group"
-          data-cy="termination-event-group"
-          class="flex-column align-items-center"
-          v-show="plantsAtLocation"
-        >
-          <BFormGroup
-            id="termination-event-group-checkbox"
-            data-cy="termination-event-group-checkbox"
-            class="w-100"
-            label-for="termination-event-checkbox"
-            label-cols="auto"
-            label-align="end"
-          >
-            <template v-slot:label>
-              <span
-                id="termination-event-label"
-                data-cy="termination-event-label"
-                >Termination Event:</span
-              >
-            </template>
-
-            <BFormCheckbox
-              id="termination-event-checkbox"
-              data-cy="termination-event-checkbox"
-              v-model="form.termination"
-              size="lg"
-            />
-          </BFormGroup>
-          <ActivePlantAssetPicklist
-            id="termination-event-picklist"
-            data-cy="termination-event-picklist"
-            v-bind:required="form.termination"
-            v-bind:location="form.location"
-            v-bind:showValidityStyling="validity.show"
-            v-bind:picked="form.picked"
-            v-bind:includeEmptyBeds="true"
-            v-on:update:picked="form.picked = $event"
-            v-on:hasPlants="plantsAtLocation = $event"
-            v-on:update:area="form.area = $event"
-            v-on:valid="(valid) => (picklistValid = valid)"
-            v-on:error="
-              (error) => showErrorToast('Network Error', error.message)
-            "
-            v-on:ready="createdCount++"
-          />
-        </div>
+        <!-- Unified Bed & Plant Asset Selection -->
+        <ActivePlantAssetPicklist
+          id="termination-event-picklist"
+          data-cy="termination-event-picklist"
+          v-bind:required="form.termination"
+          v-bind:location="form.location"
+          v-bind:showValidityStyling="validity.show"
+          v-bind:picked="form.picked"
+          v-bind:includeEmptyBeds="true"
+          v-on:update:picked="form.picked = $event"
+          v-on:update:checkedBeds="form.beds = $event"
+          v-on:hasPlants="plantsAtLocation = $event"
+          v-on:update:area="form.area = $event"
+          v-on:valid="(valid) => (picklistValid = valid)"
+          v-on:error="(error) => showErrorToast('Network Error', error.message)"
+          v-on:ready="createdCount++"
+        />
         <hr />
 
         <!-- Equipment -->

--- a/modules/farm_fd2/src/entrypoints/soil_disturbance/App.vue
+++ b/modules/farm_fd2/src/entrypoints/soil_disturbance/App.vue
@@ -50,6 +50,7 @@
           includeFields
           includeGreenhousesWithBeds
           v-model:selected="form.location"
+          v-bind:allowBedSelection="false"
           v-bind:showValidityStyling="validity.show"
           v-on:valid="validity.location = $event"
           v-on:update:selected="form.location = $event"

--- a/modules/farm_fd2/src/entrypoints/soil_disturbance/App.vue
+++ b/modules/farm_fd2/src/entrypoints/soil_disturbance/App.vue
@@ -59,8 +59,8 @@
 
         <!-- Unified Bed & Plant Asset Selection -->
         <ActivePlantAssetPicklist
-          id="termination-event-picklist"
-          data-cy="termination-event-picklist"
+          id="unified-bed-plant-picklist"
+          data-cy="unified-bed-plant-picklist"
           v-bind:required="form.termination"
           v-bind:location="form.location"
           v-bind:showValidityStyling="validity.show"
@@ -74,6 +74,38 @@
           v-on:error="(error) => showErrorToast('Network Error', error.message)"
           v-on:ready="createdCount++"
         />
+
+        <!-- Termination Event -->
+        <div
+          id="termination-event-group"
+          data-cy="termination-event-group"
+          class="flex-column align-items-center"
+          v-show="plantsAtLocation"
+        >
+          <BFormGroup
+            id="termination-event-group-checkbox"
+            data-cy="termination-event-group-checkbox"
+            class="w-100"
+            label-for="termination-event-checkbox"
+            label-cols="auto"
+            label-align="end"
+          >
+            <template v-slot:label>
+              <span
+                id="termination-event-label"
+                data-cy="termination-event-label"
+                >Termination Event:</span
+              >
+            </template>
+
+            <BFormCheckbox
+              id="termination-event-checkbox"
+              data-cy="termination-event-checkbox"
+              v-model="form.termination"
+              size="lg"
+            />
+          </BFormGroup>
+        </div>
         <hr />
 
         <!-- Equipment -->

--- a/modules/farm_fd2/src/entrypoints/soil_disturbance/App.vue
+++ b/modules/farm_fd2/src/entrypoints/soil_disturbance/App.vue
@@ -90,9 +90,8 @@
           </BFormGroup>
         </div>
 
-        <!-- Unified Bed & Plant Asset Selection -->
         <ActivePlantAssetPicklist
-          id="unified-bed-plant-picklist"
+          id="termination-event--picklist"
           data-cy="termination-event-picklist"
           v-bind:required="form.termination"
           v-bind:location="form.location"

--- a/modules/farm_fd2/src/entrypoints/soil_disturbance/soil_disturbance.location.e2e.cy.js
+++ b/modules/farm_fd2/src/entrypoints/soil_disturbance/soil_disturbance.location.e2e.cy.js
@@ -52,4 +52,27 @@ describe('Soil Disturbance: Location Component', () => {
       .find('[data-cy="selector-input"]')
       .should('have.class', 'is-invalid');
   });
+
+  it('selects all beds by default for H', () => {
+    cy.get('[data-cy="soil-disturbance-location"]')
+      .find('[data-cy="selector-input"]')
+      .select('H');
+    cy.get('[data-cy="picker-options"]')
+      .find('input[type="checkbox"]')
+      .each((checkbox) => {
+        cy.wrap(checkbox).should('be.checked');
+      });
+  });
+
+  it('does not select all beds by default for ALF', () => {
+    cy.get('[data-cy="soil-disturbance-location"]')
+      .find('[data-cy="selector-input"]')
+      .select('ALF');
+    cy.get('[data-cy="picker-options"]')
+      .find('input[type="checkbox"]')
+      .should('have.length.greaterThan', 0)
+      .each((checkbox) => {
+        cy.wrap(checkbox).should('not.be.checked');
+      });
+  });
 });

--- a/modules/farm_fd2/src/entrypoints/soil_disturbance/soil_disturbance.selections.e2e.cy.js
+++ b/modules/farm_fd2/src/entrypoints/soil_disturbance/soil_disturbance.selections.e2e.cy.js
@@ -42,7 +42,6 @@ describe('Soil Disturbance: Selector visibility scenarios', () => {
       .find('[data-cy="selector-input"]')
       .select('H');
     cy.get('[data-cy="termination-event-group"]').should('not.be.visible');
-    //ISSUE HERE TOO
     cy.get('[data-cy="termination-event-picklist"]').should('be.visible');
     cy.get('[data-cy="active-plant-asset-bed-picker"]')
       .should('exist')
@@ -55,7 +54,6 @@ describe('Soil Disturbance: Selector visibility scenarios', () => {
       .find('[data-cy="selector-input"]')
       .select('J');
     cy.get('[data-cy="termination-event-group"]').should('not.be.visible');
-    //ISSUE HERE WITH BE VISIBLE
     cy.get('[data-cy="termination-event-picklist"]').should('be.visible');
     cy.get('[data-cy="active-plant-asset-bed-picker"]').should('not.exist');
     cy.get('[data-cy="location-beds-accordion"]').should('not.exist');

--- a/modules/farm_fd2/src/entrypoints/soil_disturbance/soil_disturbance.selections.e2e.cy.js
+++ b/modules/farm_fd2/src/entrypoints/soil_disturbance/soil_disturbance.selections.e2e.cy.js
@@ -42,11 +42,12 @@ describe('Soil Disturbance: Selector visibility scenarios', () => {
       .find('[data-cy="selector-input"]')
       .select('H');
     cy.get('[data-cy="termination-event-group"]').should('not.be.visible');
-    cy.get('[data-cy="termination-event-picklist"]').should('not.be.visible');
-    cy.get('[data-cy="active-plant-asset-bed-picker"]').should(
-      'not.be.visible'
-    );
-    cy.get('[data-cy="location-beds-accordion"]').should('be.visible');
+    //ISSUE HERE TOO
+    cy.get('[data-cy="termination-event-picklist"]').should('be.visible');
+    cy.get('[data-cy="active-plant-asset-bed-picker"]')
+      .should('exist')
+      .and('be.visible');
+    cy.get('[data-cy="location-beds-accordion"]').should('not.exist');
   });
 
   it('Shows neither BedSelector nor ActivePlantAssetPicklist for location J', () => {
@@ -54,7 +55,8 @@ describe('Soil Disturbance: Selector visibility scenarios', () => {
       .find('[data-cy="selector-input"]')
       .select('J');
     cy.get('[data-cy="termination-event-group"]').should('not.be.visible');
-    cy.get('[data-cy="termination-event-picklist"]').should('not.be.visible');
+    //ISSUE HERE WITH BE VISIBLE
+    cy.get('[data-cy="termination-event-picklist"]').should('be.visible');
     cy.get('[data-cy="active-plant-asset-bed-picker"]').should('not.exist');
     cy.get('[data-cy="location-beds-accordion"]').should('not.exist');
   });

--- a/modules/farm_fd2/src/entrypoints/soil_disturbance/soil_disturbance.submission.e2e.cy.js
+++ b/modules/farm_fd2/src/entrypoints/soil_disturbance/soil_disturbance.submission.e2e.cy.js
@@ -25,9 +25,6 @@ describe('Soil Disturbance: Submission tests', () => {
       cy.get('[data-cy="soil-disturbance-location"]')
         .find('[data-cy="selector-input"]')
         .select('H');
-      cy.get('[data-cy="location-bed-picker"]')
-        .find('[data-cy="picker-all-button"]')
-        .click();
     } else {
       cy.get('[data-cy="soil-disturbance-location"]')
         .find('[data-cy="selector-input"]')

--- a/modules/farm_fd2/src/entrypoints/soil_disturbance/soil_disturbance.termination.e2e.cy.js
+++ b/modules/farm_fd2/src/entrypoints/soil_disturbance/soil_disturbance.termination.e2e.cy.js
@@ -73,19 +73,16 @@ describe('Direct Seeding: Termination event group', () => {
     cy.get('[data-cy="termination-event-group"]').should('not.be.visible');
     cy.get('[data-cy="termination-event-checkbox"]').should('not.be.visible');
     cy.get('[data-cy="termination-event-label"]').should('not.be.visible');
-    cy.get('[data-cy="termination-event-picklist"]').should('not.be.visible');
+    cy.get('[data-cy="termination-event-picklist"]').should('be.visible');
     cy.get('[data-cy="picklist-all-button"]').should('not.exist');
     cy.get('[data-cy="sort-order-button"]').should('not.exist');
     cy.get('[data-cy^="picklist-checkbox-"]').should('not.exist');
 
     cy.get('[data-cy="active-plant-asset-bed-picker"]').should('exist');
-    cy.get('[data-cy="soil-disturbance-location"]')
+    cy.get('[data-cy="active-plant-asset-bed-picker"]')
       .find('[data-cy="picker-options"]')
       .should('be.visible');
-    cy.get('[data-cy="soil-disturbance-location"]')
-      .find('[data-cy="picker-all-button"]')
-      .should('be.visible');
-    cy.get('[data-cy="soil-disturbance-location"]')
+    cy.get('[data-cy="active-plant-asset-bed-picker"]')
       .find('[data-cy="picker-options"]')
       .find('input')
       .each(($el) => {
@@ -181,19 +178,18 @@ describe('Direct Seeding: Termination event group', () => {
     cy.get('[data-cy="termination-event-group"]').should('not.be.visible');
     cy.get('[data-cy="termination-event-checkbox"]').should('not.be.visible');
     cy.get('[data-cy="termination-event-label"]').should('not.be.visible');
-    cy.get('[data-cy="termination-event-picklist"]').should('not.be.visible');
+    cy.get('[data-cy="termination-event-picklist"]').should('be.visible');
     cy.get('[data-cy="picklist-all-button"]').should('not.exist');
     cy.get('[data-cy="sort-order-button"]').should('not.exist');
     cy.get('[data-cy^="picklist-checkbox-"]').should('not.exist');
 
-    cy.get('[data-cy="location-beds-accordion"]').should('exist');
-    cy.get('[data-cy="soil-disturbance-location"]')
+    cy.get('[data-cy="active-plant-asset-bed-picker"]')
+      .should('exist')
+      .and('be.visible');
+    cy.get('[data-cy="active-plant-asset-bed-picker"]')
       .find('[data-cy="picker-options"]')
       .should('be.visible');
-    cy.get('[data-cy="soil-disturbance-location"]')
-      .find('[data-cy="picker-all-button"]')
-      .should('be.visible');
-    cy.get('[data-cy="soil-disturbance-location"]')
+    cy.get('[data-cy="active-plant-asset-bed-picker"]')
       .find('[data-cy="picker-options"]')
       .find('input')
       .each(($el) => {
@@ -245,19 +241,18 @@ describe('Direct Seeding: Termination event group', () => {
     cy.get('[data-cy="termination-event-group"]').should('not.be.visible');
     cy.get('[data-cy="termination-event-checkbox"]').should('not.be.visible');
     cy.get('[data-cy="termination-event-label"]').should('not.be.visible');
-    cy.get('[data-cy="termination-event-picklist"]').should('not.be.visible');
+    cy.get('[data-cy="termination-event-picklist"]').should('be.visible');
     cy.get('[data-cy="picklist-all-button"]').should('not.exist');
     cy.get('[data-cy="sort-order-button"]').should('not.exist');
     cy.get('[data-cy^="picklist-checkbox-"]').should('not.exist');
 
-    cy.get('[data-cy="location-beds-accordion"]').should('exist');
-    cy.get('[data-cy="soil-disturbance-location"]')
+    cy.get('[data-cy="active-plant-asset-bed-picker"]')
+      .should('exist')
+      .and('be.visible');
+    cy.get('[data-cy="active-plant-asset-bed-picker"]')
       .find('[data-cy="picker-options"]')
       .should('be.visible');
-    cy.get('[data-cy="soil-disturbance-location"]')
-      .find('[data-cy="picker-all-button"]')
-      .should('be.visible');
-    cy.get('[data-cy="soil-disturbance-location"]')
+    cy.get('[data-cy="active-plant-asset-bed-picker"]')
       .find('[data-cy="picker-options"]')
       .find('input')
       .each(($el) => {

--- a/modules/farm_fd2/src/entrypoints/soil_disturbance/soil_disturbance.termination.e2e.cy.js
+++ b/modules/farm_fd2/src/entrypoints/soil_disturbance/soil_disturbance.termination.e2e.cy.js
@@ -78,7 +78,7 @@ describe('Direct Seeding: Termination event group', () => {
     cy.get('[data-cy="sort-order-button"]').should('not.exist');
     cy.get('[data-cy^="picklist-checkbox-"]').should('not.exist');
 
-    cy.get('[data-cy="location-beds-accordion"]').should('exist');
+    cy.get('[data-cy="active-plant-asset-bed-picker"]').should('exist');
     cy.get('[data-cy="soil-disturbance-location"]')
       .find('[data-cy="picker-options"]')
       .should('be.visible');


### PR DESCRIPTION
**Pull Request Description**

Select all beds if beds exist and there are no active plant assets in the location.

Closes #499 

---

**Licensing Certification**

FarmData2 is a [Free Cultural Work](https://freedomdefined.org/Definition) and all accepted contributions are licensed as described in the LICENSE.md file. This requires that the contributor holds the rights to do so. By submitting this pull request **I certify that I satisfy the terms of the [Developer Certificate of Origin](https://developercertificate.org/)** for its contents.
