### PR TITLE
fix(dev): .devcontainer patch

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -66,64 +66,45 @@
                 "runOn": "folderOpen"
               },
               "presentation": {
-                "reveal": "never"
+                "reveal": "always",
+                "panel": "shared"
               }
             },
             {
               "label": "Open Loading Page",
               "type": "shell",
-              "command": "code -r .devcontainer/fd2_loading.md",
-              "presentation": {
-                "reveal": "never"
-              }
+              "command": "code -r .devcontainer/fd2_loading.md"
             },
             {
               "label": "Customize Welcome Page",
               "type": "shell",
-              "command": "./.devcontainer/homepage.bash",
-              "presentation": {
-                "reveal": "never"
-              }
+              "command": "./.devcontainer/homepage.bash"
             },
             {
               "label": "Run fd2-up.bash Script",
               "type": "shell",
-              "command": "bin/fd2-up.bash",
-              "presentation": {
-                "reveal": "never"
-              }
+              "command": "bin/fd2-up.bash"
             },
             {
               "label": "Open Welcome Page",
               "type": "shell",
-              "command": "code -r .devcontainer/fd2_welcome.md",
-              "presentation": {
-                "reveal": "never"
-              }
+              "command": "code -r .devcontainer/fd2_welcome.md"
             },
             {
               "label": "Start Heartbeat Server",
               "type": "shell",
-              "command": ".devcontainer/startHeartbeat.bash",
-              "presentation": {
-                "reveal": "never"
-              }
+              "command": ".devcontainer/startHeartbeat.bash"
             },
             {
               "label": "Open Running Page",
               "type": "shell",
-              "command": "sleep 300; code -r .devcontainer/fd2_running.md",
-              "presentation": {
-                "reveal": "never",
-                "panel": "new"
-              }
+              "command": "sleep 300; code -r .devcontainer/fd2_running.md"
             },
             {
               "label": "Start Heartbeat Listener",
               "type": "shell",
               "command": "fuser -k 8888/tcp; ncat -lk 8888",
               "presentation": {
-                "reveal": "always",
                 "panel": "new"
               }
             }


### PR DESCRIPTION
Patches the .devcontainer to reveal the terminal in which VSCode tasks are running.  This appears to be a change in how GitHub codespaces execute the VSCode tasks.  If the terminal was not revealed the first task would fail and no further tasks would run.  Revealing the terminal window solved this issue.

---

**Licensing Certification**

FarmData2 is a [Free Cultural Work](https://freedomdefined.org/Definition) and all accepted contributions are licensed as described in the LICENSE.md file. This requires that the contributor holds the rights to do so. By submitting this pull request **I certify that I satisfy the terms of the [Developer Certificate of Origin](https://developercertificate.org/)** for its contents.
