### PR TITLE
docs: add browser refresh shortcuts to Quick Reference

### DIFF
--- a/docs/contributing/quickReference.md
+++ b/docs/contributing/quickReference.md
@@ -33,6 +33,8 @@
 | ----------------------- | ------------------------- | -------------------------- |
 | `F12`                   | `F12`                     | Toggle the Developer Tools |
 | `Ctrl + Shift + Delete` | &#8984;`+ Shift + Delete` | Clear browsing history.    |
+| `Ctrl + R`              | &#8984;`+ R`              | Standard refresh            |
+| `Ctrl + Shift + R`      | &#8984;`+ Shift + R`      | Hard refresh (bypass cache) |
 
 ## FarmData2 Commands
 

--- a/docs/contributing/quickReference.md
+++ b/docs/contributing/quickReference.md
@@ -29,12 +29,14 @@
 
 ### Browser
 
-| Windows/Linux           | MacOS                     | Action                     |
-| ----------------------- | ------------------------- | -------------------------- |
-| `F12`                   | `F12`                     | Toggle the Developer Tools |
-| `Ctrl + Shift + Delete` | &#8984;`+ Shift + Delete` | Clear browsing history.    |
-| `Ctrl + R`              | &#8984;`+ R`              | Standard refresh            |
-| `Ctrl + Shift + R`      | &#8984;`+ Shift + R`      | Hard refresh (bypass cache) |
+
+| Windows/Linux           | MacOS                     | Action                        |
+| ----------------------- | ------------------------- | ----------------------------- |
+| `F12`                   | `F12`                     | Toggle the Developer Tools    |
+| `Ctrl + Shift + Delete` | &#8984;`+ Shift + Delete` | Clear browsing history.       |
+| `Ctrl + R`              | &#8984;`+ R`              | Standard refresh              |
+| `Ctrl + Shift + R`      | &#8984;`+ Shift + R`      | Hard refresh (bypass cache)   |
+
 
 ## FarmData2 Commands
 


### PR DESCRIPTION
### Purpose

Add browser refresh and hard refresh keyboard shortcuts to the Quick Reference document.

### Verification Steps

1. Open `docs/contributing/quickReference.md`.
2. Navigate to the **Browser** section.
3. Verify that the following shortcuts are present:
   - `Ctrl + R` / `⌘ + R` – Standard refresh
   - `Ctrl + Shift + R` / `⌘ + Shift + R` – Hard refresh (bypass cache)

### Approach

Added the two requested browser refresh shortcuts while preserving the existing table formatting and documentation style.

### Testing

Documentation-only change. No code or automated tests were modified.

### Related issues

Fixes #617

### Further Information

No additional information.


### Licensing Certification

- [x] **I attest that myself and any co-authors meet the terms of the [Developer Certificate of Origin](https://developercertificate.org/) for the contents of this pull request.**