### PR TITLE
fix(lib): patches tests broken by new sampleDB.

### DIFF
--- a/library/farmosUtil/farmosUtil.beds.unit.cy.js
+++ b/library/farmosUtil/farmosUtil.beds.unit.cy.js
@@ -14,12 +14,12 @@ describe('Test the bed utility functions', () => {
   it('Get the bed land assets', () => {
     cy.wrap(farmosUtil.getBeds()).then((beds) => {
       expect(beds).to.not.be.null;
-      expect(beds.length).to.equal(15);
+      expect(beds.length).to.equal(17);
 
       expect(beds[0].attributes.name).to.equal('ALF-1');
       expect(beds[0].type).to.equal('asset--land');
 
-      expect(beds[14].attributes.name).to.equal('H-2');
+      expect(beds[14].attributes.name).to.equal('GHANA-4');
       expect(beds[14].type).to.equal('asset--land');
     });
   });
@@ -53,7 +53,7 @@ describe('Test the bed utility functions', () => {
   it('Get the BedNameToAsset map', () => {
     cy.wrap(farmosUtil.getBedNameToAssetMap()).then((bedNameMap) => {
       expect(bedNameMap).to.not.be.null;
-      expect(bedNameMap.size).to.equal(15);
+      expect(bedNameMap.size).to.equal(17);
 
       expect(bedNameMap.get('ALF-1')).to.not.be.null;
       expect(bedNameMap.get('ALF-1').type).to.equal('asset--land');
@@ -69,7 +69,7 @@ describe('Test the bed utility functions', () => {
   it('Get the BedIdToAsset map', () => {
     cy.wrap(farmosUtil.getBedIdToAssetMap()).then((bedIdMap) => {
       expect(bedIdMap).to.not.be.null;
-      expect(bedIdMap.size).to.equal(15);
+      expect(bedIdMap.size).to.equal(17);
 
       cy.wrap(farmosUtil.getBedNameToAssetMap()).then((bedNameMap) => {
         const bedALF1Id = bedNameMap.get('ALF-1').id;


### PR DESCRIPTION
### Purpose

The update to SampleDB 3.8.0 broke a few tests in the library because new beds were added to the sample db.

### Verification Steps

Run `test.bash --lib --unit --glob=library/farmosUtil/*.beds.unit.cy.js` and confirm that the tests pass.

### Approach

Updated the expected number of beds in a few tests and the expected bed in one test.

### Testing

The modified tests were in `library/farmosUtil/*.beds.unit.cy.js`, they pass after the updates.

### Related issues

The updates that were addressed and resulted in the test failures were in #519.

### Licensing Certification

FarmData2 is a [Free Cultural Work](https://freedomdefined.org/Definition) and all accepted contributions are licensed as described in the LICENSE.md file. This requires that the contributor holds the rights to do so. By submitting this pull request **the contributor (and any listed co-authors) certify that they meet the terms of the [Developer Certificate of Origin](https://developercertificate.org/)** for its contents.