### PR TITLE
fix(fd2): patches soil disturbance submission test for empty beds

### DIFF
--- a/modules/farm_fd2/src/entrypoints/soil_disturbance/App.vue
+++ b/modules/farm_fd2/src/entrypoints/soil_disturbance/App.vue
@@ -374,6 +374,7 @@ export default {
 #termination-event-group {
   display: flex;
   align-items: center;
+  margin-bottom: 8px;
 }
 
 #termination-event-group label {

--- a/modules/farm_fd2/src/entrypoints/soil_disturbance/soil_disturbance.submission.e2e.cy.js
+++ b/modules/farm_fd2/src/entrypoints/soil_disturbance/soil_disturbance.submission.e2e.cy.js
@@ -44,6 +44,10 @@ describe('Soil Disturbance: Submission tests', () => {
 
       cy.get('[data-cy="picklist-checkbox-0"]').check();
       cy.get('[data-cy="picklist-checkbox-1"]').check();
+
+      cy.get(
+        '[data-cy="picker-options"] input[name="picker-options"][value="ALF-4"]'
+      ).check();
     }
 
     cy.get('[data-cy="multi-equipment-selector"]')
@@ -107,6 +111,9 @@ describe('Soil Disturbance: Submission tests', () => {
         expect(formData.picked.get(1).row.crop).to.equal('LETTUCE-ICEBERG');
         expect(formData.picked.get(1).row.bed).to.equal('ALF-1');
 
+        expect(formData.beds[0]).to.equal('ALF-1');
+        expect(formData.beds[1]).to.equal('ALF-4');
+
         /* The termination flag should remain false in this test to avoid
          * terminating crops. If termination is mistakenly set to true,
          * subsequent tests may fail as the database will reflect fewer
@@ -114,7 +121,7 @@ describe('Soil Disturbance: Submission tests', () => {
          */
         expect(formData.termination).to.equal(false);
 
-        expect(formData.area).to.equal(25);
+        expect(formData.area).to.equal(50);
       } else {
         expect(formData.location).to.equal('H');
         expect(formData.beds[0]).to.equal('H-1');


### PR DESCRIPTION
**Pull Request Description**

Adds an empty bed selection to the submission test for the case with active plant assets.

Closes #495 

---

**Licensing Certification**

FarmData2 is a [Free Cultural Work](https://freedomdefined.org/Definition) and all accepted contributions are licensed as described in the LICENSE.md file. This requires that the contributor holds the rights to do so. By submitting this pull request **I certify that I satisfy the terms of the [Developer Certificate of Origin](https://developercertificate.org/)** for its contents.
