### PR TITLE
fix(dev): patches the codespaces devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -67,13 +67,13 @@
               "label": "Open FarmData Dev Environment",
               "dependsOrder": "sequence",
               "dependsOn": [
-                //"Hide UI Elements",
                 "Open Loading Page",
                 "Customize Welcome Page",
                 "Run fd2-up.bash Script",
                 "Open Welcome Page",
                 "Start Heartbeat Server",
-                "Start Heartbeat Listener"
+                "Start Heartbeat Listener",
+                "Open Running Page"
               ],
               "runOptions": {
                 "runOn": "folderOpen"
@@ -129,7 +129,15 @@
               "presentation": {
                 "reveal": "never"
               }
-            }
+            },
+            {
+              "label": "Open Running Page",
+              "type": "shell",
+              "command": "sleep 300; code -r .devcontainer/fd2_running.md",
+              "presentation": {
+                "reveal": "never"
+              }
+            },
           ],
         }
       }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -133,7 +133,7 @@
             {
               "label": "Start Heartbeat Listener",
               "type": "shell",
-              "command": "ncat -lk 8888",
+              "command": "fuser -k 8888/tcp; ncat -lk 8888",
               "presentation": {
                 "reveal": "never"
               }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -71,9 +71,9 @@
                 "Customize Welcome Page",
                 "Run fd2-up.bash Script",
                 "Open Welcome Page",
+                "Open Running Page",
                 "Start Heartbeat Server",
-                "Start Heartbeat Listener",
-                "Open Running Page"
+                "Start Heartbeat Listener"
               ],
               "runOptions": {
                 "runOn": "folderOpen"
@@ -115,6 +115,14 @@
               }
             },
             {
+              "label": "Open Running Page",
+              "type": "shell",
+              "command": "sleep 300; code -r .devcontainer/fd2_running.md",
+              "presentation": {
+                "reveal": "never"
+              }
+            },
+            {
               "label": "Start Heartbeat Server",
               "type": "shell",
               "command": ".devcontainer/startHeartbeat.bash",
@@ -126,14 +134,6 @@
               "label": "Start Heartbeat Listener",
               "type": "shell",
               "command": "ncat -lk 8888",
-              "presentation": {
-                "reveal": "never"
-              }
-            },
-            {
-              "label": "Open Running Page",
-              "type": "shell",
-              "command": "sleep 300; code -r .devcontainer/fd2_running.md",
               "presentation": {
                 "reveal": "never"
               }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -137,8 +137,8 @@
               "presentation": {
                 "reveal": "never"
               }
-            },
-          ],
+            }
+          ]
         }
       }
     }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -65,7 +65,7 @@
               "label": "Open FarmData Dev Environment",
               "dependsOrder": "sequence",
               "dependsOn": [
-                "Hide UI Elements",
+                //"Hide UI Elements",
                 "Open Loading Page",
                 "Customize Welcome Page",
                 "Run fd2-up.bash Script",
@@ -80,14 +80,14 @@
                 "reveal": "never"
               }
             },
-            {
-              "label": "Hide UI Elements",
-              "type": "process",
-              "command": "${input:hideUIElements}",
-              "presentation": {
-                "reveal": "never"
-              }
-            },
+            // {
+            //   "label": "Hide UI Elements",
+            //   "type": "process",
+            //   "command": "${input:hideUIElements}",
+            //   "presentation": {
+            //     "reveal": "never"
+            //   }
+            // },
             {
               "label": "Open Loading Page",
               "type": "shell",

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -25,7 +25,8 @@
   "customizations": {
     "vscode": {
       "extensions": [
-        "emeraldwalk.RunOnSave"
+        "emeraldwalk.RunOnSave",
+        "sirmspencer.vscode-autohide"
       ],
       "settings": {
         // Hide most of the VSCode UI via settings.
@@ -48,6 +49,7 @@
         "window.restoreWindows": "none",
         "terminal.integrated.hideOnStartup": "always",
         "github.codespaces.devcontainerChangedNotificationStyle": "none",
+        "autoHide.hideOnOpen": true,
         "emeraldwalk.runonsave": {
           "commands": [
             {
@@ -80,14 +82,6 @@
                 "reveal": "never"
               }
             },
-            // {
-            //   "label": "Hide UI Elements",
-            //   "type": "process",
-            //   "command": "${input:hideUIElements}",
-            //   "presentation": {
-            //     "reveal": "never"
-            //   }
-            // },
             {
               "label": "Open Loading Page",
               "type": "shell",
@@ -137,22 +131,6 @@
               }
             }
           ],
-          "inputs": [
-            {
-              // Hides some additional VSCode UI elements for which there
-              // are no settings available.
-              "id": "hideUIElements",
-              "type": "command",
-              "command": "runCommands",
-              "args": {
-                "commands": [
-                  "workbench.action.closeAllEditors",
-                  "workbench.action.closeSidebar",
-                  "workbench.action.closePanel"
-                ]
-              }
-            }
-          ]
         }
       }
     }

--- a/.devcontainer/fd2_running.md
+++ b/.devcontainer/fd2_running.md
@@ -2,7 +2,7 @@
   <h1>The FarmData2 Development Environment</h1>
   <h3>The Development Environment is curently Running or Reopening</h3>
 
-  <image  src="../docs/install/images/FD2-dev-env.jpg" alt="The FarmData2 Development Environment"/>
+  <image src="../docs/install/images/FD2-dev-env.jpg" alt="The FarmData2 Development Environment" width="250"/>
         
   <br>
   If you are reopening the Codesoace<br>

--- a/.devcontainer/fd2_running.md
+++ b/.devcontainer/fd2_running.md
@@ -1,10 +1,17 @@
 <center>
   <h1>The FarmData2 Development Environment</h1>
-  <h3>The Development Environment is curently Running or Reopening</h3>
+  <h3>The Development Environment is currently running or is reopening.</h3>
 
   <image src="../docs/install/images/FD2-dev-env.jpg" alt="The FarmData2 Development Environment" width="250"/>
         
   <br>
-  If you are reopening the Codesoace<br>
-  the Loading Screen will appear in a few moments.<br>
+  If you are reopening an existing Development Environment<br>
+  the Loading screen will appear in a few moments.<br>
+  <br>
+  <br>
+  <small><small>
+  If this screen appeared before you opened the Development Environment<br>
+  you can click <a href="fd2_weclome.md">here</a>
+  to return to the Welcome screen.
+  </small></small>
 </center>

--- a/.devcontainer/fd2_running.md
+++ b/.devcontainer/fd2_running.md
@@ -1,0 +1,10 @@
+<center>
+  <h1>The FarmData2 Development Environment</h1>
+  <h3>The Development Environment is curently Running or Reopening</h3>
+
+  <image  src="../docs/install/images/FD2-dev-env.jpg" alt="The FarmData2 Development Environment"/>
+        
+  <br>
+  If you are reopening the Codesoace<br>
+  the Loading Screen will appear in a few moments.<br>
+</center>

--- a/.devcontainer/fd2_running.md
+++ b/.devcontainer/fd2_running.md
@@ -9,9 +9,8 @@
   the Loading screen will appear in a few moments.<br>
   <br>
   <br>
-  <small><small>
+  <small>
   If this screen appeared before you opened the Development Environment<br>
-  you can click <a href="fd2_weclome.md">here</a>
-  to return to the Welcome screen.
-  </small></small>
+  reload the browser window and wait for the Welcome screen. 
+  </small>
 </center>

--- a/.devcontainer/fd2_running.md
+++ b/.devcontainer/fd2_running.md
@@ -11,6 +11,9 @@
   <br>
   <small>
   If this screen appeared before you opened the Development Environment<br>
-  reload the browser window and wait for the Welcome screen. 
+  reload the browser window and wait for this screen to reappear.<br>
+  It will then be replaced shortly after by the Loading Screen<br>
+  and then the Welcome screen,<br>
+  from which you can launch the Development Environment.
   </small>
 </center>

--- a/bin/fd2-up.bash
+++ b/bin/fd2-up.bash
@@ -163,4 +163,6 @@ echo -e "${UNDERLINE_BLUE}FarmData2 Development Environment started${NO_COLOR}"
 echo ""
 
 # Run bash to pickup any new groups that were assigned to the user.
-/bin/bash
+if [[ "$PROFILE" != "codespace" ]]; then
+  /bin/bash
+fi

--- a/docs/install/codespaces.md
+++ b/docs/install/codespaces.md
@@ -18,7 +18,7 @@ Use the following steps to create a new FarmData2 Development Environment in Cod
 
 1. Log in to GitHub.
 
-1. [Create a (classic) Personal Access Token (PAT)] in GitHub with the `repo`, `workflow` and `codespace` scopes selected. Choose an expiration date that is appropraite for the work you plan to do. __Be sure to copy and paste your token somewhere safe.__ You'll need it later and you cannot retrieve again after you leave the creation page.
+1. [Create a (classic) Personal Access Token (PAT)] in GitHub with the `repo`, `workflow`, `read:org` and `codespace` scopes selected. Choose an expiration date that is appropraite for the work you plan to do. __Be sure to copy and paste your token somewhere safe.__ You'll need it later and you cannot retrieve again after you leave the creation page.
 
 1. Visit the [Codespace settings page](https://github.com/settings/codespaces). Scroll down and adjust the "Default Idle Timeout" setting. This is the amount of time the codespace will continue running if you are not interacting with the development environment. 15 minutes is a good balance that ensures the development environment is not shutdown too soon, but also does not waste your free usage.
 

--- a/docs/install/codespaces.md
+++ b/docs/install/codespaces.md
@@ -8,11 +8,11 @@ If you are already familiar with Codespaces, running the FarmData2 Development E
 
 ## Install Help
 
-If you run into problems during the install visit the dedicated [install stream](https://farmdata2.zulipchat.com/#narrow/stream/270906-install) on the [FarmData2 Zulip chat](https://farmdata2.zulipchat.com). Use the search feature to see of others have had and solved the problem you are experiencing. If you do not find a solution, post a summary of your problem and the community will help.
+If you run into problems during the install visit the dedicated [install channel](https://farmdata2.zulipchat.com/#narrow/stream/270906-install) on the [FarmData2 Zulip chat](https://farmdata2.zulipchat.com). Use the search feature to see of others have had and solved the problem you are experiencing. If you do not find a solution, post a summary of your problem and the community will help.
 
 ## Creating a FarmData2 Development Environment in Codespaces
 
-Creating a new FarmData2 Development Environment in Codespaces will take about 10 minutes. [Restarting a development environment](#restarting-a-farmdata2-development-environment-in-codespaces) is much faster.
+Creating a new FarmData2 Development Environment in Codespaces will take about 10 minutes. When you restart an existing development environment it will be much faster.
 
 Use the following steps to create a new FarmData2 Development Environment in Codespaces:
 

--- a/docs/install/codespaces.md
+++ b/docs/install/codespaces.md
@@ -37,7 +37,7 @@ Use the following steps to create a new FarmData2 Development Environment in Cod
 1. Connect to the FarmData2 Development Environment in one of the following ways:
 
    1. **Open in your Browser:** This is the fastest and easiest way to connect, but has the limitation that you will not be able to copy and paste information directly between the FarmData2 Development Environment and your local machine.
-      - Click the link provided under the "Open in your Browser" heading.
+      - Click the link provided on the "The FarmData2 Development Environment" page in your browser under the "Open in your Browser" heading.
       - The FarmData2 Development Environment will open in a new browser tab.
    2. **Open on your Machine with VNC:** If you will want to copy and paste information between the FarmData2 Development Environment and your local machine frequently, this is the best way to connect.
       - Confirm that the following dependencies are installed on your machine:
@@ -46,7 +46,7 @@ Use the following steps to create a new FarmData2 Development Environment in Cod
           - For Windows, download and run the `vncviewer64.1.13.0.exe` file.
           - For Mac, download and open the `TigerVNC.1.13.0.dmg` file and then copy the "TigerVNC Viewer" to your Applications folder.
           - Note: Newer versions of the Tiger VNC Viewer might work, but have not been tested.
-      - Follow the directions provided under the "Open on your Machine with VNC" heading.
+      - Follow the directions provided on the "The FarmData2 Development Environment" page in your browser under the "Open on your Machine with VNC" heading.
 
 1. Follow the directions to [Setup the FarmData2 Development Environment](setup.md).
 

--- a/docs/install/codespaces.md
+++ b/docs/install/codespaces.md
@@ -18,6 +18,8 @@ Use the following steps to create a new FarmData2 Development Environment in Cod
 
 1. Log in to GitHub.
 
+1. [Create a (classic) Personal Access Token (PAT)] in GitHub with the `repo`, `workflow` and `codespace` scopes selected. Choose an expiration date that is appropraite for the work you plan to do. __Be sure to copy and paste your token somewhere safe.__ You'll need it later and you cannot retrieve again after you leave the creation page.
+
 1. Visit the [Codespace settings page](https://github.com/settings/codespaces). Scroll down and adjust the "Default Idle Timeout" setting. This is the amount of time the codespace will continue running if you are not interacting with the development environment. 15 minutes is a good balance that ensures the development environment is not shutdown too soon, but also does not waste your free usage.
 
 1. Fork the [upstream FarmData2 repository](https://github.com/FarmData2/FarmData2) in GitHub.


### PR DESCRIPTION
**Pull Request Description**

The devcontainer spec (or at least an unsupported feature) has changed and the code that ran some `workspace.action` commands to hide some UI elements no longer works. This PR removes those elements and also updates some install documentation.

---

**Licensing Certification**

FarmData2 is a [Free Cultural Work](https://freedomdefined.org/Definition) and all accepted contributions are licensed as described in the LICENSE.md file. This requires that the contributor holds the rights to do so. By submitting this pull request **I certify that I satisfy the terms of the [Developer Certificate of Origin](https://developercertificate.org/)** for its contents.
