### PR TITLE
feat(comp): add crop prop to ActivePlantAssetPicklist

### DIFF
--- a/components/ActivePlantAssetPicklist/ActivePlantAssetPicklist.content.comp.cy.js
+++ b/components/ActivePlantAssetPicklist/ActivePlantAssetPicklist.content.comp.cy.js
@@ -142,4 +142,115 @@ describe('Test the default ActivePlantAssetPicklist content', () => {
         cy.get('[data-cy="picklist-bed-19"]').should('have.text', 'CHUAU-3');
       });
   });
+
+  it('Checks crop prop filters plant assets (crop="BROCCOLI")', () => {
+    const readySpy = cy.spy().as('readySpy');
+
+    cy.mount(ActivePlantAssetPicklist, {
+      props: {
+        isInTrays: true,
+        isInGround: false,
+        location: 'CHUAU',
+        crop: 'BROCCOLI',
+        onReady: readySpy,
+      },
+    });
+
+    cy.get('@readySpy')
+      .should('have.been.calledOnce')
+      .then(() => {
+        // Should only show BROCCOLI plants
+        cy.get('[data-cy^="picklist-crop-"]')
+          .its('length')
+          .then((count) => {
+            expect(count).to.equal(3);
+          });
+
+        // All visible crops should be BROCCOLI
+        cy.get('[data-cy="picklist-crop-0"]').should('have.text', 'BROCCOLI');
+        cy.get('[data-cy="picklist-crop-1"]').should('have.text', 'BROCCOLI');
+        cy.get('[data-cy="picklist-crop-2"]').should('have.text', 'BROCCOLI');
+      });
+  });
+
+  it('Checks crop prop filters plant assets (crop="HERB-CILANTRO")', () => {
+    const readySpy = cy.spy().as('readySpy');
+
+    cy.mount(ActivePlantAssetPicklist, {
+      props: {
+        isInGround: true,
+        isInTrays: false,
+        location: 'CHUAU',
+        crop: 'HERB-CILANTRO',
+        onReady: readySpy,
+      },
+    });
+
+    cy.get('@readySpy')
+      .should('have.been.calledOnce')
+      .then(() => {
+        // Should only show HERB-CILANTRO plants
+        cy.get('[data-cy^="picklist-crop-"]')
+          .its('length')
+          .then((count) => {
+            expect(count).to.equal(2);
+          });
+
+        // All visible crops should be HERB-CILANTRO
+        cy.get('[data-cy="picklist-crop-0"]').should(
+          'have.text',
+          'HERB-CILANTRO'
+        );
+        cy.get('[data-cy="picklist-crop-1"]').should(
+          'have.text',
+          'HERB-CILANTRO'
+        );
+      });
+  });
+
+  it('Checks crop prop with null/undefined shows all crops', () => {
+    const readySpy = cy.spy().as('readySpy');
+
+    cy.mount(ActivePlantAssetPicklist, {
+      props: {
+        isInGround: true,
+        isInTrays: false,
+        location: 'CHUAU',
+        crop: null,
+        onReady: readySpy,
+      },
+    });
+
+    cy.get('@readySpy')
+      .should('have.been.calledOnce')
+      .then(() => {
+        // Should show all plants (same as without crop prop)
+        cy.get('[data-cy^="picklist-crop-"]')
+          .its('length')
+          .then((count) => {
+            expect(count).to.equal(8);
+          });
+      });
+  });
+
+  it('Checks crop prop with non-existent crop shows no plants', () => {
+    const readySpy = cy.spy().as('readySpy');
+
+    cy.mount(ActivePlantAssetPicklist, {
+      props: {
+        isInGround: true,
+        isInTrays: false,
+        location: 'CHUAU',
+        crop: 'NONEXISTENT-CROP',
+        onReady: readySpy,
+      },
+    });
+
+    cy.get('@readySpy')
+      .should('have.been.calledOnce')
+      .then(() => {
+        // Should show no plants
+        cy.get('[data-cy^="picklist-crop-"]').should('not.exist');
+      });
+  });
 });

--- a/components/ActivePlantAssetPicklist/ActivePlantAssetPicklist.vue
+++ b/components/ActivePlantAssetPicklist/ActivePlantAssetPicklist.vue
@@ -41,6 +41,7 @@ import PicklistBase from '@comps/PicklistBase/PicklistBase.vue';
  *   v-bind:picked="form.picked"
  *   v-bind:isInTrays="isInTrays"
  *   v-bind:isInGround="isInGround"
+ *   v-bind:crop="selectedCrop"
  *   v-on:hasPlants="form.hasPlants = $event"
  *   v-on:update:picked="(picked) => (form.picked = picked)"
  *   v-on:update:area="form.area = $event"
@@ -91,6 +92,15 @@ export default {
       required: true,
     },
     /**
+     * The crop name used to filter the active plant assets.
+     * If provided, only plant assets matching this crop will be returned.
+     */
+    crop: {
+      type: String,
+      required: false,
+      default: null,
+    },
+    /**
      * The crops that are currently picked.
      */
     picked: {
@@ -125,6 +135,7 @@ export default {
       },
     };
   },
+
   computed: {
     plantsAtLocation() {
       return this.affectedPlants.length > 0;
@@ -227,12 +238,16 @@ export default {
     async checkPlantsAtLocation() {
       if (this.location) {
         try {
+          // If a crop filter is provided, pass it to farmOS; otherwise use no crop filtering.
+          const cropsFilter = this.crop ? [this.crop] : [];
+
           const results = await farmosUtil.getPlantAssets(
             this.location,
-            [],
+            cropsFilter,
             this.isInTrays,
             this.isInGround
           );
+
           // Map results to rows for PicklistBase
           this.affectedPlants = results.flatMap((plant) =>
             plant.beds.length > 0
@@ -276,6 +291,7 @@ export default {
             };
           }
 
+          // Reset picked rows when data changes
           if (this.pickedRow.size > 0) {
             this.pickedRow = new Map();
             this.$emit('update:picked', this.pickedRow);
@@ -319,6 +335,11 @@ export default {
       },
       immediate: true,
     },
+    crop: {
+      handler() {
+        this.checkPlantsAtLocation();
+      },
+    },
     isInTrays: {
       handler() {
         this.checkPlantsAtLocation();
@@ -351,3 +372,7 @@ export default {
   },
 };
 </script>
+
+
+
+


### PR DESCRIPTION
This draft pull request adds the crop prop to the ActivePlantAssetPicklist component as described in Issue #550.

Summary of Changes

Added a new crop prop to ActivePlantAssetPicklist.vue.

Passed the prop through to PicklistBase so the list can support filtering by crop.

Updated the component to properly handle and expose the new prop.

Why this is a Draft PR

I was not able to run the full development environment or execute frontend tests for two reasons:

1. Local Mac environment

My local setup does not currently have Node.js or npm installed, and my MacBook Air does not support Docker due to limited storage. Because of this, I could not run the development server or frontend tests from my local clone of the repository.

2. GitHub Codespaces attempt

I attempted to use GitHub Codespaces to run the project, but the container environment there did not include Node.js or npm (both node and npm returned “command not found”). As a result, I could not install dependencies or run the application inside Codespaces either.

Since I could not test the changes directly in a running environment, I am submitting this as a Draft PR so the maintainers can review the code structure and confirm that the implementation aligns with Issue #550.

Once I receive feedback or confirmation, I will finalize the PR or make any requested changes.

Closes

Closes #550