### PR TITLE
fix(dev): improves devcontainer nginx configuration

### DIFF
--- a/docker/nginx.conf/nginx.codespaces.conf.template
+++ b/docker/nginx.conf/nginx.codespaces.conf.template
@@ -25,21 +25,10 @@ server {
     deny all;
   }
 
-  location /user/logout {
-    # Rewrite the Location header for the logout request.
-    proxy_pass http://farmos/user/logout;
-    proxy_hide_header Location;
-    add_header Location "https://${CODESPACE_NAME}-443.${GITHUB_CODESPACES_PORT_FORWARDING_DOMAIN}";
-  }
-
-  location /403 {
-    # Rewrite the Location header for the login request.
-    proxy_pass http://farmos;
-    proxy_hide_header Location;
-    add_header Location "https://${CODESPACE_NAME}-443.${GITHUB_CODESPACES_PORT_FORWARDING_DOMAIN}";
-  }
-
   location / {
     proxy_pass http://farmos;
+
+    # Update Location headers from Drupal/farmOS that point to localhost to the GitHub app domain.
+    proxy_redirect https://localhost https://${CODESPACE_NAME}-443.${GITHUB_CODESPACES_PORT_FORWARDING_DOMAIN};
   }
 }

--- a/docs/maintainers/infrastructure.md
+++ b/docs/maintainers/infrastructure.md
@@ -19,11 +19,22 @@ The overview of the organization of the FarmData2 codebase found in the [Introdu
 
 ## The Development Environment
 
-The FarmData2 Development Environment is a [Development Container](https://containers.dev/) that runs in GitHub Codespaces. When running this development container provides a Linux machine with a Visual Studio Code IDE, all the tools and extensions necessary for FarmData2 work, and a running instance of farmOS. The running instance of farmOS is provided by three _side car_ containers that are started when the development container is started:
+The FarmData2 Development Environment is a [Development Container](https://containers.dev/) that runs in GitHub Codespaces. When running this development container provides a Linux machine with a Visual Studio Code IDE, all the tools and extensions necessary for FarmData2 work, and a running instance of farmOS.
+
+### The farmOS Instance
+
+The running instance of farmOS is provided by three _side car_ containers that are started by the `.devcontainer/postCreate.bash` script when the development container is started:
 
 - `fd2_farmos` - a Drupal instance that is running farmOS.
 - `fd2_postgres` - the postgres database that Drupal uses to store its data.
 - `fd2_nginx` - An Nginx reverse proxy server allowing farmOS to be accessed via https.
+
+These containers are configured by the `compose.yml` and `compose.codespaces.yml` in the `docker` directory.
+
+- `compose.yml` - provides a base configuration for running the containers on a hosted server (a deployment), but that will not work when farmOS is running on an exposed port within a codespace.
+- `compose.codespace.yml` - is [merged](https://docs.docker.com/compose/how-tos/multiple-compose-files/merge/) with `compose.yml` when running within codespaces. This config defines a few environment variables and changes the nginx configuration that is mounted into the `fd2_nginx` container so that farmOS runs correctly within codespaces.
+
+### The devcontainer
 
 The structure of the Development Environment is described here, while instructions for starting the Development Environment in a codespace are given in [INSTALL.md](../../INSTALL.md).
 


### PR DESCRIPTION
### Purpose

PR #608 patched the login/logout issues by rewriting the Location headers in responses using nginx.  #609 reports that there are many other locations that suffered from the same issue where the Location header was being set to `localhost`.  This PR addresses all locations by redirecting all responses with a Location of `localhost` to the GitHub `app.github.dev` URL when running within codespaces.

Documentation of the docker configuration has also been added to `docs/maintaners/infrastructure.md` to describe how the nginx reverse proxy is configured.

### Verification Steps

1. Start the development environment in a codespace.
2. Log into farmOS.
3. Observe that the dashboard is displayed.
4. Create a new term, asset or log.
5. Notice that after clicking "Save" the correct page is displayed.
6. Logout of farmOS.
7. Notice that the login page is displayed.

### Approach

The nginx configuration that is used when running in codesapces (`nginx.codespaces.conf.template`) was modified to rewrite all Location headers containing `localhost` to contain the `app.github.dev` URL from which the app is being served.

### Testing

N/A

### Related issues

Closes #609 

### Licensing Certification

FarmData2 is a [Free Cultural Work](https://freedomdefined.org/Definition) and all accepted contributions are licensed as described in the LICENSE.md file. This requires that the contributor holds the rights to do so. By submitting this pull request **the contributor (and any listed co-authors) certify that they meet the terms of the [Developer Certificate of Origin](https://developercertificate.org/)** for its contents.
