### PR TITLE
fix(dev): Add case for component end-to-end tests in lint-staged

### DIFF
--- a/.lintstagedrc.cjs
+++ b/.lintstagedrc.cjs
@@ -8,7 +8,6 @@ const fd2LibsTested = new Map();
 const examplesLibsTested = new Map();
 const schoolLibsTested = new Map();
 const compsTested = new Map();
-const compsE2ETested = new Map();
 const libsTested = new Map();
 
 /*
@@ -202,18 +201,23 @@ const getModuleTestsUnitCyJs = (files) => {
 
 /*
  * Construct a test command for each component .vue file that is staged.
- * The command will use a glob to run all comp.cy.js component tests in the
- * component directory containing the .vue file.
+ * The command will use a glob to run all comp.cy.js component tests and
+ * all e2e.cy.js end-to-end tests in the component directory containing
+ * the .vue file.
  */
 const getCompTestsVue = (files) => {
   const testCommands = files.map((file) => {
     compsTested.set(path.basename(path.dirname(file)), true);
-    return (
+    return [
       'test.bash --comp --glob=' +
-      '/components/' +
-      path.basename(path.dirname(file)) +
-      '/*.comp.cy.js'
-    );
+        '/components/' +
+        path.basename(path.dirname(file)) +
+        '/*.comp.cy.js',
+      'test.bash --e2e --fd2 --live --glob=' +
+        '/components/' +
+        path.basename(path.dirname(file)) +
+        '/*.e2e.cy.js',
+    ];
   });
 
   return testCommands;
@@ -242,10 +246,9 @@ const getCompTestsCompCyJs = (files) => {
  */
 const getCompTestsE2ECyJs = (files) => {
   const testCommands = files.map((file) => {
-    if (compsE2ETested.get(path.basename(path.dirname(file)))) {
+    if (compsTested.get(path.basename(path.dirname(file)))) {
       return 'skipping ' + file;
     } else {
-      compsE2ETested.set(path.basename(path.dirname(file)), true);
       return (
         'test.bash --e2e --fd2 --live --glob=' +
         file.substring(file.indexOf('/components'))

--- a/.lintstagedrc.cjs
+++ b/.lintstagedrc.cjs
@@ -206,7 +206,7 @@ const getModuleTestsUnitCyJs = (files) => {
  * in the component directory containing the .vue file.
  */
 const getCompTestsVue = (files) => {
-  const testCommands1 = files.map((file) => {
+  const compTestCommands = files.map((file) => {
     compsTested.set(path.basename(path.dirname(file)), true);
     return (
       'test.bash --comp --glob=' +
@@ -216,8 +216,8 @@ const getCompTestsVue = (files) => {
     );
   });
 
-  const testCommands2 = files.map((file) => {
-    // Only run *.e2e.cy.js tests if at least one exists.
+  const e2eTestCommands = files.map((file) => {
+    // Only create the command for *.e2e.cy.js tests if at least one exists.
     const dirFiles = fs.readdirSync(
       './components/' + path.basename(path.dirname(file))
     );
@@ -239,10 +239,10 @@ const getCompTestsVue = (files) => {
     }
   });
 
-  if (testCommands2.length > 0) {
-    return [...testCommands1, ...testCommands2];
+  if (e2eTestCommands.length > 0) {
+    return [...compTestCommands, ...e2eTestCommands];
   } else {
-    return testCommands1;
+    return compTestCommands;
   }
 };
 

--- a/.lintstagedrc.cjs
+++ b/.lintstagedrc.cjs
@@ -342,4 +342,3 @@ module.exports = {
     return getLibTestsUnitCyJs(files);
   },
 };
-

--- a/.lintstagedrc.cjs
+++ b/.lintstagedrc.cjs
@@ -8,6 +8,7 @@ const fd2LibsTested = new Map();
 const examplesLibsTested = new Map();
 const schoolLibsTested = new Map();
 const compsTested = new Map();
+const compsE2ETested = new Map();
 const libsTested = new Map();
 
 /*
@@ -235,11 +236,16 @@ const getCompTestsCompCyJs = (files) => {
   return testCommands;
 };
 
+/*
+ * Construct a test command for each component e2e.cy.js file that is staged.
+ * These tests interact with farmOS and require --e2e --fd2 --live flags.
+ */
 const getCompTestsE2ECyJs = (files) => {
   const testCommands = files.map((file) => {
-    if (compsTested.get(path.basename(path.dirname(file)))) {
+    if (compsE2ETested.get(path.basename(path.dirname(file)))) {
       return 'skipping ' + file;
     } else {
+      compsE2ETested.set(path.basename(path.dirname(file)), true);
       return (
         'test.bash --e2e --fd2 --live --glob=' +
         file.substring(file.indexOf('/components'))
@@ -336,3 +342,4 @@ module.exports = {
     return getLibTestsUnitCyJs(files);
   },
 };
+

--- a/.lintstagedrc.cjs
+++ b/.lintstagedrc.cjs
@@ -1,5 +1,6 @@
 const { ESLint } = require('eslint');
 const path = require('path');
+const fs = require('fs');
 
 const fd2EntrypointsTested = new Map();
 const examplesEntrypointsTested = new Map();
@@ -201,26 +202,48 @@ const getModuleTestsUnitCyJs = (files) => {
 
 /*
  * Construct a test command for each component .vue file that is staged.
- * The command will use a glob to run all comp.cy.js component tests and
- * all e2e.cy.js end-to-end tests in the component directory containing
- * the .vue file.
+ * The command will use a glob to run all comp.cy.js component tests
+ * in the component directory containing the .vue file.
  */
 const getCompTestsVue = (files) => {
-  const testCommands = files.map((file) => {
+  const testCommands1 = files.map((file) => {
     compsTested.set(path.basename(path.dirname(file)), true);
-    return [
+    return (
       'test.bash --comp --glob=' +
-        '/components/' +
-        path.basename(path.dirname(file)) +
-        '/*.comp.cy.js',
-      'test.bash --e2e --fd2 --live --glob=' +
-        '/components/' +
-        path.basename(path.dirname(file)) +
-        '/*.e2e.cy.js',
-    ];
+      '/components/' +
+      path.basename(path.dirname(file)) +
+      '/*.comp.cy.js'
+    );
   });
 
-  return testCommands;
+  const testCommands2 = files.map((file) => {
+    // Only run *.e2e.cy.js tests if at least one exists.
+    const dirFiles = fs.readdirSync(
+      './components/' + path.basename(path.dirname(file))
+    );
+    const regEx = /.*\.e2e\.cy\.js$/;
+    const matchFound = dirFiles.some((dirFile) => regEx.test(dirFile));
+    if (matchFound) {
+      return (
+        'test.bash --e2e --fd2 --live --glob=' +
+        '/components/' +
+        path.basename(path.dirname(file)) +
+        '/*.e2e.cy.js'
+      );
+    } else {
+      return (
+        'skipping /components/' +
+        path.basename(path.dirname(file)) +
+        '*.e2e.cjs'
+      );
+    }
+  });
+
+  if (testCommands2.length > 0) {
+    return [...testCommands1, ...testCommands2];
+  } else {
+    return testCommands1;
+  }
 };
 
 /*


### PR DESCRIPTION
### Purpose

Enables line-staged to detect and run staged E2E tests for components during the pre-commit hooks.  It also ensures that the same component e2e tests are not run multiple times.

### Verification Steps

1. Stage any component E2E test with an e2e test:
`git add components/CropSelector/CropSelector.e2e.cy.js`
2. Run lint-staged
`npx lint-staged`
3. Verify output consistent as if done manually
`test.bash --e2e --fd2 --live --glob=/components/CropSelector/CropSelector.e2e.cy.js `

### Approach

Checked for the existence of e2e tests in any component directory that has a staged .vue file.  If e2e tests are found, then a test command is generated for them, if not they are skipped.

### Related issues

Closes #483 

### Licensing Certification

FarmData2 is a [Free Cultural Work](https://freedomdefined.org/Definition) and all accepted contributions are licensed as described in the LICENSE.md file. This requires that the contributor holds the rights to do so. By submitting this pull request **the contributor (and any listed co-authors) certify that they meet the terms of the [Developer Certificate of Origin](https://developercertificate.org/)** for its contents.