### PR TITLE
fix(dev): patches first database install

### DIFF
--- a/.devcontainer/postCreate.bash
+++ b/.devcontainer/postCreate.bash
@@ -58,7 +58,6 @@ echo "Set up."
 # these builds will generate errors, but they will still
 # work as expected once the sample database is installed.
 echo "Building FarmData2 Drupal modules..."
-echo "  Note: Errors during these builds are expected."
 echo "  Building farm_fd2..."
 rm -rf "$REPO_DIR/modules/farm_fd2/dist"
 mkdir "$REPO_DIR/modules/farm_fd2/dist"

--- a/bin/installDB.bash
+++ b/bin/installDB.bash
@@ -220,7 +220,7 @@ else
   # If Drupal is not connected to the database then this is a new codespace and we have
   # not yet installed a database, so we don't need to uninstall the FarmData2 module.
   DB_CONNECTED=$(docker exec fd2_farmos drush status | grep -E "^Database\s+: Connected")
-  FD2_ENABLED=$(docker exec fd2_farmos drush pm-list --type=Module --status=enabled | grep "(farm_fd2)")
+  FD2_ENABLED=$(docker exec fd2_farmos drush pm-list --type=Module --status=enabled 2> /dev/null | grep "(farm_fd2)")
   if [ -n "$DB_CONNECTED" ] && [ -n "$FD2_ENABLED" ]; then
     # If we didn't use the same DB then uninstall the FarmData2 module here.
     # We will rebuild and reinstall it after the new database has been installed.

--- a/bin/installDB.bash
+++ b/bin/installDB.bash
@@ -217,23 +217,28 @@ else
   error_check "Unable to download the database."
   echo "Database downloaded."
 
-  # If we didn't use the same DB then uninstall the FarmData2 module here.
-  # We will rebuild and reinstall it after the new database has been installed.
-  # This is important when we switch to a branch where the module targets a different DB version.
-  echo "Uninstalling the FarmData2 module..."
-  echo "  Deleting custom farm_fd2 module custom fields..."
-  "$REPO_DIR/bin/deleteCustomFD2Fields.bash"
-  error_check "Unable to delete custom FD2 fields."
-  echo "  Deleted."
-  echo "  Running farmOS cron to update fields..."
-  docker exec fd2_farmos drush cron > /dev/null 2>&1
-  error_check "Unable to run cron."
-  echo "  Done."
-  echo "  Removing farm_fd2 module from farmOS..."
-  docker exec fd2_farmos drush pmu farm_fd2 -y
-  error_check "Unable to remove the farm_fd2 module from farmOS."
-  echo "  Removed."
-  echo "Uninstalled."
+  # If Drupal is not connected to the database then this is a new codespace and we have
+  # not yet installed a database, so we don't need to uninstall the FarmData2 module.
+  DB_CONNECTED=$(docker exec fd2_farmos drush status | grep -E "^Database\s+: Connected")
+  FD2_ENABLED=$(docker exec fd2_farmos drush pm-list --type=Module --status=enabled | grep "(farm_fd2)")
+  if [ -n "$DB_CONNECTED" ] && [ -n "$FD2_ENABLED" ]; then
+    # If we didn't use the same DB then uninstall the FarmData2 module here.
+    # We will rebuild and reinstall it after the new database has been installed.
+    # This is important when we switch to a branch where the module targets a different DB version.
+    echo "Uninstalling the FarmData2 module..."
+    echo "  Deleting custom farm_fd2 module custom fields..."
+    "$REPO_DIR/bin/deleteCustomFD2Fields.bash" > /dev/null 2>&1
+    echo "  Deleted."
+    echo "  Running farmOS cron to update fields..."
+    docker exec fd2_farmos drush cron > /dev/null 2>&1
+    error_check "Unable to run cron."
+    echo "  Done."
+    echo "  Removing farm_fd2 module from farmOS..."
+    docker exec fd2_farmos drush pmu farm_fd2 -y > /dev/null 2>&1
+    error_check "Unable to remove the farm_fd2 module from farmOS."
+    echo "  Removed."
+    echo "Uninstalled."
+  fi
 fi
 
 echo "Stopping farmOS..."
@@ -311,14 +316,14 @@ if [ -z "$CURRENT" ]; then
   error_check "Unable to rebuild the FarmData2 module."
   echo "  Built."
   echo "  Installing farm_fd2 module into farmOS..."
-  docker exec fd2_farmos drush en farm_fd2 -y
+  docker exec fd2_farmos drush en farm_fd2 -y > /dev/null 2>&1
   error_check "Unable to reinstall the FarmData2 module."
   echo "  Installed."
   echo "Added."
 fi
 
 echo "Clearing the Drupal cache..."
-docker exec fd2_farmos drush cr
+docker exec fd2_farmos drush cr > /dev/null 2>&1
 error_check "Unable to clear the cache."
 echo "Cleared."
 


### PR DESCRIPTION
### Purpose

The `installDB.bash` script was failing on the first database install because the farm_fd2 module could not be removed.  This PR resolves that issue.

### Verification Steps

Create a new codespace and verify that it is created without error.

### Approach

The `instalDB.bash` script checks to see if the Drupal instance is connected to the database.  If so, it also checks if the `farm_fd2` module is enabled.  If not connected or the `farm_fd2` module is not enabled, then the steps of uninstalling the `farm_fd2` module are skipped.

### Licensing Certification

FarmData2 is a [Free Cultural Work](https://freedomdefined.org/Definition) and all accepted contributions are licensed as described in the LICENSE.md file. This requires that the contributor holds the rights to do so. By submitting this pull request **the contributor (and any listed co-authors) certify that they meet the terms of the [Developer Certificate of Origin](https://developercertificate.org/)** for its contents.