### PR TITLE
fix(examples): enhance the MultiSelectorBase example

### DIFF
--- a/modules/farm_fd2_examples/src/entrypoints/multi_selector_base/App.vue
+++ b/modules/farm_fd2_examples/src/entrypoints/multi_selector_base/App.vue
@@ -141,6 +141,10 @@
     </thead>
     <tbody>
       <tr>
+        <td>ready</td>
+        <td>None</td>  
+      </tr>
+      <tr>
         <td>update:selected</td>
         <td>{{ form.selected }}</td>
       </tr>


### PR DESCRIPTION
### Summary
- Added missing `ready` event to the Component Event Payloads table
- Ensured events are listed in alphabetical order

### Context
The MultiSelectorBase example documentation was missing the `ready` event,
causing inconsistency with the component’s emitted events.