### PR TITLE
fix(comp): patches selector in crop related component popup tests 

### DIFF
--- a/.lintstagedrc.cjs
+++ b/.lintstagedrc.cjs
@@ -235,6 +235,21 @@ const getCompTestsCompCyJs = (files) => {
   return testCommands;
 };
 
+const getCompTestsE2ECyJs = (files) => {
+  const testCommands = files.map((file) => {
+    if (compsTested.get(path.basename(path.dirname(file)))) {
+      return 'skipping ' + file;
+    } else {
+      return (
+        'test.bash --e2e --fd2 --live --glob=' +
+        file.substring(file.indexOf('/components'))
+      );
+    }
+  });
+
+  return testCommands;
+};
+
 /*
  * Construct a test command for each library .js file that is staged.
  * The command will use a glob to run all unit.cy.js unit tests in the
@@ -310,6 +325,9 @@ module.exports = {
   },
   'components/**/*.comp.cy.js': (files) => {
     return getCompTestsCompCyJs(files);
+  },
+  'components/**/*.e2e.cy.js': (files) => {
+    return getCompTestsE2ECyJs(files);
   },
   'library/!(cypress)/!(*unit.cy).js': (files) => {
     return getLibTestsJs(files);

--- a/components/CropSelector/CropSelector.popup.e2e.cy.js
+++ b/components/CropSelector/CropSelector.popup.e2e.cy.js
@@ -31,7 +31,7 @@ describe('CropSelector popup test', () => {
       .type('NewCrop');
 
     cy.get('@iframeBody')
-      .find('[id="edit-fd2-harvest-units-0-target-id"]', { timeout: 10000 })
+      .find('[id="edit-fd2-harvest-unit-0-target-id"]', { timeout: 10000 })
       .should('be.visible') // Ensure the input field is visible
       .type('COUNT');
 

--- a/components/MultiCropSelector/MultiCropSelector.popup.e2e.cy.js
+++ b/components/MultiCropSelector/MultiCropSelector.popup.e2e.cy.js
@@ -31,7 +31,7 @@ describe('MultiCropSelector popup test', () => {
       .type('NewCrop');
 
     cy.get('@iframeBody')
-      .find('[id="edit-fd2-harvest-units-0-target-id"]', { timeout: 10000 })
+      .find('[id="edit-fd2-harvest-unit-0-target-id"]', { timeout: 10000 })
       .should('be.visible') // Ensure the input field is visible
       .type('COUNT');
 


### PR DESCRIPTION
**Pull Request Description**

Patches typo in the popup tests for the harvest unit field in the CropSelector and MultCropSelector components.  It also adds component e2e tests to the lintstaged configuration.

Closes #520 

---

**Licensing Certification**

FarmData2 is a [Free Cultural Work](https://freedomdefined.org/Definition) and all accepted contributions are licensed as described in the LICENSE.md file. This requires that the contributor holds the rights to do so. By submitting this pull request **I certify that I satisfy the terms of the [Developer Certificate of Origin](https://developercertificate.org/)** for its contents.
