### PR TITLE
fix(comp): Update ActivePlantAssetPicklist to handle some beds

### DIFF
--- a/.fd2-cspell.txt
+++ b/.fd2-cspell.txt
@@ -2,6 +2,7 @@ autoconnect
 backmerge
 backmerged
 bashlint
+bedless
 bierner
 Braught
 chgrp

--- a/.fd2dev/db.conf
+++ b/.fd2dev/db.conf
@@ -1,2 +1,2 @@
-v3.8.0-development.1
+v3.8.0
 db.sample.tar.gz

--- a/.fd2dev/db.conf
+++ b/.fd2dev/db.conf
@@ -1,2 +1,2 @@
-v3.7.1
+v3.8.0-development.1
 db.sample.tar.gz

--- a/components/ActivePlantAssetPicklist/ActivePlantAssetPicklist.content.comp.cy.js
+++ b/components/ActivePlantAssetPicklist/ActivePlantAssetPicklist.content.comp.cy.js
@@ -134,8 +134,8 @@ describe('Test the default ActivePlantAssetPicklist content', () => {
         );
 
         // check assets with no beds
-        cy.get('[data-cy="picklist-bed-0"]').should('have.text', 'N/A');
-        cy.get('[data-cy="picklist-bed-10"]').should('have.text', 'N/A');
+        cy.get('[data-cy="picklist-bed-0"]').should('have.text', '');
+        cy.get('[data-cy="picklist-bed-10"]').should('have.text', '');
 
         // check assets with beds
         cy.get('[data-cy="picklist-bed-11"]').should('have.text', 'CHUAU-1');

--- a/components/ActivePlantAssetPicklist/ActivePlantAssetPicklist.events.area.comp.cy.js
+++ b/components/ActivePlantAssetPicklist/ActivePlantAssetPicklist.events.area.comp.cy.js
@@ -193,6 +193,170 @@ describe('Test the ActivePlantAssetPicklist `update:area` event', () => {
     });
   });
 
+  it('should correctly calculate and emit `update:area` for a location with active plant assets and some beds', () => {
+    const readySpy = cy.spy().as('readySpy');
+    const areaSpy = cy.spy().as('areaSpy');
+
+    cy.mount(ActivePlantAssetPicklist, {
+      props: {
+        location: 'D',
+        onReady: readySpy,
+        'onUpdate:area': areaSpy,
+      },
+    }).then(() => {
+      cy.get('@readySpy')
+        .should('have.been.calledOnce')
+        .then(() => {
+          // Once on creation and then on location prop update
+          cy.get('@areaSpy').should('have.been.calledTwice');
+
+          // Select BEAN in field
+          cy.get('[data-cy="picklist-checkbox-0"]').check();
+          cy.get('@areaSpy')
+            .should('have.been.calledThrice')
+            .its('lastCall.args.0')
+            .should((areaValue) => {
+              expect(areaValue).to.equal(20);
+            });
+
+          // Select RADISH in field
+          cy.get('[data-cy="picklist-checkbox-1"]').check();
+          cy.get('@areaSpy')
+            .should('have.callCount', 4)
+            .its('lastCall.args.0')
+            .should((areaValue) => {
+              expect(areaValue).to.equal(40);
+            });
+
+          // Select LETTUCE-ICEBERG in field
+          cy.get('[data-cy="picklist-checkbox-2"]').check();
+          cy.get('@areaSpy')
+            .should('have.callCount', 5)
+            .its('lastCall.args.0')
+            .should((areaValue) => {
+              expect(areaValue).to.equal(60);
+            });
+
+          // Select first LETTUCE-ICEBERG in D-1
+          cy.get('[data-cy="picklist-checkbox-3"]').check();
+          cy.get('@areaSpy')
+            .should('have.callCount', 6)
+            .its('lastCall.args.0')
+            .should((areaValue) => {
+              expect(areaValue).to.equal(70);
+            });
+
+          // Select second LETTUCE-ICEBERG in D-1
+          cy.get('[data-cy="picklist-checkbox-4"]').check();
+          cy.get('@areaSpy')
+            .should('have.callCount', 7)
+            .its('lastCall.args.0')
+            .should((areaValue) => {
+              expect(areaValue).to.equal(80);
+            });
+
+          // Select LETTUCE-ICEBERG in D-2
+          cy.get('[data-cy="picklist-checkbox-5"]').check();
+          cy.get('@areaSpy')
+            .should('have.callCount', 8)
+            .its('lastCall.args.0')
+            .should((areaValue) => {
+              expect(areaValue).to.equal(100);
+            });
+
+          // Unselect BEAN in field
+          cy.get('[data-cy="picklist-checkbox-0"]').uncheck();
+          cy.get('@areaSpy')
+            .should('have.callCount', 9)
+            .its('lastCall.args.0')
+            .should((areaValue) => {
+              expect(areaValue).to.equal(80);
+            });
+
+          // Unselect RADISH in field
+          cy.get('[data-cy="picklist-checkbox-1"]').uncheck();
+          cy.get('@areaSpy')
+            .should('have.callCount', 10)
+            .its('lastCall.args.0')
+            .should((areaValue) => {
+              expect(areaValue).to.equal(60);
+            });
+
+          // Unselect LETTUCE-ICEBERG in field
+          cy.get('[data-cy="picklist-checkbox-2"]').uncheck();
+          cy.get('@areaSpy')
+            .should('have.callCount', 11)
+            .its('lastCall.args.0')
+            .should((areaValue) => {
+              expect(areaValue).to.equal(40);
+            });
+
+          // Unselect first LETTUCE-ICEBERG in D-1
+          cy.get('[data-cy="picklist-checkbox-3"]').uncheck();
+          cy.get('@areaSpy')
+            .should('have.callCount', 12)
+            .its('lastCall.args.0')
+            .should((areaValue) => {
+              expect(areaValue).to.equal(30);
+            });
+
+          // Unselect LETTUCE-ICEBERG in D-2
+          cy.get('[data-cy="picklist-checkbox-5"]').uncheck();
+          cy.get('@areaSpy')
+            .should('have.callCount', 13)
+            .its('lastCall.args.0')
+            .should((areaValue) => {
+              expect(areaValue).to.equal(10);
+            });
+
+          // Select first LETTUCE-ICEBERG in D-1
+          cy.get('[data-cy="picklist-checkbox-3"]').check();
+          cy.get('@areaSpy')
+            .should('have.callCount', 14)
+            .its('lastCall.args.0')
+            .should((areaValue) => {
+              expect(areaValue).to.equal(20);
+            });
+
+          // Unselect second LETTUCE-ICEBERG in D-1
+          cy.get('[data-cy="picklist-checkbox-4"]').uncheck();
+          cy.get('@areaSpy')
+            .should('have.callCount', 15)
+            .its('lastCall.args.0')
+            .should((areaValue) => {
+              expect(areaValue).to.equal(10);
+            });
+
+          // Select LETTUCE-ICEBERG in D-2
+          cy.get('[data-cy="picklist-checkbox-5"]').check();
+          cy.get('@areaSpy')
+            .should('have.callCount', 16)
+            .its('lastCall.args.0')
+            .should((areaValue) => {
+              expect(areaValue).to.equal(30);
+            });
+
+          // Unselect first LETTUCE-ICEBERG in D-1
+          cy.get('[data-cy="picklist-checkbox-3"]').uncheck();
+          cy.get('@areaSpy')
+            .should('have.callCount', 17)
+            .its('lastCall.args.0')
+            .should((areaValue) => {
+              expect(areaValue).to.equal(20);
+            });
+
+          // Unselect LETTUCE-ICEBERG in D-2
+          cy.get('[data-cy="picklist-checkbox-5"]').uncheck();
+          cy.get('@areaSpy')
+            .should('have.callCount', 18)
+            .its('lastCall.args.0')
+            .should((areaValue) => {
+              expect(areaValue).to.equal(0);
+            });
+        });
+    });
+  });
+
   //-------------------------------Check it does not emit `update:area`-----------------------------------//
 
   it('should not emit `update:area` when switching between locations with beds if no crops are selected', () => {

--- a/components/ActivePlantAssetPicklist/ActivePlantAssetPicklist.vue
+++ b/components/ActivePlantAssetPicklist/ActivePlantAssetPicklist.vue
@@ -197,14 +197,24 @@ export default {
         return acc;
       }, {});
 
+      // Get total number of plants without beds
+      const bedlessTotal = this.affectedPlants.filter(
+        (p) => p.bed === ''
+      ).length;
+
+      // Get number of picked plants without beds
+      const bedlessPicked = [...picked.values()].filter(
+        (p) => p.row.bed === ''
+      ).length;
+
       // Get total number of unique beds
-      const totalUniqueBeds = Object.keys(bedTotals).length;
+      const totalUniqueBeds = Object.keys(bedTotals).length + bedlessTotal;
       if (totalUniqueBeds === 0) {
         return 0; // Avoid division by zero
       }
 
       // Area = [ ( SUM (picked crops in bed_i / total crops in bed_i) ) / total unique beds ] * 100
-      let weightedSum = 0;
+      let weightedSum = bedlessPicked;
 
       for (const [bed, totalForBed] of Object.entries(bedTotals)) {
         const pickedForBed = bedPicks[bed] || 0;

--- a/components/ActivePlantAssetPicklist/ActivePlantAssetPicklist.vue
+++ b/components/ActivePlantAssetPicklist/ActivePlantAssetPicklist.vue
@@ -183,7 +183,7 @@ export default {
 
       // Map "Bed -> Total # of plants in that bed"
       const bedTotals = this.affectedPlants.reduce((acc, row) => {
-        if (row.bed !== 'N/A') {
+        if (row.bed !== '') {
           acc[row.bed] = (acc[row.bed] || 0) + 1;
         }
         return acc;
@@ -191,7 +191,7 @@ export default {
 
       // Map "Bed -> # of picked plants in that bed"
       const bedPicks = [...picked.values()].reduce((acc, row) => {
-        if (row.row.bed !== 'N/A') {
+        if (row.row.bed !== '') {
           acc[row.row.bed] = (acc[row.row.bed] || 0) + 1;
         }
         return acc;
@@ -247,7 +247,7 @@ export default {
               : [
                   {
                     crop: plant.crop.join(', '),
-                    bed: 'N/A',
+                    bed: '',
                     timestamp: plant.timestamp,
                     uuid: plant.uuid,
                     location: plant.location,
@@ -256,9 +256,9 @@ export default {
                 ]
           );
 
-          // Check if all plants have 'N/A' beds and adjust columns accordingly
+          // Check if all plants have no beds and adjust columns accordingly
           const allBedsNA = this.affectedPlants.every(
-            (plant) => plant.bed === 'N/A'
+            (plant) => plant.bed === ''
           );
 
           if (allBedsNA) {


### PR DESCRIPTION
This pull request changes the picklist from displaying N/A in the beds column if the plant is not assigned to a bed to nothing (an empty string). My implementation approach was to change assigning plants with no beds a string 'N/A' to a string '', then updating all checks that look for the 'N/A' string to look for an empty string. A potential bug could be if a plant is assigned to a bed with no name, it will be treated as not having a bed, though that seems unlikely. 
I still need to edit the calculatePickedArea method to correctly handle calculations in this scenario. This will be added to this PR when it is done.

Closes #554 

---

**Licensing Certification**

FarmData2 is a [Free Cultural Work](https://freedomdefined.org/Definition) and all accepted contributions are licensed as described in the LICENSE.md file. This requires that the contributor holds the rights to do so. By submitting this pull request **I certify that I satisfy the terms of the [Developer Certificate of Origin](https://developercertificate.org/)** for its contents.
