### PR TITLE
Enhanced the CommentBox example 

### DIFF
--- a/components/CommentBox/CommentBox.events.comp.cy.js
+++ b/components/CommentBox/CommentBox.events.comp.cy.js
@@ -35,6 +35,22 @@ describe('Test the CommentBox component events', () => {
       });
   });
 
+  it('Emits "ready" with payload true', () => {
+    const readySpy = cy.spy().as('readySpy');
+
+    cy.mount(CommentBox, {
+      props: {
+        onReady: readySpy,
+      },
+    });
+
+    cy.get('@readySpy')
+      .should('have.been.calledOnce')
+      .then(() => {
+        cy.get('@readySpy').should('have.been.calledWith', true);
+      });
+  });
+
   it('Payload of "update:comment" is trimmed', () => {
     const readySpy = cy.spy().as('readySpy');
     const updateSpy = cy.spy().as('updateSpy');

--- a/components/CommentBox/CommentBox.vue
+++ b/components/CommentBox/CommentBox.vue
@@ -102,6 +102,7 @@ export default {
 
     /**
      * The component is ready for use.
+     * @property {boolean} valid true to indicate that the component is initialized and ready for use.
      */
     this.$emit('ready', true);
   },

--- a/components/CommentBox/CommentBox.vue
+++ b/components/CommentBox/CommentBox.vue
@@ -103,7 +103,7 @@ export default {
     /**
      * The component is ready for use.
      */
-    this.$emit('ready');
+    this.$emit('ready', true);
   },
 };
 </script>

--- a/modules/farm_fd2_examples/src/entrypoints/comment_box/App.vue
+++ b/modules/farm_fd2_examples/src/entrypoints/comment_box/App.vue
@@ -23,6 +23,7 @@
     <thead>
       <th>Prop</th>
       <th>Control</th>
+      <th>Value</th>
     </thead>
     <tbody>
       <tr>
@@ -47,6 +48,7 @@
             Clear Comment
           </BButton>
         </td>
+        <td>{{ form.comment }}</td>
       </tr>
     </tbody>
   </table>

--- a/modules/farm_fd2_examples/src/entrypoints/comment_box/App.vue
+++ b/modules/farm_fd2_examples/src/entrypoints/comment_box/App.vue
@@ -38,6 +38,7 @@
           >
             Insert Comment
           </BButton>
+          <br />
           <BButton
             id="clear-comment-button"
             data-cy="clear-comment-button"

--- a/modules/farm_fd2_examples/src/entrypoints/comment_box/App.vue
+++ b/modules/farm_fd2_examples/src/entrypoints/comment_box/App.vue
@@ -14,12 +14,7 @@
         validity.comment = valid;
       }
     "
-    v-on:ready="
-      (ready) => {
-        ready.comment = ready;
-        createdCount++;
-      }
-    "
+    v-on:ready="handleReady"
   />
   <hr />
 
@@ -104,17 +99,23 @@ export default {
         comment: '',
       },
       validity: {
-        comment: true,
+        comment: false,
       },
       ready: {
-        comment: true,
+        comment: false,
       },
       createdCount: 0,
     };
   },
   computed: {
     pageDoneLoading() {
-      return this.createdCount == 1;
+      return this.createdCount === 2;
+    },
+  },
+  methods: {
+    handleReady(ready) {
+      this.ready.comment = ready;
+      this.createdCount++;
     },
   },
   created() {

--- a/modules/farm_fd2_examples/src/entrypoints/comment_box/App.vue
+++ b/modules/farm_fd2_examples/src/entrypoints/comment_box/App.vue
@@ -14,7 +14,12 @@
         validity.comment = valid;
       }
     "
-    v-on:ready="createdCount++"
+    v-on:ready="
+      (ready) => {
+        ready.comment = ready;
+        createdCount++;
+      }
+    "
   />
   <hr />
 
@@ -62,6 +67,10 @@
     </thead>
     <tbody>
       <tr>
+        <td>ready</td>
+        <td>{{ ready.comment }}</td>
+      </tr>
+      <tr>
         <td>update:comment</td>
         <td>{{ form.comment }}</td>
       </tr>
@@ -97,12 +106,15 @@ export default {
       validity: {
         comment: true,
       },
+      ready: {
+        comment: true,
+      },
       createdCount: 0,
     };
   },
   computed: {
     pageDoneLoading() {
-      return this.createdCount == 2;
+      return this.createdCount == 1;
     },
   },
   created() {


### PR DESCRIPTION
### Purpose

Enhance the CommentBox example page to improve clarity and completeness of the documentation tables:
- Add a Value column to the Component Props table that displays the current Vue `data` value bound to the `comment` prop.
- Stack the `Insert Comment` and `Clear Comment` buttons vertically.
- Add a `ready` event row to the Component Event Payloads table to display its payload.
- Ensure rows in both tables appear in alphabetical order.

### Verification Steps

1. Rebuild the examples: `npm run build:examples`
2. Open the examples site and navigate: FD2-Examples → Components → CommentBox
3. Hard refresh the page: `SHIFT + reload`
4. Verify Component Props table:
- A Value column exists on the right side.
- The Value cell for comment shows the current value of the Vue data attribute bound to the prop.
- The` Insert Comment `button appears above the `Clear Comment` button.
5. Verify Component Event Payloads table:
- There is a row for the `ready` event and it displays the payload `true` for that event.
- Table rows are sorted alphabetically by event name.

### Approach

For the Component Props table:
- Added a new Value column that renders the reactive Vue `data` value bound to the `comment` prop so users can see the live/current prop input.
- Adjusted the styling so the `Insert Comment` and `Clear Comment` actions are vertically stacked for readability.

For the Component Event Payloads table:
- Added the missing `ready` event row and displayed its payload.

### Testing

- Add the 'Emits:ready with payload true test' in `CommentBox.events.comp.cy.js` to test the trueness of the ready event.
- Other changes were verified manually by rebuilding the examples and checking the CommentBox example page in the browser.

### Related issues
Fixes #573

### Further Information

### Licensing Certification

FarmData2 is a [Free Cultural Work](https://freedomdefined.org/Definition) and all accepted contributions are licensed as described in the LICENSE.md file. This requires that the contributor holds the rights to do so. By submitting this pull request **the contributor (and any listed co-authors) certify that they meet the terms of the [Developer Certificate of Origin](https://developercertificate.org/)** for its contents.

### Co-Authors
Co-authored-by: Gracie Nguyen <@gracienl>