### PR TITLE
fix(fd2): adds harvest log category

### DIFF
--- a/bin/reinstallFD2Module.bash
+++ b/bin/reinstallFD2Module.bash
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+echo "Deleting custom fd2_fields..."
+docker exec fd2_farmos drush php-eval "\Drupal\field\Entity\FieldStorageConfig::loadByName('taxonomy_term', 'fd2_unit_conversions')->delete();"
+docker exec fd2_farmos drush php-eval "\Drupal\field\Entity\FieldStorageConfig::loadByName('taxonomy_term', 'fd2_harvest_unit')->delete();"
+echo "Deleted."
+echo "Running cron..."
+docker exec fd2_farmos drush cron > /dev/null 2>&1
+echo "Done."
+
+echo "Uninstalling farm_fd2 module..."
+docker exec fd2_farmos drush pmu farm_fd2 -y
+echo "Uninstalled."
+
+echo "Rebuilding farm_fd2 module..."
+npm run build:fd2 > /dev/null
+echo "Rebuilt."
+
+echo "Reinstalling farm_fd2 module..."
+docker exec fd2_farmos drush en farm_fd2 -y
+echo "Reinstalled."

--- a/modules/farm_fd2/src/module/farm_fd2.install
+++ b/modules/farm_fd2/src/module/farm_fd2.install
@@ -27,6 +27,7 @@ function add_log_categories() {
     ['name' => 'tillage', 'parent' => '', 'description' => 'For logs representing soil disturbances.' ],
     ['name' => 'transplanting', 'parent' => '', 'description' => 'For logs representing transplantation of a plant.' ],
     ['name' => 'weed_control', 'parent' => '', 'description' => 'For logs related to weed control.' ],
+    ['name' => 'harvest', 'parent' => '', 'description' => 'For logs related to harvesting of a plant.' ],
   ];
 
   addTerms($vocab, $terms);


### PR DESCRIPTION
**Pull Request Description**

Adds a log category for harvests.  The code to add the category is in the module's `.install` file. 

Also added is a script that will uninstall and reinstall the `farm_fd2` module.  This is useful when working on the module files.  It is necessary because `farm_fd2` adds custom fields and drupal will not allow it to uninstalled while those fields exist. So this script deletes those fields, uninstalls `farm_fd2`, builds `farm_fd2`, and then reinstalls `farm_fd2`.


---

**Licensing Certification**

FarmData2 is a [Free Cultural Work](https://freedomdefined.org/Definition) and all accepted contributions are licensed as described in the LICENSE.md file. This requires that the contributor holds the rights to do so. By submitting this pull request **I certify that I satisfy the terms of the [Developer Certificate of Origin](https://developercertificate.org/)** for its contents.
