### PR TITLE
fix(dev): reveals terminal for the heartbeat listener

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -24,10 +24,7 @@
   },
   "customizations": {
     "vscode": {
-      "extensions": [
-        "emeraldwalk.RunOnSave",
-        "sirmspencer.vscode-autohide"
-      ],
+      "extensions": ["emeraldwalk.RunOnSave", "sirmspencer.vscode-autohide"],
       "settings": {
         // Hide most of the VSCode UI via settings.
         // Here instead of .vscode/settings.json so that
@@ -53,10 +50,10 @@
         "emeraldwalk.runonsave": {
           "commands": [
             {
-                "match": ".*",
-                "isAsync": true,
-                "autoShowOutputPanel": "never",
-                "cmd": "echo 'heartbeat' | ncat 172.18.0.1 8888"
+              "match": ".*",
+              "isAsync": true,
+              "autoShowOutputPanel": "never",
+              "cmd": "echo 'heartbeat' | ncat 172.18.0.1 8888"
             }
           ]
         },
@@ -136,10 +133,10 @@
               "type": "shell",
               "command": "fuser -k 8888/tcp; ncat -lk 8888",
               "presentation": {
-                "reveal": "never",
+                "reveal": "always",
                 "panel": "new"
               }
-            },
+            }
           ]
         }
       }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -24,7 +24,7 @@
   },
   "customizations": {
     "vscode": {
-      "extensions": ["emeraldwalk.RunOnSave", "sirmspencer.vscode-autohide"],
+      "extensions": ["sirmspencer.vscode-autohide"],
       "settings": {
         // Hide most of the VSCode UI via settings.
         // Here instead of .vscode/settings.json so that
@@ -47,16 +47,6 @@
         "terminal.integrated.hideOnStartup": "always",
         "github.codespaces.devcontainerChangedNotificationStyle": "none",
         "autoHide.hideOnOpen": true,
-        "emeraldwalk.runonsave": {
-          "commands": [
-            {
-              "match": ".*",
-              "isAsync": true,
-              "autoShowOutputPanel": "never",
-              "cmd": "echo 'heartbeat' | ncat 172.18.0.1 8888"
-            }
-          ]
-        },
         "tasks": {
           "version": "2.0.0",
           "tasks": [

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -9,6 +9,6 @@
   // codeActionsOnSave that sends a heartbeat signal to
   // the codespace that keeps it from timing out due to inactivity.
   "files.autoSave": "afterDelay",
-  "files.autoSaveDelay": 1000,
+  "files.autoSaveDelay": 30000,
   "vale.valeCLI.path": "${workspaceFolder}/node_modules/@vvago/vale/bin/vale"
 }


### PR DESCRIPTION
**Pull Request Description**

The terminal in which the heartbeat listener is running in the codespace is revealed to ensure that text displayed in that terminal counts as interaction and resets the timeout timer.

---

**Licensing Certification**

FarmData2 is a [Free Cultural Work](https://freedomdefined.org/Definition) and all accepted contributions are licensed as described in the LICENSE.md file. This requires that the contributor holds the rights to do so. By submitting this pull request **I certify that I satisfy the terms of the [Developer Certificate of Origin](https://developercertificate.org/)** for its contents.
