### PR TITLE
fix(examples): enhance the TraySizeSelector example

### DIFF
--- a/components/TraySizeSelector/TraySizeSelector.events.comp.cy.js
+++ b/components/TraySizeSelector/TraySizeSelector.events.comp.cy.js
@@ -71,7 +71,7 @@ describe('Test the TraySizeSelector events', () => {
     });
   });
 
-  it('Test that "ready" event is propagated', () => {
+  it('Test that "ready" event is emitted with true', () => {
     const readySpy = cy.spy().as('readySpy');
 
     cy.mount(TraySizeSelector, {

--- a/components/TraySizeSelector/TraySizeSelector.events.comp.cy.js
+++ b/components/TraySizeSelector/TraySizeSelector.events.comp.cy.js
@@ -70,4 +70,17 @@ describe('Test the TraySizeSelector events', () => {
         .should('have.been.calledWith', 'Unable to fetch tray sizes.');
     });
   });
+
+  it('Test that "ready" event is propagated', () => {
+    const readySpy = cy.spy().as('readySpy');
+
+    cy.mount(TraySizeSelector, {
+      props: {
+        onReady: readySpy,
+      },
+    });
+    cy.get('@readySpy')
+      .should('have.been.calledOnce')
+      .should('have.been.calledWith', true);
+  });
 });

--- a/components/TraySizeSelector/TraySizeSelector.vue
+++ b/components/TraySizeSelector/TraySizeSelector.vue
@@ -13,7 +13,6 @@
       v-on:valid="handleValid($event)"
       v-on:add-clicked="handleAddClicked"
       v-bind:popupUrl="popupUrl"
-      v-on:created="created($event)"
     />
   </div>
 </template>
@@ -127,7 +126,6 @@ export default {
       }
     },
   },
-  watch: {},
   created() {
     let canCreate = farmosUtil.checkPermission('create-terms-in-tray_size');
     let trayMap = farmosUtil.getTraySizeToTermMap();
@@ -143,7 +141,7 @@ export default {
 
         /**
          * The select has been populated with the list of tray sizes and the component is ready to be used.
-         * @property {boolean} true whether the component is ready.
+         * @property {boolean} true indicates the component is initialized and ready for use.
          */
         this.$emit('ready', true);
       })

--- a/components/TraySizeSelector/TraySizeSelector.vue
+++ b/components/TraySizeSelector/TraySizeSelector.vue
@@ -13,6 +13,7 @@
       v-on:valid="handleValid($event)"
       v-on:add-clicked="handleAddClicked"
       v-bind:popupUrl="popupUrl"
+      v-on:created="created($event)"
     />
   </div>
 </template>
@@ -142,8 +143,9 @@ export default {
 
         /**
          * The select has been populated with the list of tray sizes and the component is ready to be used.
+         * @property {boolean} true whether the component is ready.
          */
-        this.$emit('ready');
+        this.$emit('ready', true);
       })
       .catch((error) => {
         console.error('TraySizeSelector: Error fetching tray sizes.');

--- a/modules/farm_fd2_examples/src/entrypoints/tray_size_selector/App.vue
+++ b/modules/farm_fd2_examples/src/entrypoints/tray_size_selector/App.vue
@@ -15,7 +15,7 @@
     v-bind:showValidityStyling="validity.showStyling"
     v-model:selected="form.selected"
     v-on:valid="(valid) => (validity.selected = valid)"
-    v-on:ready="createdCount++"
+    v-on:ready="handleReady"
   />
   <hr />
   <h5>Component Props:</h5>
@@ -97,6 +97,12 @@
     </thead>
     <tbody>
       <tr>
+        <td>ready</td>
+        <td>
+          {{ ready }}
+        </td>
+      </tr>
+      <tr>
         <td>update:selected</td>
         <td>{{ form.selected === null ? 'null' : form.selected }}</td>
       </tr>
@@ -135,11 +141,16 @@ export default {
         selected: false,
       },
       createdCount: 0,
+      ready: false,
     };
   },
   methods: {
     selectFirstAvailableOption() {
       this.form.selected = '72';
+    },
+    handleReady(payload) {
+      this.ready = payload;
+      this.createdCount++;
     },
   },
   computed: {

--- a/modules/farm_fd2_examples/src/entrypoints/tray_size_selector/App.vue
+++ b/modules/farm_fd2_examples/src/entrypoints/tray_size_selector/App.vue
@@ -24,6 +24,7 @@
       <tr>
         <th>Prop</th>
         <th>Control</th>
+        <th>Value</th>
       </tr>
     </thead>
     <tbody>
@@ -37,16 +38,8 @@
             v-model="required"
           />
         </td>
-      </tr>
-      <tr>
-        <td>showValidityStyling</td>
         <td>
-          <BFormCheckbox
-            id="styling-checkbox"
-            data-cy="styling-checkbox"
-            switch
-            v-model="validity.showStyling"
-          />
+          {{ required }}
         </td>
       </tr>
       <tr>
@@ -60,7 +53,7 @@
             v-on:click="selectFirstAvailableOption"
             title="Selects '72' which is expected to be an available option."
           >
-            Select first available
+            Select 1st size
           </BButton>
           <BButton
             id="clear-button"
@@ -72,6 +65,23 @@
           >
             Clear
           </BButton>
+        </td>
+        <td>
+          {{ this.form.selected }}
+        </td>
+      </tr>
+      <tr>
+        <td>showValidityStyling</td>
+        <td>
+          <BFormCheckbox
+            id="styling-checkbox"
+            data-cy="styling-checkbox"
+            switch
+            v-model="validity.showStyling"
+          />
+        </td>
+        <td>
+          {{ validity.showStyling }}
         </td>
       </tr>
     </tbody>


### PR DESCRIPTION
### Purpose

This PR enhances the ```TraySizeSelector``` example page to provide better visibility into the component's state and behavior. It adds a "Value" column to the props table to show real-time data bindings, reorganizes the table for better readability, and adds tracking for the ```ready``` event payload. Additionally, it updates the ```TraySizeSelector``` component to emit a specific payload with the ```ready``` event to support this tracking.

### Verification Steps

1. Navigate to FD2 Examples -> Components -> TraySizeSelector.
2. Scroll down to the Component Props table.
3. Verify that a Value column exists on the right side.
4. Toggle the "required" switch and confirm the value in the table updates to ```true```/```false```.
5. Verify the button is labeled "Select 1st size". Click it and confirm the "selected" value updates to ```72```.
6. Confirm the rows are listed in alphabetical order (```required```, ```selected```, ```showValidityStyling```).
7. Scroll down to the Component Event Payloads table.
8. Verify that a row for the ```ready``` event exists.
9. Confirm that the payload value is displayed as ```true```.

### Approach

In ```TraySizeSelectorExamplePage.vue```, we added a new "Value" column to the "Component Props" table that binds directly to the Vue data attributes. We renamed the "Select first available" button to "Select 1st size" and reordered the table rows alphabetically.

For the event payloads, We updated ```TraySizeSelector.vue``` to explicitly emit ```true``` as a payload with the ```ready``` event. In the example page, we implemented a ```handleReady``` method to capture this payload and store it in a local data property (```this.ready```), which is then displayed in the "Component Event Payloads" table.

### Testing

We added a new Cypress test case named ```Test that "ready" event is propagated``` in ```components/TraySizeSelector/TraySizeSelector.events.comp.cy.js```. This test mounts the ```TraySizeSelector``` component with a spy attached to the ```ready``` event. It asserts that the event is emitted exactly once and specifically verifies that it carries the payload ```true```.

### Related issues

Fixes #591 

### Further Information

This took us about 1 hour and 30 minutes.

### Licensing Certification

FarmData2 is a [Free Cultural Work](https://freedomdefined.org/Definition) and all accepted contributions are licensed as described in the LICENSE.md file. This requires that the contributor holds the rights to do so. By submitting this pull request **the contributor (and any listed co-authors) certify that they meet the terms of the [Developer Certificate of Origin](https://developercertificate.org/)** for its contents.

### Co-Authors

Co-authored-by: Lam Pham <180245822+tlamDson@users.noreply.github.com>
