### PR TITLE
feat(lib)!: Updates farmOS logs to use 'log--transplanting'

### DIFF
--- a/library/farmosUtil/farmosUtil.transplanting.js
+++ b/library/farmosUtil/farmosUtil.transplanting.js
@@ -46,7 +46,7 @@ export async function createTransplantingActivityLog(
       .name;
 
   const activityLogData = {
-    type: 'log--activity',
+    type: 'log--transplanting',
     attributes: {
       name: logName,
       timestamp: dayjs(transplantingDate).format(),
@@ -81,7 +81,7 @@ export async function createTransplantingActivityLog(
 export async function getTransplantingActivityLog(activityLogId) {
   const farm = await getFarmOSInstance();
   const results = await farm.log.fetch({
-    filter: { type: 'log--activity', id: activityLogId },
+    filter: { type: 'log--transplanting', id: activityLogId },
   });
   return results.data[0];
 }

--- a/library/farmosUtil/farmosUtil.transplanting.unit.cy.js
+++ b/library/farmosUtil/farmosUtil.transplanting.unit.cy.js
@@ -111,7 +111,7 @@ describe('Test the transplanting activity log functions', () => {
           '1999-01-02_xp_BROCCOLI'
         );
         expect(transplantingLog.attributes.timestamp).to.contain('1999-01-02');
-        expect(transplantingLog.type).to.equal('log--activity');
+        expect(transplantingLog.type).to.equal('log--transplanting');
         expect(transplantingLog.attributes.status).to.equal('done');
         expect(transplantingLog.attributes.is_movement).to.equal(true);
 
@@ -197,7 +197,7 @@ describe('Test the transplanting activity log functions', () => {
   });
 
   it('Error creating a transplanting log', { retries: 4 }, () => {
-    cy.intercept('POST', '**/api/log/activity', {
+    cy.intercept('POST', '**/api/log/transplanting', {
       statusCode: 401,
     });
 


### PR DESCRIPTION
**Pull Request Description**

Changed the activityLogData const type to log--transplanting and changed the filter type to 'log--tranplanting. Updated the expect function to 'log--transplanting' and changed cy.intercept function file path to ../log/transplanting.

*Why I made the changes*

The original createTransplantingActivityLog() function was updated to create logs of type log--transplanting instead of log--activity. After this change, several unit tests began failing because getTransplantingActivityLog() still filtered logs by the old type (log--activity). As a result, the fetch returned zero results, causing downstream code in the test to attempt to access attributes of undefined. Additionally when running the pre-commit checks, one of the soil disturbance termination unit tests expected a 404 error message, but the actual intercepted response returned a 401. These updates were necessary to ensure that the transplanting log utilities and their associated unit tests work consistently with the new log type.

*Approach to implementation*

- Updated the filter type in getTransplantingActivityLog() from log--activity to log--transplanting so that the fetch request correctly retrieves newly created transplanting logs.
- Updated the relevant unit test in farmosUtil.soilDisturbanceTerminationLog.unit.cy.js to expect a 401 status code instead of 404, matching the configured intercept and existing patterns across other unit tests.

*Possible complications*

Changing the filter to log--transplanting assumes that all transplanting logs created elsewhere in the system also use the new type. If any external components still generate log--activity transplanting logs, those will no longer be retrievable using this function.

Closes #560  

BREAKING CHANGE: Changes the log type for transplanting event from `log--activity` to `log--transplanting`.

---

**Licensing Certification**

FarmData2 is a [Free Cultural Work](https://freedomdefined.org/Definition) and all accepted contributions are licensed as described in the LICENSE.md file. This requires that the contributor holds the rights to do so. By submitting this pull request **I certify that I satisfy the terms of the [Developer Certificate of Origin](https://developercertificate.org/)** for its contents.
