### PR TITLE
Update devcontainer.json to pin base image to bookworm

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,5 +1,5 @@
 {
-  "image": "mcr.microsoft.com/devcontainers/base:debian",
+  "image": "mcr.microsoft.com/devcontainers/base:bookworm",
   "features": {
     "ghcr.io/devcontainers/features/docker-in-docker:2": {}
   },


### PR DESCRIPTION
A new Debian base image was released that was not compatible with the Docker-In-Docker features.  This patch pegs the base image being used to be compatible with the version of the Docker-in-Docker feature that is installed.

**Pull Request Description**

_Describe what your Pull Request does here_

_Include a "Closes #" line for the issue your PR closes._

---

**Licensing Certification**

FarmData2 is a [Free Cultural Work](https://freedomdefined.org/Definition) and all accepted contributions are licensed as described in the LICENSE.md file. This requires that the contributor holds the rights to do so. By submitting this pull request **I certify that I satisfy the terms of the [Developer Certificate of Origin](https://developercertificate.org/)** for its contents.
