### PR TITLE
fix(dev): patch codespace dev container to hide all UI

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -71,9 +71,9 @@
                 "Customize Welcome Page",
                 "Run fd2-up.bash Script",
                 "Open Welcome Page",
-                "Open Running Page",
                 "Start Heartbeat Server",
-                "Start Heartbeat Listener"
+                "Start Heartbeat Listener",
+                "Open Running Page"
               ],
               "runOptions": {
                 "runOn": "folderOpen"
@@ -115,14 +115,6 @@
               }
             },
             {
-              "label": "Open Running Page",
-              "type": "shell",
-              "command": "sleep 300; code -r .devcontainer/fd2_running.md",
-              "presentation": {
-                "reveal": "never"
-              }
-            },
-            {
               "label": "Start Heartbeat Server",
               "type": "shell",
               "command": ".devcontainer/startHeartbeat.bash",
@@ -133,7 +125,15 @@
             {
               "label": "Start Heartbeat Listener",
               "type": "shell",
-              "command": "fuser -k 8888/tcp; ncat -lk 8888",
+              "command": "fuser -k 8888/tcp; ncat -lk 8888 &",
+              "presentation": {
+                "reveal": "never"
+              }
+            },
+            {
+              "label": "Open Running Page",
+              "type": "shell",
+              "command": "sleep 300; code -r .devcontainer/fd2_running.md",
               "presentation": {
                 "reveal": "never"
               }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -125,7 +125,7 @@
             {
               "label": "Start Heartbeat Listener",
               "type": "shell",
-              "command": "fuser -k 8888/tcp; ncat -lk 8888 &",
+              "command": "fuser -k 8888/tcp; nohup bash -c 'ncat -lk 8888 &'> /dev/null 2>&1",
               "presentation": {
                 "reveal": "never"
               }


### PR DESCRIPTION
**Pull Request Description**

Patches the .devcontainer.json so that the heartbeat server runs in the background.  With the prior commit the heartbeat server process (ncat) was being terminated when the task completed. 

---

**Licensing Certification**

FarmData2 is a [Free Cultural Work](https://freedomdefined.org/Definition) and all accepted contributions are licensed as described in the LICENSE.md file. This requires that the contributor holds the rights to do so. By submitting this pull request **I certify that I satisfy the terms of the [Developer Certificate of Origin](https://developercertificate.org/)** for its contents.
