### PR TITLE
updates to latest database version with harvest units

### DIFF
--- a/.fd2dev/db.conf
+++ b/.fd2dev/db.conf
@@ -1,2 +1,2 @@
-v3.6.0
+v3.7.0
 db.sample.tar.gz

--- a/bin/installDB.bash
+++ b/bin/installDB.bash
@@ -265,13 +265,6 @@ docker start fd2_farmos > /dev/null
 error_check "Error starting farmOS."
 echo "  Started."
 
-echo "Reinstalling the FarmData2 module..."
-docker exec fd2_farmos drush pm-uninstall farm_fd2 -y
-error_check "Unable to uninstall the FarmData2 module."
-docker exec fd2_farmos drush pm-enable farm_fd2 -y
-error_check "Unable to enable the FarmData2 module."
-echo "  FarmData2 module reinstalled."
-
 echo "Clearing the Drupal cache..."
 docker exec fd2_farmos drush cr
 error_check "Unable to clear the cache."


### PR DESCRIPTION
**Pull Request Description**

Updates the `.fd2dev/db.conf` to point to version 3.7.0 of the database that includes the harvest units and unit conversions for plant type vocabulary terms.

---

**Licensing Certification**

FarmData2 is a [Free Cultural Work](https://freedomdefined.org/Definition) and all accepted contributions are licensed as described in the LICENSE.md file. This requires that the contributor holds the rights to do so. By submitting this pull request **I certify that I satisfy the terms of the [Developer Certificate of Origin](https://developercertificate.org/)** for its contents.
