### PR TITLE
fix(dev): update the timeout for loading the running page

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -125,7 +125,7 @@
             {
               "label": "Open Running Page",
               "type": "shell",
-              "command": "sleep 10; code -r .devcontainer/fd2_running.md",
+              "command": "sleep 300; code -r .devcontainer/fd2_running.md",
               "presentation": {
                 "reveal": "never",
                 "panel": "new"

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -72,8 +72,8 @@
                 "Run fd2-up.bash Script",
                 "Open Welcome Page",
                 "Start Heartbeat Server",
-                "Start Heartbeat Listener",
-                "Open Running Page"
+                "Open Running Page",
+                "Start Heartbeat Listener"
               ],
               "runOptions": {
                 "runOn": "folderOpen"
@@ -123,21 +123,23 @@
               }
             },
             {
-              "label": "Start Heartbeat Listener",
+              "label": "Open Running Page",
               "type": "shell",
-              "command": "fuser -k 8888/tcp; nohup bash -c 'ncat -lk 8888 &'> /dev/null 2>&1",
+              "command": "sleep 10; code -r .devcontainer/fd2_running.md",
               "presentation": {
-                "reveal": "never"
+                "reveal": "never",
+                "panel": "new"
               }
             },
             {
-              "label": "Open Running Page",
+              "label": "Start Heartbeat Listener",
               "type": "shell",
-              "command": "sleep 300; code -r .devcontainer/fd2_running.md",
+              "command": "fuser -k 8888/tcp; ncat -lk 8888",
               "presentation": {
-                "reveal": "never"
+                "reveal": "never",
+                "panel": "new"
               }
-            }
+            },
           ]
         }
       }


### PR DESCRIPTION
**Pull Request Description**

The timeout was left at 10 seconds that was used for debugging and should have been changed back to 300 seconds. 

---

**Licensing Certification**

FarmData2 is a [Free Cultural Work](https://freedomdefined.org/Definition) and all accepted contributions are licensed as described in the LICENSE.md file. This requires that the contributor holds the rights to do so. By submitting this pull request **I certify that I satisfy the terms of the [Developer Certificate of Origin](https://developercertificate.org/)** for its contents.
