### PR TITLE
fix(dev): reorder devcontainer tasks to run heartbeat earlier

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -71,9 +71,9 @@
                 "Customize Welcome Page",
                 "Run fd2-up.bash Script",
                 "Open Welcome Page",
-                "Open Running Page",
                 "Start Heartbeat Server",
-                "Start Heartbeat Listener"
+                "Start Heartbeat Listener",
+                "Open Running Page"
               ],
               "runOptions": {
                 "runOn": "folderOpen"
@@ -115,14 +115,6 @@
               }
             },
             {
-              "label": "Open Running Page",
-              "type": "shell",
-              "command": "sleep 300; code -r .devcontainer/fd2_running.md",
-              "presentation": {
-                "reveal": "never"
-              }
-            },
-            {
               "label": "Start Heartbeat Server",
               "type": "shell",
               "command": ".devcontainer/startHeartbeat.bash",
@@ -133,7 +125,15 @@
             {
               "label": "Start Heartbeat Listener",
               "type": "shell",
-              "command": "fuser -k 8888/tcp; ncat -lk 8888",
+              "command": "fuser -k 8888/tcp; ncat -lk 8888 &",
+              "presentation": {
+                "reveal": "never"
+              }
+            },
+            {
+              "label": "Open Running Page",
+              "type": "shell",
+              "command": "sleep 300; code -r .devcontainer/fd2_running.md",
               "presentation": {
                 "reveal": "never"
               }


### PR DESCRIPTION
**Pull Request Description**

Heartbeat listener was not starting if the browser tab showing the "Running" screen was never active. This would be a common issue as once the dev env is started there is no reason to make the tab with the "Running" screen active again.  The heartbeat listener is now started before waiting to display the "Running" Screen which should address the issue.

---

**Licensing Certification**

FarmData2 is a [Free Cultural Work](https://freedomdefined.org/Definition) and all accepted contributions are licensed as described in the LICENSE.md file. This requires that the contributor holds the rights to do so. By submitting this pull request **I certify that I satisfy the terms of the [Developer Certificate of Origin](https://developercertificate.org/)** for its contents.
