### PR TITLE
patches installDB.bash to use info in .fd2dev/db.conf by default

### DIFF
--- a/bin/installDB.bash
+++ b/bin/installDB.bash
@@ -9,12 +9,15 @@ function usage {
   echo "  -h|--help : Display this message."
   echo ""
   echo "  The default behavior if no flags are provided is to install the"
-  echo "  latest release of the sample database."
+  echo "  release of the sample database indicated in .fd2dev/db.conf."
   echo ""
   echo "  -c|--current : Reinstall the most recently installed sample database."
   echo "    - The file .fd2/db.sample.tar.gz will be installed if it exists."
   echo "    - If .fd2/db.sample.tar.gz does not exist then the default behavior will be used."
   echo "    - No other flags may be specified with -c|--current."
+  echo ""
+  echo "  -l|--latest : Install the latest release of the sample database."
+  echo "    - No other flags may be specified with -l|--latest."
   echo ""
   echo "  -p|--prompt : Prompt for the release and database artifact to install."
   echo "    - No other flags may be specified with -p|--prompt."
@@ -40,12 +43,12 @@ REPO_DIR=$(git rev-parse --show-toplevel)
 DB_DIR="$REPO_DIR/docker/db"
 
 if [ "$#" == "0" ]; then
-  LATEST=1
+  PREFERRED=1
 else
 
   # Process the command line flags
-  FLAGS=$(getopt -o a::c::h::p::r:: \
-    --long asset::,current::,help::,prompt::,release:: \
+  FLAGS=$(getopt -o a::c::h::l::p::r:: \
+    --long asset::,current::,help::,latest::,prompt::,release:: \
     -- "$@")
   error_check "Unrecognized option provided."
   eval set -- "$FLAGS"
@@ -67,6 +70,10 @@ else
         ;;
       -h | --help)
         usage
+        ;;
+      -l | --latest)
+        LATEST=1
+        shift 2
         ;;
       -p | --prompt)
         PROMPT=1
@@ -151,6 +158,9 @@ else
 
     DB_RELEASE="${RELEASES[0]}"
     DB_ASSET="db.sample.tar.gz"
+  elif [ -n "$PREFERRED" ]; then
+    DB_RELEASE=$(cat "$REPO_DIR/.fd2dev/db.conf" | head -1)
+    DB_ASSET=$(cat "$REPO_DIR/.fd2dev/db.conf" | tail -1)
   elif [ -n "$PROMPT" ]; then
     # shellcheck disable=SC2207
     RELEASES=(


### PR DESCRIPTION
**Pull Request Description**

The default behavior of `installDB.bash` had been to install the latest database release.  This patch changes that so that the default behavior is to install the version of the database that is recorded in the `.fd2dev/db.conf` file.

---

**Licensing Certification**

FarmData2 is a [Free Cultural Work](https://freedomdefined.org/Definition) and all accepted contributions are licensed as described in the LICENSE.md file. This requires that the contributor holds the rights to do so. By submitting this pull request **I certify that I satisfy the terms of the [Developer Certificate of Origin](https://developercertificate.org/)** for its contents.
